### PR TITLE
sysdetect: replace logic AND with bitwise AND operator

### DIFF
--- a/src/components/sysdetect/x86_cpu_utils.c
+++ b/src/components/sysdetect/x86_cpu_utils.c
@@ -697,7 +697,7 @@ cpuid_get_leaf4_mask( apic_subid_mask_t *mask )
     unsigned int core_plus_smt_max_cnt = (reg.ebx >> 16) & 0x000000ff;
 
     cpuid(&reg, 4);
-    unsigned int core_max_cnt = ((reg.eax >> 26) && 0x0000003f) + 1;
+    unsigned int core_max_cnt = ((reg.eax >> 26) & 0x0000003f) + 1;
 
     unsigned int core_width = bit_width(core_max_cnt);
     unsigned int smt_width = bit_width(core_plus_smt_max_cnt) - core_width;


### PR DESCRIPTION
There was a typo in the sysdetect code for the x86 CPU architecture that computed a bitwise AND of two variables using the logic AND (&&) instead of the bitwise AND (&). This patch fixes the problem.