### PR TITLE
Sde shutdown

### DIFF
--- a/src/sde_lib/sde_lib.c
+++ b/src/sde_lib/sde_lib.c
@@ -519,7 +519,12 @@ papi_sde_add_counter_to_group(papi_handle_t handle, const char *event_name, cons
 
     }else{
         if( NULL == tmp_group->u.cntr_group.group_head ){
-            SDE_ERROR("papi_sde_add_counter_to_group(): Found an empty counter group: '%s'. This might indicate that a cleanup routine is not doing its job.", group_name);
+            if( CNTR_CLASS_PLACEHOLDER == tmp_group->cntr_class ){
+                tmp_group->cntr_class = CNTR_CLASS_GROUP;
+            }else{
+                SDE_ERROR("papi_sde_add_counter_to_group(): Found an empty counter group: '%s'. This might indicate that a cleanup routine is not doing its job.", group_name);
+            }
+
         }
 
         // make sure the caller is not trying to change the flags of the group after it has been created.

--- a/src/sde_lib/sde_lib.h
+++ b/src/sde_lib/sde_lib.h
@@ -41,6 +41,7 @@
 #define SDE_ENOMEM     -2     /**< Insufficient memory */
 #define SDE_ECMP       -4     /**< Not supported by component */
 #define SDE_ENOEVNT    -7     /**< Event does not exist */
+#define SDE_EMISC      -14    /**< Unknown error code */
 
 #define register_fp_counter register_counter_cb
 #define papi_sde_register_fp_counter papi_sde_register_counter_cb

--- a/src/sde_lib/sde_lib_datastructures.c
+++ b/src/sde_lib/sde_lib_datastructures.c
@@ -125,8 +125,11 @@ sde_counter_t *ht_delete(papisde_list_entry_t *hash_table, int ht_key, uint32_t 
     // If the head contains the element to be deleted, free the space of the counter and pull the list up.
     if( list_head->item->glb_uniq_id == uniq_id ){
         item = list_head->item;
-        if( NULL != list_head->next)
+        if( NULL != list_head->next){
             *list_head = *(list_head->next);
+        }else{
+            memset(list_head, 0, sizeof(papisde_list_entry_t));
+        }
         return item;
     }
 

--- a/src/sde_lib/sde_lib_internal.h
+++ b/src/sde_lib/sde_lib_internal.h
@@ -139,6 +139,7 @@ struct sde_counter_s {
    int overflow;
    int cntr_type;
    int cntr_mode;
+   int ref_count;
    papisde_library_desc_t *which_lib;
 };
 
@@ -187,7 +188,7 @@ struct papisde_control_s {
 
 int sdei_setup_counter_internals( papi_handle_t handle, const char *event_name, int cntr_mode, int cntr_type, enum CNTR_CLASS cntr_class, cntr_class_specific_t cntr_union );
 int sdei_delete_counter(papisde_library_desc_t* lib_handle, const char *name);
-int sdei_free_counter(sde_counter_t *counter);
+int sdei_inc_ref_count(sde_counter_t *counter);
 int sdei_read_counter_group( sde_counter_t *counter, long long int *rslt_ptr );
 void sdei_counting_set_to_list( void *cset_handle, cset_list_object_t **list_head );
 int sdei_read_and_update_data_value( sde_counter_t *counter, long long int previous_value, long long int *rslt_ptr );

--- a/src/sde_lib/sde_lib_internal.h
+++ b/src/sde_lib/sde_lib_internal.h
@@ -199,6 +199,7 @@ sde_counter_t *ht_lookup_by_id(papisde_list_entry_t *hash_table, uint32_t uniq_i
 sde_counter_t *ht_lookup_by_name(papisde_list_entry_t *hash_table, const char *name);
 sde_counter_t *ht_delete(papisde_list_entry_t *hash_table, int ht_key, uint32_t uniq_id);
 void ht_insert(papisde_list_entry_t *hash_table, int ht_key, sde_counter_t *sde_counter);
+int ht_to_array(papisde_list_entry_t *hash_table, sde_counter_t **rslt_array);
 uint32_t ht_hash_name(const char *str);
 uint32_t ht_hash_id(uint32_t uniq_id);
 papi_handle_t do_sde_init(const char *name_of_library, papisde_control_t *gctl);


### PR DESCRIPTION
This PR fixes the code that unregisters counters in the presence of groups. The basic idea behind the change is adding a reference count to each counter so we can keep track of the number of groups it belongs to. In the process of fixing this, I also abstracted the use of the hash-tables a bit, so we don't access their internal structure from multiple places in the code, and added some locking to prevent race conditions between reading and shutdown.