### PR TITLE
Add smoke tests for spack install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Test
         run: .github/workflows/ci.sh ${{matrix.component}}
-# powercap_ppc
-# sensors_ppc
-# infiniband
+  papi_spack:
+    runs-on: cpu
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build/Test/Install via Spack
+        run: .github/workflows/spack.sh

--- a/.github/workflows/spack.sh
+++ b/.github/workflows/spack.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+COMPILER=$1
+
+[ -z "$COMPILER" ] && COMPILER=gcc@10 
+
+source /etc/profile
+set +x
+set -e
+trap 'echo "# $BASH_COMMAND"' DEBUG
+shopt -s expand_aliases
+
+export HOME=`pwd`
+git clone https://github.com/spack/spack spack || true
+source spack/share/spack/setup-env.sh
+
+SPEC="papi@master +lmsensors +powercap +sde +infiniband +rapl +cuda %$COMPILER"
+echo SPEC=$SPEC
+
+module load $COMPILER
+spack compiler find
+spack install --fresh --only=dependencies $SPEC
+spack dev-build -i --fresh --test=root $SPEC
+spack test run papi

--- a/src/smoke_tests/Makefile
+++ b/src/smoke_tests/Makefile
@@ -1,0 +1,22 @@
+
+EXECUTABLES = simple threads
+
+CC ?= gcc
+
+PAPIROOT ?= /path/to/papi/install/prefix
+CFLAGS ?= -O0 -pthread -I$(PAPIROOT)/include
+LIBS = -L$(PAPIROOT)/lib  -lm -ldl -lpapi -Wl,-rpath=$(PAPIROOT)/lib
+
+all: $(EXECUTABLES)
+
+clean:
+	/bin/rm -f core *.o $(EXECUTABLES)
+
+i.SUFFIXES: .c .o
+	.c.o:
+	    $(CC) $(CFLAGS) -c $*.c
+
+simple: simple.o 
+	$(CC) $(CFLAGS) -o simple simple.o $(LIBS)
+threads: threads.o 
+	$(CC) $(CFLAGS) -o threads threads.o $(LIBS)

--- a/src/smoke_tests/simple.c
+++ b/src/smoke_tests/simple.c
@@ -1,0 +1,69 @@
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <papi.h>
+#define NUM_EVENTS 2
+
+int main( int argc, char **argv )
+{
+    int retval, i;
+    long long       values[NUM_EVENTS];
+    int             EventSet = PAPI_NULL;
+    int             events[NUM_EVENTS];
+    char            *EventName[] = { "PAPI_TOT_CYC", "PAPI_TOT_INS" };
+    
+    retval = PAPI_library_init( PAPI_VER_CURRENT );
+    if ( retval != PAPI_VER_CURRENT ) {
+        printf("ERROR: PAPI_library_init: %d: %s\n", retval, PAPI_strerror(retval));
+        exit(EXIT_FAILURE);
+    } else {
+        printf ( "PAPI_VERSION     : %4d %6d %7d\n",
+	         PAPI_VERSION_MAJOR ( PAPI_VERSION ),
+	         PAPI_VERSION_MINOR ( PAPI_VERSION ),
+	         PAPI_VERSION_REVISION ( PAPI_VERSION ) );
+    }
+
+    retval = PAPI_create_eventset ( &EventSet );
+    if ( retval != PAPI_OK ) {
+        printf("ERROR: PAPI_create_eventset: %d: %s\n", retval, PAPI_strerror(retval));
+        exit(EXIT_FAILURE);
+    }
+
+    for( i = 0; i < NUM_EVENTS; i++ ) {
+        retval = PAPI_event_name_to_code ( EventName[i], &events[i] );
+        if ( retval != PAPI_OK ) {
+            printf("ERROR: PAPI_event_name_to_code: %d: %s\n", retval, PAPI_strerror(retval));
+            exit(EXIT_FAILURE);
+        }
+    }
+    
+    retval = PAPI_add_events ( EventSet, events, NUM_EVENTS );
+    if ( retval != PAPI_OK ) {
+        printf("ERROR: PAPI_add_events: %d: %s\n", retval, PAPI_strerror(retval));
+        exit(EXIT_FAILURE);
+    }
+
+    retval = PAPI_start( EventSet );
+    if ( retval != PAPI_OK ) {
+        printf("ERROR: PAPI_start: %d: %s\n", retval, PAPI_strerror(retval));
+        exit(EXIT_FAILURE);
+    }
+
+    // do work
+    sleep(3);
+                
+    retval = PAPI_stop( EventSet, values );
+    if ( retval != PAPI_OK ) {
+        printf("ERROR: PAPI_stop: %d: %s\n", retval, PAPI_strerror(retval));
+        exit(EXIT_FAILURE);
+    }
+                
+    for( i = 0; i < NUM_EVENTS; i++ ) {           
+        printf( "%12lld \t\t --> %s  \n", values[i],
+                EventName[i] );
+    }
+
+    PAPI_shutdown();
+    return EXIT_SUCCESS;
+}
+

--- a/src/smoke_tests/threads.c
+++ b/src/smoke_tests/threads.c
@@ -1,0 +1,124 @@
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <papi.h>
+#define NUM_PTHREADS 2
+#define NUM_EVENTS 2 
+
+void *
+Thread(void *arg)
+{
+    int retval, i;
+    long long       values[NUM_EVENTS];
+    int             EventSet = PAPI_NULL;
+    int             events[NUM_EVENTS];
+    char            *EventName[] = { "PAPI_TOT_CYC", "PAPI_TOT_INS" };
+    
+    int thread;
+    thread = *(int *) arg;
+ 
+    retval = PAPI_register_thread(  );
+    if ( retval != PAPI_OK ) {
+        printf("ERROR: PAPI_register_thread: %d: %s\n", retval, PAPI_strerror(retval));
+        exit(EXIT_FAILURE);
+    }
+
+    for( i = 0; i < NUM_EVENTS; i++ ) {
+        retval = PAPI_event_name_to_code( EventName[i], &events[i] );
+        if ( retval != PAPI_OK ) {
+            printf("ERROR: PAPI_event_name_to_code: %d: %s\n", retval, PAPI_strerror(retval));
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    retval = PAPI_create_eventset( &EventSet );
+    if ( retval != PAPI_OK ) {
+        printf("ERROR: PAPI_create_eventset: %d: %s\n", retval, PAPI_strerror(retval));
+        exit(EXIT_FAILURE);
+    }
+
+    retval = PAPI_add_events( EventSet, events, NUM_EVENTS );
+    if ( retval != PAPI_OK ) {
+        printf("ERROR: PAPI_add_events: %d: %s\n", retval, PAPI_strerror(retval));
+        exit(EXIT_FAILURE);
+    }
+
+    retval = PAPI_start( EventSet );
+    if ( retval != PAPI_OK ) {
+        printf("ERROR: PAPI_start: %d: %s\n", retval, PAPI_strerror(retval));
+        exit(EXIT_FAILURE);
+    }        
+
+    // do work
+    sleep(3);
+                
+    retval = PAPI_stop( EventSet, values );
+    if ( retval != PAPI_OK ) {
+        printf("ERROR: PAPI_stop: %d: %s\n", retval, PAPI_strerror(retval));
+        exit(EXIT_FAILURE);
+    }
+                
+    for( i = 0; i < NUM_EVENTS; i++ ) {           
+        printf( "%12lld \t\t --> %s  (thread %d) \n", values[i],
+                EventName[i], thread );
+    }
+
+    retval = PAPI_unregister_thread(  );
+    if ( retval != PAPI_OK ) {
+        printf("ERROR: PAPI_unregister_thread: %d: %s\n", retval, PAPI_strerror(retval));
+        exit(EXIT_FAILURE);
+    }
+
+    return 0;
+}
+
+
+int main( int argc, char **argv )
+{
+    pthread_t tids[NUM_PTHREADS];
+    int i, vals[NUM_PTHREADS];
+    int retval, rc;
+    void* retval2;
+        
+    /* Init PAPI library */
+    retval = PAPI_library_init( PAPI_VER_CURRENT );
+    if ( retval != PAPI_VER_CURRENT ) { 
+        printf("ERROR: PAPI_library_init: %d: %s\n", retval, PAPI_strerror(retval) );
+        exit(EXIT_FAILURE);
+    } else {
+        printf ( "PAPI_VERSION     : %4d %6d %7d\n",
+                 PAPI_VERSION_MAJOR ( PAPI_VERSION ),
+                 PAPI_VERSION_MINOR ( PAPI_VERSION ),
+                 PAPI_VERSION_REVISION ( PAPI_VERSION ) );
+    }
+            
+    retval = PAPI_thread_init( ( unsigned long ( * )( void ) )( pthread_self ) );
+    if ( retval != PAPI_OK ) { 
+        printf("ERROR: PAPI_thread_init: %d: %s\n", retval, PAPI_strerror(retval) );
+        exit(EXIT_FAILURE);
+    }
+    
+    for ( i = 0; i < NUM_PTHREADS; i++) {
+        vals[i] = i;
+        retval = pthread_create( &tids[i], NULL, Thread, &vals[i] );
+        if ( retval != 0 ) {
+            printf("ERROR: pthread_create: %d\n", retval );
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    for ( i = 0; i < NUM_PTHREADS; i++) {
+        printf("Trying to join with tid %d\n", i);
+        retval = pthread_join(tids[i], &retval2);
+        if ( retval != 0 ) {
+            printf("ERROR: pthread_join: %d\n", retval );
+            exit(EXIT_FAILURE);
+        } else {
+            printf("Joined with tid %d\n", i);
+        }
+    }
+    
+    PAPI_shutdown();
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
We need to include the required "smoke test" files so that spack can use these to validate the installation of papi.  I put these into `src/smoke_tests`.  Is there a better location?

Once the location and require test environment are set, we can implement the smoke tests within the papi spack package.