### PR TITLE
sysdetect: add include path for cuda headers to makefile

### DIFF
--- a/src/components/sysdetect/Rules.sysdetect
+++ b/src/components/sysdetect/Rules.sysdetect
@@ -25,6 +25,10 @@ CFLAGS += -I$(PAPI_ROCM_ROOT)/include                  \
           -I$(PAPI_ROCM_ROOT)/rocm_smi/include/rocm_smi
 endif
 
+ifneq ($(PAPI_CUDA_ROOT),)
+CFLAGS += -I$(PAPI_CUDA_ROOT)/include
+endif
+
 sysdetect.o: components/sysdetect/sysdetect.c components/sysdetect/sysdetect.h $(HEADERS) 
 	$(CC) $(LIBCFLAGS) $(OPTFLAGS) -c components/sysdetect/sysdetect.c -o $@
 


### PR DESCRIPTION
 ## Pull Request Description
This PR adds explicit preprocessor flags to the sysdetect makefile in order to allow the component to find the cuda headers in the system.

 ## Author Checklist
 - [x] **Description**
 _Why_ this PR exists. Reference all relevant information including _background_, _issues_, _test failures_, etc
 - [x] **Commits**
 _Commits_ are self contained and only do one thing
 _Commit_ headers have the form: `module: short description`
 _Commit_ bodies contain a detailed description of what problem is addressed and how it is addressed
 - [ ] **Tests**
 The PR needs to pass all the tests