### PR TITLE
Fix vendor library search path in sysdetect component

### DIFF
--- a/src/components/cuda/linux-cuda.c
+++ b/src/components/cuda/linux-cuda.c
@@ -920,7 +920,7 @@ static int _cuda_linkCudaLibraries(void)
     cuptiEventGroupResetAllEventsPtr = DLSYM_AND_CHECK(dl3, "cuptiEventGroupResetAllEvents");
     cuptiGetResultStringPtr = DLSYM_AND_CHECK(dl3, "cuptiGetResultString");
     cuptiEnableKernelReplayModePtr = DLSYM_AND_CHECK(dl3, "cuptiEnableKernelReplayMode");
-    cuptiDisableKernelReplayModePtr = DLSYM_AND_CHECK(dl3, "cuptiEnableKernelReplayMode");
+    cuptiDisableKernelReplayModePtr = DLSYM_AND_CHECK(dl3, "cuptiDisableKernelReplayMode");
 
 #if CUPTI_API_VERSION >= 13
     cuptiProfilerInitializePtr = DLSYM_AND_CHECK(dl3, "cuptiProfilerInitialize");

--- a/src/components/sysdetect/Rules.sysdetect
+++ b/src/components/sysdetect/Rules.sysdetect
@@ -21,7 +21,8 @@ CFLAGS += -I$(PAPI_ROCM_ROOT)/include                  \
           -I$(PAPI_ROCM_ROOT)/hsa/include/hsa          \
           -I$(PAPI_ROCM_ROOT)/include/rocm_smi         \
           -I$(PAPI_ROCM_ROOT)/rocm_smi/include         \
-          -I$(PAPI_ROCM_ROOT)/rocm_smi/include/rocm_smi
+          -I$(PAPI_ROCM_ROOT)/rocm_smi/include/rocm_smi\
+          -I$(PAPI_CUDA_ROOT)/include
 
 sysdetect.o: components/sysdetect/sysdetect.c components/sysdetect/sysdetect.h $(HEADERS) 
 	$(CC) $(LIBCFLAGS) $(OPTFLAGS) -c components/sysdetect/sysdetect.c -o $@

--- a/src/components/sysdetect/amd_gpu.c
+++ b/src/components/sysdetect/amd_gpu.c
@@ -236,22 +236,10 @@ hsa_is_enabled( void )
 int
 load_hsa_sym( char *status )
 {
-    char pathname[PAPI_MAX_STR_LEN] = { 0 };
+    char pathname[PATH_MAX] = "libhsa-runtime64.so";
     char *rocm_root = getenv("PAPI_ROCM_ROOT");
-    if (rocm_root == NULL) {
-        const char *message =
-            "Can't load libhsa-runtime64.so, PAPI_ROCM_ROOT not set.";
-        int count = snprintf(status, strlen(message) + 1, "%s", message);
-        if (count >= PAPI_MAX_STR_LEN) {
-            SUBDBG("Status string truncated.");
-        }
-        return -1;
-    }
-
-    int expect = snprintf(pathname, PAPI_MAX_STR_LEN,
-                          "%s/lib/libhsa-runtime64.so", rocm_root);
-    if (expect > PAPI_MAX_STR_LEN) {
-        SUBDBG("HSA pathname truncated.");
+    if (rocm_root != NULL) {
+        sprintf(pathname, "%s/lib/libhsa-runtime64.so", rocm_root);
     }
 
     rocm_dlp = dlopen(pathname, RTLD_NOW | RTLD_GLOBAL);
@@ -330,22 +318,10 @@ rsmi_is_enabled( void )
 int
 load_rsmi_sym( char *status )
 {
-    char pathname[PAPI_MAX_STR_LEN] = { 0 };
-    char *rocm_root = getenv("PAPI_ROCM_ROOT");
-    if (rocm_root == NULL) {
-        const char *message =
-            "Can't load librocm_smi64.so, PAPI_ROCM_ROOT not set.";
-        int count = snprintf(status, strlen(message) + 1, "%s", message);
-        if (count >= PAPI_MAX_STR_LEN) {
-            SUBDBG("Status string truncated.");
-        }
-        return -1;
-    }
-
-    int expect = snprintf(pathname, PAPI_MAX_STR_LEN,
-                          "%s/rocm_smi/lib/librocm_smi64.so", rocm_root);
-    if (expect > PAPI_MAX_STR_LEN) {
-        SUBDBG("ROCM-SMI pathname truncated.");
+    char pathname[PATH_MAX] = "librocm_smi64.so";
+    char *rsmi_root = getenv("PAPI_ROCM_ROOT");
+    if (rsmi_root != NULL) {
+        sprintf(pathname, "%s/lib/librocm_smi64.so", rsmi_root);
     }
 
     rsmi_dlp = dlopen(pathname, RTLD_NOW | RTLD_GLOBAL);

--- a/src/components/sysdetect/nvidia_gpu.c
+++ b/src/components/sysdetect/nvidia_gpu.c
@@ -197,7 +197,12 @@ cuda_is_enabled( void )
 int
 load_cuda_sym( char *status )
 {
-    cuda_dlp = dlopen("libcuda.so", RTLD_NOW | RTLD_GLOBAL);
+    char cuda_dl_path[PATH_MAX] = "libcuda.so";
+    char *cuda_root = getenv("PAPI_CUDA_ROOT");
+    if (cuda_root != NULL) {
+        sprintf(cuda_dl_path, "%s/libcuda.so", cuda_root);
+    }
+    cuda_dlp = dlopen(cuda_dl_path, RTLD_NOW | RTLD_GLOBAL);
     if (cuda_dlp == NULL) {
         int count = snprintf(status, PAPI_MAX_STR_LEN, "%s", dlerror());
         if (count >= PAPI_MAX_STR_LEN) {
@@ -292,7 +297,12 @@ nvml_is_enabled( void )
 int
 load_nvml_sym( char *status )
 {
-    nvml_dlp = dlopen("libnvidia-ml.so", RTLD_NOW | RTLD_GLOBAL);
+    char nvml_dl_path[PATH_MAX] = "libnvidia-ml.so";
+    char *nvml_root = getenv("PAPI_CUDA_ROOT");
+    if (nvml_root != NULL) {
+        sprintf(nvml_dl_path, "%s/libnvidia-ml.so", nvml_root);
+    }
+    nvml_dlp = dlopen(nvml_dl_path, RTLD_NOW | RTLD_GLOBAL);
     if (nvml_dlp == NULL) {
         int count = snprintf(status, PAPI_MAX_STR_LEN, "%s", dlerror());
         if (count >= PAPI_MAX_STR_LEN) {


### PR DESCRIPTION
The sysdetect component provides system attribute access on a range of devices, including GPUs from NVIDIA and AMD. Access to GPU attributes is done by dlopen the vendor library and calling the proper `GetAttribute` function symbol. The vendor library used by the component is the one find in the system path (if any). This causes problem if the user wants to specify the path to such library using the conventional mechanism of environment variables (e.g. PAPI_CUDA_ROOT). This PR fixes the problem by searching in the system path by default, unless the vendor environment variable is set; in which case this overwrites the system available vendor library.