### PR TITLE
sysdetect: Add cuda header path to Rules file

### DIFF
--- a/src/components/sysdetect/Rules.sysdetect
+++ b/src/components/sysdetect/Rules.sysdetect
@@ -21,7 +21,8 @@ CFLAGS += -I$(PAPI_ROCM_ROOT)/include                  \
           -I$(PAPI_ROCM_ROOT)/hsa/include/hsa          \
           -I$(PAPI_ROCM_ROOT)/include/rocm_smi         \
           -I$(PAPI_ROCM_ROOT)/rocm_smi/include         \
-          -I$(PAPI_ROCM_ROOT)/rocm_smi/include/rocm_smi
+          -I$(PAPI_ROCM_ROOT)/rocm_smi/include/rocm_smi \
+          -I$(PAPI_CUDA_ROOT)/include
 
 sysdetect.o: components/sysdetect/sysdetect.c components/sysdetect/sysdetect.h $(HEADERS) 
 	$(CC) $(LIBCFLAGS) $(OPTFLAGS) -c components/sysdetect/sysdetect.c -o $@


### PR DESCRIPTION
This fixes configuring PAPI without cuda component. If 
`$ ./configure && make`
then `components/sysdetect/nvidia_gpu.o` complains that `"cuda.h"` not found.

If `./configure --with-components=cuda && make`
then the error goes away.

This PR fixes the above problem by adding include path to cuda header.