### PR TITLE
remove references to Bitbucket

### DIFF
--- a/PAPI_FAQ.html
+++ b/PAPI_FAQ.html
@@ -68,11 +68,11 @@ __thread implementation, please report it to us.</p><br />
 <h2>The PAPI GIT Source Repository</h2>
 
 <strong>Can I browse the source repository on the web?</strong>
-<p>Yes. The latest copy of the PAPI source tree is viewable through a web based source browser accessible from the Bitbucket repository at:<br /><a href="../../trac/papi/browser">https://bitbucket.org/icl/papi</a></p>
+<p>Yes. The latest copy of the PAPI source tree is viewable through a web based source browser accessible from the GitHub repository at:<br /><a href="../../trac/papi/browser">https://github.com/icl-utk-edu/papi</a></p>
 <p>&nbsp;</p><strong>How do I download a copy of the current PAPI source tree?</strong>
 <p>Make sure git is installed on your machine. You can download a copy <a href="http://git-scm.com/">here</a>.</p>
 <p>Download the PAPI repository the first time with the following command:</p>
-<p>&gt; git clone https://bitbucket.org/icl/papi.git</p>
+<p>&gt; git clone https://github.com/icl-utk-edu/papi.git</p>
 <p>This creates a complete copy of the papi git repository on your computer in a folder called 'papi'.</p>
 <p>To make sure your copy is up to date with the repository:</p>
 <p>&gt; cd papi<br />&gt; git pull&nbsp;</p><strong>Can I commit changes to the PAPI repository?</strong>

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ performance counters in a system, including the new software-defined events.
 
 # Documentation
 
-* [PAPI Wiki](https://bitbucket.org/icl/papi/wiki/) is the main documentation for HOWTOs, Supported Architectures, PAPI Releases.
+* [PAPI Wiki](https://github.com/icl-utk-edu/papi/wiki/) is the main documentation for HOWTOs, Supported Architectures, PAPI Releases.
 * [PAPI Papers and Presentations](https://www.icl.utk.edu/view/biblio/project/papi?items_per_page=All)
 
 
@@ -64,7 +64,7 @@ performance counters in a system, including the new software-defined events.
 # Contributing
 
 The PAPI project welcomes contributions from new developers. Contributions can
-be offered through the standard Bitbucket pull request model. We strongly
+be offered through the standard GitHub pull request model. We strongly
 encourage you to coordinate large contributions with the PAPI development team
 early in the process.
 

--- a/src/components/sde/README.md
+++ b/src/components/sde/README.md
@@ -19,4 +19,4 @@ to the user, and whether they are disabled, and when they are disabled why.
 
 ## FAQ
 
-* [Software Defined Events](https://bitbucket.org/icl/papi/wiki/Software_Defined_Events.md)
+* [Software Defined Events](https://github.com/icl-utk-edu/papi/wiki/Software_Defined_Events.md)


### PR DESCRIPTION
Removed some remaining links and references to the former Bitbucket repository and replaced them with the GitHub repository.