### PR TITLE
rocm: user HIP_ROOT for hipcc compiler in tests Makefile

### DIFF
--- a/src/components/rocm/tests/Makefile
+++ b/src/components/rocm/tests/Makefile
@@ -1,9 +1,10 @@
 NAME = rocm
 include ../../Makefile_comp_tests.target
 PAPI_ROCM_ROOT ?= /opt/rocm
+HIP_PATH ?= $(PAPI_ROCM_ROOT)/hip
 
-CC       = $(PAPI_ROCM_ROOT)/hip/bin/hipcc
-CXX      = $(PAPI_ROCM_ROOT)/hip/bin/hipcc
+CC       = $(HIP_PATH)/bin/hipcc
+CXX      = $(HIP_PATH)/bin/hipcc
 CPPFLAGS+= -I$(PAPI_ROCM_ROOT)/include          \
            -I$(PAPI_ROCM_ROOT)/include/hip      \
            -I$(PAPI_ROCM_ROOT)/include/hsa      \


### PR DESCRIPTION
The rocm tests assume hipcc is located under the same root directory as the rest of rocm toolkit software. Spack installs rocm dependencies in separate directories however, which breaks this assumption. This patch introduces a HIP_ROOT variable that, if unset, is set automatically to PAPI_ROCM_ROOT/hip. Spack can use this variable to let the tests Makefile in the PAPI rocm component know where the hipcc compiler is located.