### PR TITLE
tests: disable components tests

### DIFF
--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -57,5 +57,5 @@ utils/papi_component_avail | grep -A1000 'Active components' | grep -q "Name:   
 
 if [ "$COMPONENT" != "cuda" ]; then
    echo Testing
-   ./run_tests.sh
+   make fulltest
 fi

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -24,7 +24,7 @@ FHEADERS = $(FORT_HEADERS)
 # pkgconfig directory
 LIBPC = $(LIBDIR)/pkgconfig
 
-all: $(SHOW_CONF) $(LIBS) libsde utils tests 
+all: $(SHOW_CONF) $(LIBS) libsde utils
 .PHONY : all test fulltest tests testlib utils ctests ftests comp_tests validation_tests null
 
 include $(COMPONENT_RULES)


### PR DESCRIPTION
# Pull Request Description
By default the build system builds all tests. This causes problems with spack if some specific component is enabled (e.g. rocm). Moreover, tests should not be built unless `make fulltest` (or `make tests`) is ran. This PR fixes the behavior building tests only when `make fulltest` (or `make tests`) is called.

 ## Author Checklist
 - [x] **Description**
 _Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
 - [x] **Commits**
 _Commits_ are self contained and only do one thing
 _Commits_ have a header of the form: `module: short description`
 _Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
 - [ ] **Tests**
 The PR needs to pass all the tests