### PR TITLE
cat: put GEMM kernels back in

### DIFF
--- a/src/counter_analysis_toolkit/Makefile
+++ b/src/counter_analysis_toolkit/Makefile
@@ -7,6 +7,7 @@ CFLAGS+=-g -Wall -Wextra
 OPT0=-O0
 OPT1=-O1
 OPT2=-O2
+OPT3=-O3
 CC=gcc
 
 ## Check to see if MPI is used.
@@ -17,6 +18,7 @@ endif
 
 ## Architecture determines vector instruction set.
 ifeq ($(ARCH),X86)
+    FLOP+=-mfma -DX86
     VECSRC=vec_fma_hp vec_fma_sp vec_fma_dp vec_nonfma_hp vec_nonfma_sp vec_nonfma_dp
     VEC_META=-DAVX128_AVAIL -DAVX256_AVAIL -DAVX512_AVAIL
     VEC128=-mavx -O0 -DX86 $(VEC_META) -DX86_VEC_WIDTH_128B
@@ -28,9 +30,10 @@ ifeq ($(ARCH),X86)
     VEC=-mavx -O0 -DX86
     VEC_FMA=-mfma4 -mfma -O0 -DX86
     VEC_ALL=$(VEC) $(VEC_FMA) -O0 -DX86
-	INSTR=-mavx512vl
+    INSTR=-mavx512vl
 endif
 ifeq ($(ARCH),POWER)
+    FLOP+=-maltivec -DPOWER
     VECSRC=vec_fma_hp.o vec_fma_sp.o vec_fma_dp.o vec_nonfma_hp.o vec_nonfma_sp.o vec_nonfma_dp.o
     VEC=-maltivec -O0 -DPOWER
     VEC_FMA=-maltivec -O0 -DPOWER
@@ -71,7 +74,7 @@ dcache.o: dcache.c dcache.h
 eventstock.o: eventstock.c eventstock.h
 	$(CC) $(CFLAGS) $(OPT0) $(INCFLAGS) -c eventstock.c -o eventstock.o
 
-flops: flops.c flops.h
+flops: flops.c flops.h cat_arch.h
 	$(CC) $(CFLAGS) $(FLOP) $(OPT1) $(INCFLAGS) -c flops.c -o flops.o
 
 icache.o: icache.c icache.h
@@ -94,7 +97,7 @@ weak_symbols.o: weak_symbols.c vec.h
 vec.o: vec.c vec.h
 	-$(CC) -c $(CFLAGS) $(INCFLAGS) -D$(ARCH) $(VEC_META) vec.c
 
-vec_scalar_verify.o: vec_scalar_verify.c vec_scalar_verify.h vec_arch.h
+vec_scalar_verify.o: vec_scalar_verify.c vec_scalar_verify.h cat_arch.h
 	-$(CC) -c $(CFLAGS) $(INCFLAGS) $(VEC_ALL) vec_scalar_verify.c
 
 vec_fma_hp.o: vec_fma_hp.c vec_scalar_verify.h

--- a/src/counter_analysis_toolkit/cat_arch.h
+++ b/src/counter_analysis_toolkit/cat_arch.h
@@ -35,12 +35,12 @@ typedef __m128d DP_SCALAR_TYPE;
 #define SET_VEC_SS(_I_)         _mm_set_ss( _I_ );
 #define ADD_VEC_SS(_I_,_J_)     _mm_add_ss( _I_ , _J_ );
 #define MUL_VEC_SS(_I_,_J_)     _mm_mul_ss( _I_ , _J_ );
-#define FMA_VEC_SS(_I_,_J_,_K_) _mm_fmadd_ss( _I_ , _J_ , _K_ );
+#define FMA_VEC_SS(_out_,_I_,_J_,_K_) { _out_ = _mm_fmadd_ss( _I_ , _J_ , _K_ ); }
 
 #define SET_VEC_SD(_I_)         _mm_set_sd( _I_ );
 #define ADD_VEC_SD(_I_,_J_)     _mm_add_sd( _I_ , _J_ );
 #define MUL_VEC_SD(_I_,_J_)     _mm_mul_sd( _I_ , _J_ );
-#define FMA_VEC_SD(_I_,_J_,_K_) _mm_fmadd_sd( _I_ , _J_ , _K_ );
+#define FMA_VEC_SD(_out_,_I_,_J_,_K_) { _out_ = _mm_fmadd_sd( _I_ , _J_ , _K_ ); }
 
 #if defined(X86_VEC_WIDTH_128B)
 typedef __m128  SP_VEC_TYPE;
@@ -98,41 +98,63 @@ void  test_dp_arm_VEC_FMA( int instr_per_loop, uint64 iterations, int EventSet, 
 typedef __fp16 half;
 typedef float  SP_SCALAR_TYPE;
 typedef double DP_SCALAR_TYPE;
-
-#define SET_VEC_SH(_I_)         _I_ ;
-#define ADD_VEC_SH(_I_,_J_)     vaddh_f16( _I_ , _J_ );
-#define MUL_VEC_SH(_I_,_J_)     vmulh_f16( _I_ , _J_ );
-#define FMA_VEC_SH(_I_,_J_,_K_) vaddh_f16( vmulh_f16( _I_ , _J_) , _K_ );
-
-#define SET_VEC_SS(_I_)         _I_ ;
-#define ADD_VEC_SS(_I_,_J_)     _I_ + _J_ ;
-#define MUL_VEC_SS(_I_,_J_)     _I_ * _J_ ;
-#define FMA_VEC_SS(_I_,_J_,_K_) _I_ * _J_ + _K_ ;
-
-#define SET_VEC_SD(_I_)         _I_ ;
-#define ADD_VEC_SD(_I_,_J_)     _I_ + _J_ ;
-#define MUL_VEC_SD(_I_,_J_)     _I_ * _J_ ;
-#define FMA_VEC_SD(_I_,_J_,_K_) _I_ * _J_ + _K_ ;
-
 typedef float16x8_t HP_VEC_TYPE;
 typedef float32x4_t SP_VEC_TYPE;
 typedef float64x2_t DP_VEC_TYPE;
 
-#define SET_VEC_PH(_I_) (float16x8_t)vdupq_n_f16( _I_ );
-#define SET_VEC_PS(_I_) (float32x4_t)vdupq_n_f32( _I_ );
-#define SET_VEC_PD(_I_) (float64x2_t)vdupq_n_f64( _I_ );
+#define SET_VEC_PH(_I_) (HP_VEC_TYPE)vdupq_n_f16( _I_ );
+#define SET_VEC_PS(_I_) (SP_VEC_TYPE)vdupq_n_f32( _I_ );
+#define SET_VEC_PD(_I_) (DP_VEC_TYPE)vdupq_n_f64( _I_ );
 
-#define ADD_VEC_PH(_I_,_J_) (float16x8_t)vaddq_f16( _I_ , _J_ );
-#define ADD_VEC_PS(_I_,_J_) (float32x4_t)vaddq_f32( _I_ , _J_ );
-#define ADD_VEC_PD(_I_,_J_) (float64x2_t)vaddq_f64( _I_ , _J_ );
+#define ADD_VEC_PH(_I_,_J_) (HP_VEC_TYPE)vaddq_f16( _I_ , _J_ );
+#define ADD_VEC_PS(_I_,_J_) (SP_VEC_TYPE)vaddq_f32( _I_ , _J_ );
+#define ADD_VEC_PD(_I_,_J_) (DP_VEC_TYPE)vaddq_f64( _I_ , _J_ );
 
-#define MUL_VEC_PH(_I_,_J_) (float16x8_t)vmulq_f16( _I_ , _J_ );
-#define MUL_VEC_PS(_I_,_J_) (float32x4_t)vmulq_f32( _I_ , _J_ );
-#define MUL_VEC_PD(_I_,_J_) (float64x2_t)vmulq_f64( _I_ , _J_ );
+#define MUL_VEC_PH(_I_,_J_) (HP_VEC_TYPE)vmulq_f16( _I_ , _J_ );
+#define MUL_VEC_PS(_I_,_J_) (SP_VEC_TYPE)vmulq_f32( _I_ , _J_ );
+#define MUL_VEC_PD(_I_,_J_) (DP_VEC_TYPE)vmulq_f64( _I_ , _J_ );
 
-#define FMA_VEC_PH(_I_,_J_,_K_) (float16x8_t)vfmaq_f16( _K_ , _J_ , _I_ );
-#define FMA_VEC_PS(_I_,_J_,_K_) (float32x4_t)vfmaq_f32( _K_ , _J_ , _I_ );
-#define FMA_VEC_PD(_I_,_J_,_K_) (float64x2_t)vfmaq_f64( _K_ , _J_ , _I_ );
+#define FMA_VEC_PH(_I_,_J_,_K_) (HP_VEC_TYPE)vfmaq_f16( _K_ , _J_ , _I_ );
+#define FMA_VEC_PS(_I_,_J_,_K_) (SP_VEC_TYPE)vfmaq_f32( _K_ , _J_ , _I_ );
+#define FMA_VEC_PD(_I_,_J_,_K_) (DP_VEC_TYPE)vfmaq_f64( _K_ , _J_ , _I_ );
+
+/* There is no scalar FMA intrinsic available on this architecture. */
+#define SET_VEC_SH(_I_)         _I_ ;
+#define ADD_VEC_SH(_I_,_J_)     vaddh_f16( _I_ , _J_ );
+#define MUL_VEC_SH(_I_,_J_)     vmulh_f16( _I_ , _J_ );
+#define SQRT_VEC_SH(_I_)        vsqrth_f16( _I_ );
+#define FMA_VEC_SH(_out_,_I_,_J_,_K_) {\
+    HP_VEC_TYPE arg1 = SET_VEC_PH(_I_);\
+    HP_VEC_TYPE arg2 = SET_VEC_PH(_J_);\
+    HP_VEC_TYPE arg3 = SET_VEC_PH(_K_);\
+    HP_VEC_TYPE argTmp;\
+    argTmp = FMA_VEC_PH( arg1 , arg2 , arg3 );\
+    _out_ = ((half*)&(argTmp))[0];\
+}
+
+#define SET_VEC_SS(_I_)         _I_ ;
+#define ADD_VEC_SS(_I_,_J_)     _I_ + _J_ ;
+#define MUL_VEC_SS(_I_,_J_)     _I_ * _J_ ;
+#define FMA_VEC_SS(_out_,_I_,_J_,_K_) {\
+    SP_VEC_TYPE arg1 = SET_VEC_PS(_I_);\
+    SP_VEC_TYPE arg2 = SET_VEC_PS(_J_);\
+    SP_VEC_TYPE arg3 = SET_VEC_PS(_K_);\
+    SP_VEC_TYPE argTmp;\
+    argTmp = FMA_VEC_PS( arg1 , arg2 , arg3 );\
+    _out_ = ((SP_SCALAR_TYPE*)&(argTmp))[0];\
+}
+
+#define SET_VEC_SD(_I_)         _I_ ;
+#define ADD_VEC_SD(_I_,_J_)     _I_ + _J_ ;
+#define MUL_VEC_SD(_I_,_J_)     _I_ * _J_ ;
+#define FMA_VEC_SD(_out_,_I_,_J_,_K_) {\
+    DP_VEC_TYPE arg1 = SET_VEC_PD(_I_);\
+    DP_VEC_TYPE arg2 = SET_VEC_PD(_J_);\
+    DP_VEC_TYPE arg3 = SET_VEC_PD(_K_);\
+    DP_VEC_TYPE argTmp;\
+    argTmp = FMA_VEC_PD( arg1 , arg2 , arg3 );\
+    _out_ = ((DP_SCALAR_TYPE*)&(argTmp))[0];\
+}
 
 #elif defined(POWER)
 void  test_hp_power_VEC( int instr_per_loop, uint64 iterations, int EventSet, FILE *fp );
@@ -146,30 +168,44 @@ void  test_dp_power_VEC_FMA( int instr_per_loop, uint64 iterations, int EventSet
 
 typedef float  SP_SCALAR_TYPE;
 typedef double DP_SCALAR_TYPE;
+typedef __vector float  SP_VEC_TYPE;
+typedef __vector double DP_VEC_TYPE;
 
+#define SET_VEC_PS(_I_) (SP_VEC_TYPE){ _I_ , _I_ , _I_ , _I_ };
+#define SET_VEC_PD(_I_) (DP_VEC_TYPE){ _I_ , _I_ };
+
+#define ADD_VEC_PS(_I_,_J_) (SP_VEC_TYPE)vec_add( _I_ , _J_ );
+#define ADD_VEC_PD(_I_,_J_) (DP_VEC_TYPE)vec_add( _I_ , _J_ );
+
+#define MUL_VEC_PS(_I_,_J_) (SP_VEC_TYPE)vec_mul( _I_ , _J_ );
+#define MUL_VEC_PD(_I_,_J_) (DP_VEC_TYPE)vec_mul( _I_ , _J_ );
+
+#define FMA_VEC_PS(_I_,_J_,_K_) (SP_VEC_TYPE)vec_madd( _I_ , _J_ , _K_ );
+#define FMA_VEC_PD(_I_,_J_,_K_) (DP_VEC_TYPE)vec_madd( _I_ , _J_ , _K_ );
+
+/* There is no scalar FMA intrinsic available on this architecture. */
 #define SET_VEC_SS(_I_)         _I_ ;
 #define ADD_VEC_SS(_I_,_J_)     _I_ + _J_ ;
 #define MUL_VEC_SS(_I_,_J_)     _I_ * _J_ ;
-#define FMA_VEC_SS(_I_,_J_,_K_) _I_ * _J_ + _K_ ;
+#define FMA_VEC_SS(_out_,_I_,_J_,_K_) {\
+    SP_VEC_TYPE arg1 = SET_VEC_PS(_I_);\
+    SP_VEC_TYPE arg2 = SET_VEC_PS(_J_);\
+    SP_VEC_TYPE arg3 = SET_VEC_PS(_K_);\
+    SP_VEC_TYPE argTmp;\
+    argTmp = FMA_VEC_PS( arg1 , arg2 , arg3 );\
+    _out_ = ((SP_SCALAR_TYPE*)&(argTmp))[0];\
+}
 
 #define SET_VEC_SD(_I_)         _I_ ;
 #define ADD_VEC_SD(_I_,_J_)     _I_ + _J_ ;
 #define MUL_VEC_SD(_I_,_J_)     _I_ * _J_ ;
-#define FMA_VEC_SD(_I_,_J_,_K_) _I_ * _J_ + _K_ ;
-
-typedef __vector float  SP_VEC_TYPE;
-typedef __vector double DP_VEC_TYPE;
-
-#define SET_VEC_PS(_I_) (__vector float){ _I_ , _I_ , _I_ , _I_ };
-#define SET_VEC_PD(_I_) (__vector double){ _I_ , _I_ };
-
-#define ADD_VEC_PS(_I_,_J_) (__vector float)vec_add( _I_ , _J_ );
-#define ADD_VEC_PD(_I_,_J_) (__vector double)vec_add( _I_ , _J_ );
-
-#define MUL_VEC_PS(_I_,_J_) (__vector float)vec_mul( _I_ , _J_ );
-#define MUL_VEC_PD(_I_,_J_) (__vector double)vec_mul( _I_ , _J_ );
-
-#define FMA_VEC_PS(_I_,_J_,_K_) (__vector float)vec_madd( _I_ , _J_ , _K_ );
-#define FMA_VEC_PD(_I_,_J_,_K_) (__vector double)vec_madd( _I_ , _J_ , _K_ );
+#define FMA_VEC_SD(_out_,_I_,_J_,_K_) {\
+    DP_VEC_TYPE arg1 = SET_VEC_PD(_I_);\
+    DP_VEC_TYPE arg2 = SET_VEC_PD(_J_);\
+    DP_VEC_TYPE arg3 = SET_VEC_PD(_K_);\
+    DP_VEC_TYPE argTmp;\
+    argTmp = FMA_VEC_PD( arg1 , arg2 , arg3 );\
+    _out_ = ((DP_SCALAR_TYPE*)&(argTmp))[0];\
+}
 
 #endif

--- a/src/counter_analysis_toolkit/flops.h
+++ b/src/counter_analysis_toolkit/flops.h
@@ -2,6 +2,7 @@
 #define _FLOPS_
 
 #include "hw_desc.h"
+#include "cat_arch.h"
 
 void flops_driver(char* papi_event_str, hw_desc_t *hw_desc, char* outdir);
 

--- a/src/counter_analysis_toolkit/vec.c
+++ b/src/counter_analysis_toolkit/vec.c
@@ -4,7 +4,7 @@
 #include <unistd.h>
 #include <papi.h>
 #include "vec.h"
-#include "vec_arch.h"
+#include "cat_arch.h"
 
 void vec_driver(char* papi_event_name, hw_desc_t *hw_desc, char* outdir)
 {

--- a/src/counter_analysis_toolkit/vec_scalar_verify.c
+++ b/src/counter_analysis_toolkit/vec_scalar_verify.c
@@ -1117,19 +1117,19 @@ half test_hp_scalar_VEC_FMA_12( uint64 iterations ){
         while (i < 1000){
 
             /* The performance critical part */
-            r0 = FMA_VEC_SH(r0,r7,r9);
-            r1 = FMA_VEC_SH(r1,r8,rA);
-            r2 = FMA_VEC_SH(r2,r9,rB);
-            r3 = FMA_VEC_SH(r3,rA,rC);
-            r4 = FMA_VEC_SH(r4,rB,rD);
-            r5 = FMA_VEC_SH(r5,rC,rE);
+            FMA_VEC_SH(r0,r0,r7,r9);
+            FMA_VEC_SH(r1,r1,r8,rA);
+            FMA_VEC_SH(r2,r2,r9,rB);
+            FMA_VEC_SH(r3,r3,rA,rC);
+            FMA_VEC_SH(r4,r4,rB,rD);
+            FMA_VEC_SH(r5,r5,rC,rE);
 
-            r0 = FMA_VEC_SH(r0,rD,rF);
-            r1 = FMA_VEC_SH(r1,rC,rE);
-            r2 = FMA_VEC_SH(r2,rB,rD);
-            r3 = FMA_VEC_SH(r3,rA,rC);
-            r4 = FMA_VEC_SH(r4,r9,rB);
-            r5 = FMA_VEC_SH(r5,r8,rA);
+            FMA_VEC_SH(r0,r0,rD,rF);
+            FMA_VEC_SH(r1,r1,rC,rE);
+            FMA_VEC_SH(r2,r2,rB,rD);
+            FMA_VEC_SH(r3,r3,rA,rC);
+            FMA_VEC_SH(r4,r4,r9,rB);
+            FMA_VEC_SH(r5,r5,r8,rA);
 
             i++;
         }
@@ -1180,33 +1180,33 @@ half test_hp_scalar_VEC_FMA_24( uint64 iterations ){
         while (i < 1000){
 
             /* The performance critical part */
-            r0 = FMA_VEC_SH(r0,r7,r9);
-            r1 = FMA_VEC_SH(r1,r8,rA);
-            r2 = FMA_VEC_SH(r2,r9,rB);
-            r3 = FMA_VEC_SH(r3,rA,rC);
-            r4 = FMA_VEC_SH(r4,rB,rD);
-            r5 = FMA_VEC_SH(r5,rC,rE);
+            FMA_VEC_SH(r0,r0,r7,r9);
+            FMA_VEC_SH(r1,r1,r8,rA);
+            FMA_VEC_SH(r2,r2,r9,rB);
+            FMA_VEC_SH(r3,r3,rA,rC);
+            FMA_VEC_SH(r4,r4,rB,rD);
+            FMA_VEC_SH(r5,r5,rC,rE);
 
-            r0 = FMA_VEC_SH(r0,rD,rF);
-            r1 = FMA_VEC_SH(r1,rC,rE);
-            r2 = FMA_VEC_SH(r2,rB,rD);
-            r3 = FMA_VEC_SH(r3,rA,rC);
-            r4 = FMA_VEC_SH(r4,r9,rB);
-            r5 = FMA_VEC_SH(r5,r8,rA);
+            FMA_VEC_SH(r0,r0,rD,rF);
+            FMA_VEC_SH(r1,r1,rC,rE);
+            FMA_VEC_SH(r2,r2,rB,rD);
+            FMA_VEC_SH(r3,r3,rA,rC);
+            FMA_VEC_SH(r4,r4,r9,rB);
+            FMA_VEC_SH(r5,r5,r8,rA);
 
-            r0 = FMA_VEC_SH(r0,r7,r9);
-            r1 = FMA_VEC_SH(r1,r8,rA);
-            r2 = FMA_VEC_SH(r2,r9,rB);
-            r3 = FMA_VEC_SH(r3,rA,rC);
-            r4 = FMA_VEC_SH(r4,rB,rD);
-            r5 = FMA_VEC_SH(r5,rC,rE);
+            FMA_VEC_SH(r0,r0,r7,r9);
+            FMA_VEC_SH(r1,r1,r8,rA);
+            FMA_VEC_SH(r2,r2,r9,rB);
+            FMA_VEC_SH(r3,r3,rA,rC);
+            FMA_VEC_SH(r4,r4,rB,rD);
+            FMA_VEC_SH(r5,r5,rC,rE);
 
-            r0 = FMA_VEC_SH(r0,rD,rF);
-            r1 = FMA_VEC_SH(r1,rC,rE);
-            r2 = FMA_VEC_SH(r2,rB,rD);
-            r3 = FMA_VEC_SH(r3,rA,rC);
-            r4 = FMA_VEC_SH(r4,r9,rB);
-            r5 = FMA_VEC_SH(r5,r8,rA);
+            FMA_VEC_SH(r0,r0,rD,rF);
+            FMA_VEC_SH(r1,r1,rC,rE);
+            FMA_VEC_SH(r2,r2,rB,rD);
+            FMA_VEC_SH(r3,r3,rA,rC);
+            FMA_VEC_SH(r4,r4,r9,rB);
+            FMA_VEC_SH(r5,r5,r8,rA);
 
             i++;
         }
@@ -1257,61 +1257,61 @@ half test_hp_scalar_VEC_FMA_48( uint64 iterations ){
         while (i < 1000){
 
             /* The performance critical part */
-            r0 = FMA_VEC_SH(r0,r7,r9);
-            r1 = FMA_VEC_SH(r1,r8,rA);
-            r2 = FMA_VEC_SH(r2,r9,rB);
-            r3 = FMA_VEC_SH(r3,rA,rC);
-            r4 = FMA_VEC_SH(r4,rB,rD);
-            r5 = FMA_VEC_SH(r5,rC,rE);
+            FMA_VEC_SH(r0,r0,r7,r9);
+            FMA_VEC_SH(r1,r1,r8,rA);
+            FMA_VEC_SH(r2,r2,r9,rB);
+            FMA_VEC_SH(r3,r3,rA,rC);
+            FMA_VEC_SH(r4,r4,rB,rD);
+            FMA_VEC_SH(r5,r5,rC,rE);
 
-            r0 = FMA_VEC_SH(r0,rD,rF);
-            r1 = FMA_VEC_SH(r1,rC,rE);
-            r2 = FMA_VEC_SH(r2,rB,rD);
-            r3 = FMA_VEC_SH(r3,rA,rC);
-            r4 = FMA_VEC_SH(r4,r9,rB);
-            r5 = FMA_VEC_SH(r5,r8,rA);
+            FMA_VEC_SH(r0,r0,rD,rF);
+            FMA_VEC_SH(r1,r1,rC,rE);
+            FMA_VEC_SH(r2,r2,rB,rD);
+            FMA_VEC_SH(r3,r3,rA,rC);
+            FMA_VEC_SH(r4,r4,r9,rB);
+            FMA_VEC_SH(r5,r5,r8,rA);
 
-            r0 = FMA_VEC_SH(r0,r7,r9);
-            r1 = FMA_VEC_SH(r1,r8,rA);
-            r2 = FMA_VEC_SH(r2,r9,rB);
-            r3 = FMA_VEC_SH(r3,rA,rC);
-            r4 = FMA_VEC_SH(r4,rB,rD);
-            r5 = FMA_VEC_SH(r5,rC,rE);
+            FMA_VEC_SH(r0,r0,r7,r9);
+            FMA_VEC_SH(r1,r1,r8,rA);
+            FMA_VEC_SH(r2,r2,r9,rB);
+            FMA_VEC_SH(r3,r3,rA,rC);
+            FMA_VEC_SH(r4,r4,rB,rD);
+            FMA_VEC_SH(r5,r5,rC,rE);
 
-            r0 = FMA_VEC_SH(r0,rD,rF);
-            r1 = FMA_VEC_SH(r1,rC,rE);
-            r2 = FMA_VEC_SH(r2,rB,rD);
-            r3 = FMA_VEC_SH(r3,rA,rC);
-            r4 = FMA_VEC_SH(r4,r9,rB);
-            r5 = FMA_VEC_SH(r5,r8,rA);
+            FMA_VEC_SH(r0,r0,rD,rF);
+            FMA_VEC_SH(r1,r1,rC,rE);
+            FMA_VEC_SH(r2,r2,rB,rD);
+            FMA_VEC_SH(r3,r3,rA,rC);
+            FMA_VEC_SH(r4,r4,r9,rB);
+            FMA_VEC_SH(r5,r5,r8,rA);
 
-            r0 = FMA_VEC_SH(r0,r7,r9);
-            r1 = FMA_VEC_SH(r1,r8,rA);
-            r2 = FMA_VEC_SH(r2,r9,rB);
-            r3 = FMA_VEC_SH(r3,rA,rC);
-            r4 = FMA_VEC_SH(r4,rB,rD);
-            r5 = FMA_VEC_SH(r5,rC,rE);
+            FMA_VEC_SH(r0,r0,r7,r9);
+            FMA_VEC_SH(r1,r1,r8,rA);
+            FMA_VEC_SH(r2,r2,r9,rB);
+            FMA_VEC_SH(r3,r3,rA,rC);
+            FMA_VEC_SH(r4,r4,rB,rD);
+            FMA_VEC_SH(r5,r5,rC,rE);
 
-            r0 = FMA_VEC_SH(r0,rD,rF);
-            r1 = FMA_VEC_SH(r1,rC,rE);
-            r2 = FMA_VEC_SH(r2,rB,rD);
-            r3 = FMA_VEC_SH(r3,rA,rC);
-            r4 = FMA_VEC_SH(r4,r9,rB);
-            r5 = FMA_VEC_SH(r5,r8,rA);
+            FMA_VEC_SH(r0,r0,rD,rF);
+            FMA_VEC_SH(r1,r1,rC,rE);
+            FMA_VEC_SH(r2,r2,rB,rD);
+            FMA_VEC_SH(r3,r3,rA,rC);
+            FMA_VEC_SH(r4,r4,r9,rB);
+            FMA_VEC_SH(r5,r5,r8,rA);
 
-            r0 = FMA_VEC_SH(r0,r7,r9);
-            r1 = FMA_VEC_SH(r1,r8,rA);
-            r2 = FMA_VEC_SH(r2,r9,rB);
-            r3 = FMA_VEC_SH(r3,rA,rC);
-            r4 = FMA_VEC_SH(r4,rB,rD);
-            r5 = FMA_VEC_SH(r5,rC,rE);
+            FMA_VEC_SH(r0,r0,r7,r9);
+            FMA_VEC_SH(r1,r1,r8,rA);
+            FMA_VEC_SH(r2,r2,r9,rB);
+            FMA_VEC_SH(r3,r3,rA,rC);
+            FMA_VEC_SH(r4,r4,rB,rD);
+            FMA_VEC_SH(r5,r5,rC,rE);
 
-            r0 = FMA_VEC_SH(r0,rD,rF);
-            r1 = FMA_VEC_SH(r1,rC,rE);
-            r2 = FMA_VEC_SH(r2,rB,rD);
-            r3 = FMA_VEC_SH(r3,rA,rC);
-            r4 = FMA_VEC_SH(r4,r9,rB);
-            r5 = FMA_VEC_SH(r5,r8,rA);
+            FMA_VEC_SH(r0,r0,rD,rF);
+            FMA_VEC_SH(r1,r1,rC,rE);
+            FMA_VEC_SH(r2,r2,rB,rD);
+            FMA_VEC_SH(r3,r3,rA,rC);
+            FMA_VEC_SH(r4,r4,r9,rB);
+            FMA_VEC_SH(r5,r5,r8,rA);
 
             i++;
         }
@@ -1385,19 +1385,19 @@ float test_sp_scalar_VEC_FMA_12( uint64 iterations ){
         while (i < 1000){
 
             /* The performance critical part */
-            r0 = FMA_VEC_SS(r0,r7,r9);
-            r1 = FMA_VEC_SS(r1,r8,rA);
-            r2 = FMA_VEC_SS(r2,r9,rB);
-            r3 = FMA_VEC_SS(r3,rA,rC);
-            r4 = FMA_VEC_SS(r4,rB,rD);
-            r5 = FMA_VEC_SS(r5,rC,rE);
+            FMA_VEC_SS(r0,r0,r7,r9);
+            FMA_VEC_SS(r1,r1,r8,rA);
+            FMA_VEC_SS(r2,r2,r9,rB);
+            FMA_VEC_SS(r3,r3,rA,rC);
+            FMA_VEC_SS(r4,r4,rB,rD);
+            FMA_VEC_SS(r5,r5,rC,rE);
 
-            r0 = FMA_VEC_SS(r0,rD,rF);
-            r1 = FMA_VEC_SS(r1,rC,rE);
-            r2 = FMA_VEC_SS(r2,rB,rD);
-            r3 = FMA_VEC_SS(r3,rA,rC);
-            r4 = FMA_VEC_SS(r4,r9,rB);
-            r5 = FMA_VEC_SS(r5,r8,rA);
+            FMA_VEC_SS(r0,r0,rD,rF);
+            FMA_VEC_SS(r1,r1,rC,rE);
+            FMA_VEC_SS(r2,r2,rB,rD);
+            FMA_VEC_SS(r3,r3,rA,rC);
+            FMA_VEC_SS(r4,r4,r9,rB);
+            FMA_VEC_SS(r5,r5,r8,rA);
 
             i++;
         }
@@ -1451,33 +1451,33 @@ float test_sp_scalar_VEC_FMA_24( uint64 iterations ){
         while (i < 1000){
 
             /* The performance critical part */
-            r0 = FMA_VEC_SS(r0,r7,r9);
-            r1 = FMA_VEC_SS(r1,r8,rA);
-            r2 = FMA_VEC_SS(r2,r9,rB);
-            r3 = FMA_VEC_SS(r3,rA,rC);
-            r4 = FMA_VEC_SS(r4,rB,rD);
-            r5 = FMA_VEC_SS(r5,rC,rE);
+            FMA_VEC_SS(r0,r0,r7,r9);
+            FMA_VEC_SS(r1,r1,r8,rA);
+            FMA_VEC_SS(r2,r2,r9,rB);
+            FMA_VEC_SS(r3,r3,rA,rC);
+            FMA_VEC_SS(r4,r4,rB,rD);
+            FMA_VEC_SS(r5,r5,rC,rE);
 
-            r0 = FMA_VEC_SS(r0,rD,rF);
-            r1 = FMA_VEC_SS(r1,rC,rE);
-            r2 = FMA_VEC_SS(r2,rB,rD);
-            r3 = FMA_VEC_SS(r3,rA,rC);
-            r4 = FMA_VEC_SS(r4,r9,rB);
-            r5 = FMA_VEC_SS(r5,r8,rA);
+            FMA_VEC_SS(r0,r0,rD,rF);
+            FMA_VEC_SS(r1,r1,rC,rE);
+            FMA_VEC_SS(r2,r2,rB,rD);
+            FMA_VEC_SS(r3,r3,rA,rC);
+            FMA_VEC_SS(r4,r4,r9,rB);
+            FMA_VEC_SS(r5,r5,r8,rA);
 
-            r0 = FMA_VEC_SS(r0,r7,r9);
-            r1 = FMA_VEC_SS(r1,r8,rA);
-            r2 = FMA_VEC_SS(r2,r9,rB);
-            r3 = FMA_VEC_SS(r3,rA,rC);
-            r4 = FMA_VEC_SS(r4,rB,rD);
-            r5 = FMA_VEC_SS(r5,rC,rE);
+            FMA_VEC_SS(r0,r0,r7,r9);
+            FMA_VEC_SS(r1,r1,r8,rA);
+            FMA_VEC_SS(r2,r2,r9,rB);
+            FMA_VEC_SS(r3,r3,rA,rC);
+            FMA_VEC_SS(r4,r4,rB,rD);
+            FMA_VEC_SS(r5,r5,rC,rE);
 
-            r0 = FMA_VEC_SS(r0,rD,rF);
-            r1 = FMA_VEC_SS(r1,rC,rE);
-            r2 = FMA_VEC_SS(r2,rB,rD);
-            r3 = FMA_VEC_SS(r3,rA,rC);
-            r4 = FMA_VEC_SS(r4,r9,rB);
-            r5 = FMA_VEC_SS(r5,r8,rA);
+            FMA_VEC_SS(r0,r0,rD,rF);
+            FMA_VEC_SS(r1,r1,rC,rE);
+            FMA_VEC_SS(r2,r2,rB,rD);
+            FMA_VEC_SS(r3,r3,rA,rC);
+            FMA_VEC_SS(r4,r4,r9,rB);
+            FMA_VEC_SS(r5,r5,r8,rA);
 
             i++;
         }
@@ -1531,61 +1531,61 @@ float test_sp_scalar_VEC_FMA_48( uint64 iterations ){
         while (i < 1000){
 
             /* The performance critical part */
-            r0 = FMA_VEC_SS(r0,r7,r9);
-            r1 = FMA_VEC_SS(r1,r8,rA);
-            r2 = FMA_VEC_SS(r2,r9,rB);
-            r3 = FMA_VEC_SS(r3,rA,rC);
-            r4 = FMA_VEC_SS(r4,rB,rD);
-            r5 = FMA_VEC_SS(r5,rC,rE);
+            FMA_VEC_SS(r0,r0,r7,r9);
+            FMA_VEC_SS(r1,r1,r8,rA);
+            FMA_VEC_SS(r2,r2,r9,rB);
+            FMA_VEC_SS(r3,r3,rA,rC);
+            FMA_VEC_SS(r4,r4,rB,rD);
+            FMA_VEC_SS(r5,r5,rC,rE);
 
-            r0 = FMA_VEC_SS(r0,rD,rF);
-            r1 = FMA_VEC_SS(r1,rC,rE);
-            r2 = FMA_VEC_SS(r2,rB,rD);
-            r3 = FMA_VEC_SS(r3,rA,rC);
-            r4 = FMA_VEC_SS(r4,r9,rB);
-            r5 = FMA_VEC_SS(r5,r8,rA);
+            FMA_VEC_SS(r0,r0,rD,rF);
+            FMA_VEC_SS(r1,r1,rC,rE);
+            FMA_VEC_SS(r2,r2,rB,rD);
+            FMA_VEC_SS(r3,r3,rA,rC);
+            FMA_VEC_SS(r4,r4,r9,rB);
+            FMA_VEC_SS(r5,r5,r8,rA);
 
-            r0 = FMA_VEC_SS(r0,r7,r9);
-            r1 = FMA_VEC_SS(r1,r8,rA);
-            r2 = FMA_VEC_SS(r2,r9,rB);
-            r3 = FMA_VEC_SS(r3,rA,rC);
-            r4 = FMA_VEC_SS(r4,rB,rD);
-            r5 = FMA_VEC_SS(r5,rC,rE);
+            FMA_VEC_SS(r0,r0,r7,r9);
+            FMA_VEC_SS(r1,r1,r8,rA);
+            FMA_VEC_SS(r2,r2,r9,rB);
+            FMA_VEC_SS(r3,r3,rA,rC);
+            FMA_VEC_SS(r4,r4,rB,rD);
+            FMA_VEC_SS(r5,r5,rC,rE);
 
-            r0 = FMA_VEC_SS(r0,rD,rF);
-            r1 = FMA_VEC_SS(r1,rC,rE);
-            r2 = FMA_VEC_SS(r2,rB,rD);
-            r3 = FMA_VEC_SS(r3,rA,rC);
-            r4 = FMA_VEC_SS(r4,r9,rB);
-            r5 = FMA_VEC_SS(r5,r8,rA);
+            FMA_VEC_SS(r0,r0,rD,rF);
+            FMA_VEC_SS(r1,r1,rC,rE);
+            FMA_VEC_SS(r2,r2,rB,rD);
+            FMA_VEC_SS(r3,r3,rA,rC);
+            FMA_VEC_SS(r4,r4,r9,rB);
+            FMA_VEC_SS(r5,r5,r8,rA);
 
-            r0 = FMA_VEC_SS(r0,r7,r9);
-            r1 = FMA_VEC_SS(r1,r8,rA);
-            r2 = FMA_VEC_SS(r2,r9,rB);
-            r3 = FMA_VEC_SS(r3,rA,rC);
-            r4 = FMA_VEC_SS(r4,rB,rD);
-            r5 = FMA_VEC_SS(r5,rC,rE);
+            FMA_VEC_SS(r0,r0,r7,r9);
+            FMA_VEC_SS(r1,r1,r8,rA);
+            FMA_VEC_SS(r2,r2,r9,rB);
+            FMA_VEC_SS(r3,r3,rA,rC);
+            FMA_VEC_SS(r4,r4,rB,rD);
+            FMA_VEC_SS(r5,r5,rC,rE);
 
-            r0 = FMA_VEC_SS(r0,rD,rF);
-            r1 = FMA_VEC_SS(r1,rC,rE);
-            r2 = FMA_VEC_SS(r2,rB,rD);
-            r3 = FMA_VEC_SS(r3,rA,rC);
-            r4 = FMA_VEC_SS(r4,r9,rB);
-            r5 = FMA_VEC_SS(r5,r8,rA);
+            FMA_VEC_SS(r0,r0,rD,rF);
+            FMA_VEC_SS(r1,r1,rC,rE);
+            FMA_VEC_SS(r2,r2,rB,rD);
+            FMA_VEC_SS(r3,r3,rA,rC);
+            FMA_VEC_SS(r4,r4,r9,rB);
+            FMA_VEC_SS(r5,r5,r8,rA);
 
-            r0 = FMA_VEC_SS(r0,r7,r9);
-            r1 = FMA_VEC_SS(r1,r8,rA);
-            r2 = FMA_VEC_SS(r2,r9,rB);
-            r3 = FMA_VEC_SS(r3,rA,rC);
-            r4 = FMA_VEC_SS(r4,rB,rD);
-            r5 = FMA_VEC_SS(r5,rC,rE);
+            FMA_VEC_SS(r0,r0,r7,r9);
+            FMA_VEC_SS(r1,r1,r8,rA);
+            FMA_VEC_SS(r2,r2,r9,rB);
+            FMA_VEC_SS(r3,r3,rA,rC);
+            FMA_VEC_SS(r4,r4,rB,rD);
+            FMA_VEC_SS(r5,r5,rC,rE);
 
-            r0 = FMA_VEC_SS(r0,rD,rF);
-            r1 = FMA_VEC_SS(r1,rC,rE);
-            r2 = FMA_VEC_SS(r2,rB,rD);
-            r3 = FMA_VEC_SS(r3,rA,rC);
-            r4 = FMA_VEC_SS(r4,r9,rB);
-            r5 = FMA_VEC_SS(r5,r8,rA);
+            FMA_VEC_SS(r0,r0,rD,rF);
+            FMA_VEC_SS(r1,r1,rC,rE);
+            FMA_VEC_SS(r2,r2,rB,rD);
+            FMA_VEC_SS(r3,r3,rA,rC);
+            FMA_VEC_SS(r4,r4,r9,rB);
+            FMA_VEC_SS(r5,r5,r8,rA);
 
             i++;
         }
@@ -1639,19 +1639,19 @@ double test_dp_scalar_VEC_FMA_12( uint64 iterations ){
         while (i < 1000){
 
             /* The performance critical part */
-            r0 = FMA_VEC_SD(r0,r7,r9);
-            r1 = FMA_VEC_SD(r1,r8,rA);
-            r2 = FMA_VEC_SD(r2,r9,rB);
-            r3 = FMA_VEC_SD(r3,rA,rC);
-            r4 = FMA_VEC_SD(r4,rB,rD);
-            r5 = FMA_VEC_SD(r5,rC,rE);
+            FMA_VEC_SD(r0,r0,r7,r9);
+            FMA_VEC_SD(r1,r1,r8,rA);
+            FMA_VEC_SD(r2,r2,r9,rB);
+            FMA_VEC_SD(r3,r3,rA,rC);
+            FMA_VEC_SD(r4,r4,rB,rD);
+            FMA_VEC_SD(r5,r5,rC,rE);
             
-            r0 = FMA_VEC_SD(r0,rD,rF);
-            r1 = FMA_VEC_SD(r1,rC,rE);
-            r2 = FMA_VEC_SD(r2,rB,rD);
-            r3 = FMA_VEC_SD(r3,rA,rC);
-            r4 = FMA_VEC_SD(r4,r9,rB);
-            r5 = FMA_VEC_SD(r5,r8,rA);
+            FMA_VEC_SD(r0,r0,rD,rF);
+            FMA_VEC_SD(r1,r1,rC,rE);
+            FMA_VEC_SD(r2,r2,rB,rD);
+            FMA_VEC_SD(r3,r3,rA,rC);
+            FMA_VEC_SD(r4,r4,r9,rB);
+            FMA_VEC_SD(r5,r5,r8,rA);
 
             i++;
         }
@@ -1705,33 +1705,33 @@ double test_dp_scalar_VEC_FMA_24( uint64 iterations ){
         while (i < 1000){
 
             /* The performance critical part */
-            r0 = FMA_VEC_SD(r0,r7,r9);
-            r1 = FMA_VEC_SD(r1,r8,rA);
-            r2 = FMA_VEC_SD(r2,r9,rB);
-            r3 = FMA_VEC_SD(r3,rA,rC);
-            r4 = FMA_VEC_SD(r4,rB,rD);
-            r5 = FMA_VEC_SD(r5,rC,rE);
+            FMA_VEC_SD(r0,r0,r7,r9);
+            FMA_VEC_SD(r1,r1,r8,rA);
+            FMA_VEC_SD(r2,r2,r9,rB);
+            FMA_VEC_SD(r3,r3,rA,rC);
+            FMA_VEC_SD(r4,r4,rB,rD);
+            FMA_VEC_SD(r5,r5,rC,rE);
+            
+            FMA_VEC_SD(r0,r0,rD,rF);
+            FMA_VEC_SD(r1,r1,rC,rE);
+            FMA_VEC_SD(r2,r2,rB,rD);
+            FMA_VEC_SD(r3,r3,rA,rC);
+            FMA_VEC_SD(r4,r4,r9,rB);
+            FMA_VEC_SD(r5,r5,r8,rA);
 
-            r0 = FMA_VEC_SD(r0,rD,rF);
-            r1 = FMA_VEC_SD(r1,rC,rE);
-            r2 = FMA_VEC_SD(r2,rB,rD);
-            r3 = FMA_VEC_SD(r3,rA,rC);
-            r4 = FMA_VEC_SD(r4,r9,rB);
-            r5 = FMA_VEC_SD(r5,r8,rA);
-
-            r0 = FMA_VEC_SD(r0,r7,r9);
-            r1 = FMA_VEC_SD(r1,r8,rA);
-            r2 = FMA_VEC_SD(r2,r9,rB);
-            r3 = FMA_VEC_SD(r3,rA,rC);
-            r4 = FMA_VEC_SD(r4,rB,rD);
-            r5 = FMA_VEC_SD(r5,rC,rE);
-
-            r0 = FMA_VEC_SD(r0,rD,rF);
-            r1 = FMA_VEC_SD(r1,rC,rE);
-            r2 = FMA_VEC_SD(r2,rB,rD);
-            r3 = FMA_VEC_SD(r3,rA,rC);
-            r4 = FMA_VEC_SD(r4,r9,rB);
-            r5 = FMA_VEC_SD(r5,r8,rA);
+            FMA_VEC_SD(r0,r0,r7,r9);
+            FMA_VEC_SD(r1,r1,r8,rA);
+            FMA_VEC_SD(r2,r2,r9,rB);
+            FMA_VEC_SD(r3,r3,rA,rC);
+            FMA_VEC_SD(r4,r4,rB,rD);
+            FMA_VEC_SD(r5,r5,rC,rE);
+            
+            FMA_VEC_SD(r0,r0,rD,rF);
+            FMA_VEC_SD(r1,r1,rC,rE);
+            FMA_VEC_SD(r2,r2,rB,rD);
+            FMA_VEC_SD(r3,r3,rA,rC);
+            FMA_VEC_SD(r4,r4,r9,rB);
+            FMA_VEC_SD(r5,r5,r8,rA);
 
             i++;
         }
@@ -1785,61 +1785,61 @@ double test_dp_scalar_VEC_FMA_48( uint64 iterations ){
         while (i < 1000){
 
             /* The performance critical part */
-            r0 = FMA_VEC_SD(r0,r7,r9);
-            r1 = FMA_VEC_SD(r1,r8,rA);
-            r2 = FMA_VEC_SD(r2,r9,rB);
-            r3 = FMA_VEC_SD(r3,rA,rC);
-            r4 = FMA_VEC_SD(r4,rB,rD);
-            r5 = FMA_VEC_SD(r5,rC,rE);
+            FMA_VEC_SD(r0,r0,r7,r9);
+            FMA_VEC_SD(r1,r1,r8,rA);
+            FMA_VEC_SD(r2,r2,r9,rB);
+            FMA_VEC_SD(r3,r3,rA,rC);
+            FMA_VEC_SD(r4,r4,rB,rD);
+            FMA_VEC_SD(r5,r5,rC,rE);
+            
+            FMA_VEC_SD(r0,r0,rD,rF);
+            FMA_VEC_SD(r1,r1,rC,rE);
+            FMA_VEC_SD(r2,r2,rB,rD);
+            FMA_VEC_SD(r3,r3,rA,rC);
+            FMA_VEC_SD(r4,r4,r9,rB);
+            FMA_VEC_SD(r5,r5,r8,rA);
 
-            r0 = FMA_VEC_SD(r0,rD,rF);
-            r1 = FMA_VEC_SD(r1,rC,rE);
-            r2 = FMA_VEC_SD(r2,rB,rD);
-            r3 = FMA_VEC_SD(r3,rA,rC);
-            r4 = FMA_VEC_SD(r4,r9,rB);
-            r5 = FMA_VEC_SD(r5,r8,rA);
+            FMA_VEC_SD(r0,r0,r7,r9);
+            FMA_VEC_SD(r1,r1,r8,rA);
+            FMA_VEC_SD(r2,r2,r9,rB);
+            FMA_VEC_SD(r3,r3,rA,rC);
+            FMA_VEC_SD(r4,r4,rB,rD);
+            FMA_VEC_SD(r5,r5,rC,rE);
+            
+            FMA_VEC_SD(r0,r0,rD,rF);
+            FMA_VEC_SD(r1,r1,rC,rE);
+            FMA_VEC_SD(r2,r2,rB,rD);
+            FMA_VEC_SD(r3,r3,rA,rC);
+            FMA_VEC_SD(r4,r4,r9,rB);
+            FMA_VEC_SD(r5,r5,r8,rA);
 
-            r0 = FMA_VEC_SD(r0,r7,r9);
-            r1 = FMA_VEC_SD(r1,r8,rA);
-            r2 = FMA_VEC_SD(r2,r9,rB);
-            r3 = FMA_VEC_SD(r3,rA,rC);
-            r4 = FMA_VEC_SD(r4,rB,rD);
-            r5 = FMA_VEC_SD(r5,rC,rE);
+            FMA_VEC_SD(r0,r0,r7,r9);
+            FMA_VEC_SD(r1,r1,r8,rA);
+            FMA_VEC_SD(r2,r2,r9,rB);
+            FMA_VEC_SD(r3,r3,rA,rC);
+            FMA_VEC_SD(r4,r4,rB,rD);
+            FMA_VEC_SD(r5,r5,rC,rE);
+            
+            FMA_VEC_SD(r0,r0,rD,rF);
+            FMA_VEC_SD(r1,r1,rC,rE);
+            FMA_VEC_SD(r2,r2,rB,rD);
+            FMA_VEC_SD(r3,r3,rA,rC);
+            FMA_VEC_SD(r4,r4,r9,rB);
+            FMA_VEC_SD(r5,r5,r8,rA);
 
-            r0 = FMA_VEC_SD(r0,rD,rF);
-            r1 = FMA_VEC_SD(r1,rC,rE);
-            r2 = FMA_VEC_SD(r2,rB,rD);
-            r3 = FMA_VEC_SD(r3,rA,rC);
-            r4 = FMA_VEC_SD(r4,r9,rB);
-            r5 = FMA_VEC_SD(r5,r8,rA);
-
-            r0 = FMA_VEC_SD(r0,r7,r9);
-            r1 = FMA_VEC_SD(r1,r8,rA);
-            r2 = FMA_VEC_SD(r2,r9,rB);
-            r3 = FMA_VEC_SD(r3,rA,rC);
-            r4 = FMA_VEC_SD(r4,rB,rD);
-            r5 = FMA_VEC_SD(r5,rC,rE);
-
-            r0 = FMA_VEC_SD(r0,rD,rF);
-            r1 = FMA_VEC_SD(r1,rC,rE);
-            r2 = FMA_VEC_SD(r2,rB,rD);
-            r3 = FMA_VEC_SD(r3,rA,rC);
-            r4 = FMA_VEC_SD(r4,r9,rB);
-            r5 = FMA_VEC_SD(r5,r8,rA);
-
-            r0 = FMA_VEC_SD(r0,r7,r9);
-            r1 = FMA_VEC_SD(r1,r8,rA);
-            r2 = FMA_VEC_SD(r2,r9,rB);
-            r3 = FMA_VEC_SD(r3,rA,rC);
-            r4 = FMA_VEC_SD(r4,rB,rD);
-            r5 = FMA_VEC_SD(r5,rC,rE);
-
-            r0 = FMA_VEC_SD(r0,rD,rF);
-            r1 = FMA_VEC_SD(r1,rC,rE);
-            r2 = FMA_VEC_SD(r2,rB,rD);
-            r3 = FMA_VEC_SD(r3,rA,rC);
-            r4 = FMA_VEC_SD(r4,r9,rB);
-            r5 = FMA_VEC_SD(r5,r8,rA);
+            FMA_VEC_SD(r0,r0,r7,r9);
+            FMA_VEC_SD(r1,r1,r8,rA);
+            FMA_VEC_SD(r2,r2,r9,rB);
+            FMA_VEC_SD(r3,r3,rA,rC);
+            FMA_VEC_SD(r4,r4,rB,rD);
+            FMA_VEC_SD(r5,r5,rC,rE);
+            
+            FMA_VEC_SD(r0,r0,rD,rF);
+            FMA_VEC_SD(r1,r1,rC,rE);
+            FMA_VEC_SD(r2,r2,rB,rD);
+            FMA_VEC_SD(r3,r3,rA,rC);
+            FMA_VEC_SD(r4,r4,r9,rB);
+            FMA_VEC_SD(r5,r5,r8,rA);
 
             i++;
         }

--- a/src/counter_analysis_toolkit/vec_scalar_verify.h
+++ b/src/counter_analysis_toolkit/vec_scalar_verify.h
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <papi.h>
 #include <stdlib.h>
-#include "vec_arch.h"
+#include "cat_arch.h"
 
 void papi_stop_and_print_placeholder(long long theory, FILE *fp);
 void papi_stop_and_print(long long theory, int EventSet, FILE *fp);


### PR DESCRIPTION
Re-introduce the GEMM operation in each precision to provide a kernel that executes exclusively fused multiply-add floating-point operations.

These changes have been tested on the AMD Zen4 and Fujitsu A64FX architectures.