### PR TITLE
2023.06.20 fix fortran test flags

### DIFF
--- a/src/components/sde/tests/Makefile
+++ b/src/components/sde/tests/Makefile
@@ -1,12 +1,18 @@
 NAME=sde
 include ../../Makefile_comp_tests.target
 INCLUDE += -I$(datadir)/sde_lib -I..
+
+intel_compilers := ifort ifx
+cray_compilers := ftn crayftn
+
 ifeq ($(notdir $(F77)),gfortran)
 	FFLAGS +=-ffree-form -ffree-line-length-none
 else ifeq ($(notdir $(F77)),flang)
 	FFLAGS +=-ffree-form
-else
-	FFLAGS +=-free
+else ifeq ($(findstring $(notdir $(F77)), $(intel_compilers)),)
+    FFLAGS +=-free
+else ifeq ($(findstring $(notdir $(F77)), $(cray_compilers)),)
+    FFLAGS +=-ffree
 endif
 FFLAGS +=-g
 CFLAGS +=-g

--- a/src/components/sysdetect/tests/Makefile
+++ b/src/components/sysdetect/tests/Makefile
@@ -18,12 +18,17 @@ ifeq ($(ENABLE_FORTRAN_TESTS),yes)
     FTESTS = query_device_simple_f
 endif
 
+intel_compilers := ifort ifx
+cray_compilers := ftn crayftn
+
 ifeq ($(notdir $(F77)),gfortran)
     FFLAGS +=-ffree-form -ffree-line-length-none
 else ifeq ($(notdir $(F77)),flang)
     FFLAGS +=-ffree-form
-else
+else ifeq ($(findstring $(notdir $(F77)), $(intel_compilers)),)
     FFLAGS +=-free
+else ifeq ($(findstring $(notdir $(F77)), $(cray_compilers)),)
+    FFLAGS +=-ffree
 endif
 
 TESTS = query_device_simple \


### PR DESCRIPTION
This PR addresses issue #24. The problem comes from erroneous flags in the test Makefile of the **sysdetect** and **sde** components for fortran compilers that are neither **gfortran** nor **flang**. More specifically, a Cray fortran compiler build error was reported by the spack project in PR https://github.com/spack/spack/pull/38443. This PR fixes the typo in both
components.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
- [ ] **Tests**
The PR needs to pass all the tests