### PR TITLE
don't use fast rdpmc counter reads in attach or syswide scenarios

### DIFF
--- a/src/components/perf_event/perf_event.c
+++ b/src/components/perf_event/perf_event.c
@@ -1309,7 +1309,10 @@ _pe_read( hwd_context_t *ctx, hwd_control_state_t *ctl,
 	/* FIXME: we fallback to slow reads if *any* event in eventset fails */
 	/*        in theory we could only fall back for the one event        */
 	/*        but that makes the code more complicated.                  */
-	if ((_perf_event_vector.cmp_info.fast_counter_read) && (!pe_ctl->inherit)) {
+	if ((_perf_event_vector.cmp_info.fast_counter_read) &&
+		(!pe_ctl->inherit) &&
+		(!pe_ctl->attached) &&
+		(pe_ctl->granularity==PAPI_GRN_THR)) {
 		result=_pe_rdpmc_read( ctx, ctl, events, flags);
 		/* if successful we are done, otherwise fall back to read */
 		if (result==PAPI_OK) return PAPI_OK;


### PR DESCRIPTION
With perf_event we can use fast rdpmc reads for low-overhead counter access.  This only works in self-monitoring situations where the thread being measured is in the same process context and same CPU as PAPI.  This means it cannot generally be used in the attach case, or if trying to do system-wide measurements (granularity anything other than PAPI_GRN_THR).

Ideally the Linux kernel would notice the request to use rdpmc in inappropriate circumstances and cause the mmap() read to fail and fallback to using the read() syscall.  However for various reasons the kernel devs did not want to support this, so it's up to PAPI to avoid using rdpmc in cases where Linux will silently fail and allow rdpmc to return invalid counter values.

This should fix the "attach_cpu_sys_validate" test failure.