### PR TITLE
Sysdetect: fix snprintf behavior

### DIFF
--- a/src/components/sysdetect/amd_gpu.c
+++ b/src/components/sysdetect/amd_gpu.c
@@ -262,7 +262,7 @@ load_hsa_sym( char *status )
     if (!hsa_is_enabled() || (*hsa_initPtr)()) {
         const char *message = "dlsym() of HSA symbols failed or hsa_init() "
                               "failed";
-        int count = snprintf(status, strlen(message) + 1, "%s", message);
+        int count = snprintf(status, PAPI_MAX_STR_LEN, "%s", message);
         if (count >= PAPI_MAX_STR_LEN) {
             SUBDBG("Status string truncated.");
         }
@@ -339,7 +339,7 @@ load_rsmi_sym( char *status )
     if (!rsmi_is_enabled() || (*rsmi_initPtr)(0)) {
         const char *message = "dlsym() of RSMI symbols failed or rsmi_init() "
                               "failed";
-        int count = snprintf(status, strlen(message) + 1, "%s", message);
+        int count = snprintf(status, PAPI_MAX_STR_LEN, "%s", message);
         if (count >= PAPI_MAX_STR_LEN) {
             SUBDBG("Status string truncated.");
         }
@@ -400,7 +400,7 @@ open_amd_gpu_dev_type( _sysdetect_dev_type_info_t *dev_type_info )
     }
 #else
     const char *message = "RSMI not configured, no device affinity available";
-    int count = snprintf(dev_type_info->status, strlen(message) + 1, "%s", message);
+    int count = snprintf(dev_type_info->status, PAPI_MAX_STR_LEN, "%s", message);
     if (count >= PAPI_MAX_STR_LEN) {
         SUBDBG("Error message truncated.");
     }
@@ -410,7 +410,7 @@ open_amd_gpu_dev_type( _sysdetect_dev_type_info_t *dev_type_info )
     dev_type_info->dev_info_arr = (_sysdetect_dev_info_u *)arr;
 #else
     const char *message = "ROCm not configured, no ROCm device available";
-    int count = snprintf(dev_type_info->status, strlen(message) + 1, "%s", message);
+    int count = snprintf(dev_type_info->status, PAPI_MAX_STR_LEN, "%s", message);
     if (count >= PAPI_MAX_STR_LEN) {
         SUBDBG("Error message truncated.");
     }

--- a/src/components/sysdetect/amd_gpu.c
+++ b/src/components/sysdetect/amd_gpu.c
@@ -248,7 +248,6 @@ load_hsa_sym( char *status )
         if (count >= PAPI_MAX_STR_LEN) {
             SUBDBG("Status string truncated.");
         }
-        status[PAPI_MAX_STR_LEN - 1] = 0;
         return -1;
     }
 
@@ -330,7 +329,6 @@ load_rsmi_sym( char *status )
         if (count >= PAPI_MAX_STR_LEN) {
             SUBDBG("Status string truncated.");
         }
-        status[PAPI_MAX_STR_LEN - 1] = 0;
         return -1;
     }
 

--- a/src/components/sysdetect/nvidia_gpu.c
+++ b/src/components/sysdetect/nvidia_gpu.c
@@ -203,7 +203,6 @@ load_cuda_sym( char *status )
         if (count >= PAPI_MAX_STR_LEN) {
             SUBDBG("Status string truncated.");
         }
-        status[PAPI_MAX_STR_LEN - 1] = 0;
         return -1;
     }
 
@@ -298,7 +297,6 @@ load_nvml_sym( char *status )
         if (count >= PAPI_MAX_STR_LEN) {
             SUBDBG("Status string truncated.");
         }
-        status[PAPI_MAX_STR_LEN - 1] = 0;
         return -1;
     }
 

--- a/src/components/sysdetect/nvidia_gpu.c
+++ b/src/components/sysdetect/nvidia_gpu.c
@@ -215,7 +215,7 @@ load_cuda_sym( char *status )
 
     if (!cuda_is_enabled()) {
         const char *message = "dlsym() of CUDA symbols failed";
-        int count = snprintf(status, strlen(message) + 1, "%s", message);
+        int count = snprintf(status, PAPI_MAX_STR_LEN, "%s", message);
         if (count >= PAPI_MAX_STR_LEN) {
             SUBDBG("Status string truncated.");
         }
@@ -307,7 +307,7 @@ load_nvml_sym( char *status )
 
     if (!nvml_is_enabled()) {
         const char *message = "dlsym() of NVML symbols failed";
-        int count = snprintf(status, strlen(message) + 1, "%s", message);
+        int count = snprintf(status, PAPI_MAX_STR_LEN, "%s", message);
         if (count >= PAPI_MAX_STR_LEN) {
             SUBDBG("Status string truncated.");
         }
@@ -365,7 +365,7 @@ open_nvidia_gpu_dev_type( _sysdetect_dev_type_info_t *dev_type_info )
     }
 #else
     const char *message = "NVML not configured, no device affinity available";
-    int count = snprintf(dev_type_info->status, strlen(message) + 1, "%s", message);
+    int count = snprintf(dev_type_info->status, PAPI_MAX_STR_LEN, "%s", message);
     if (count >= PAPI_MAX_STR_LEN) {
         SUBDBG("Status string truncated.");
     }
@@ -375,7 +375,7 @@ open_nvidia_gpu_dev_type( _sysdetect_dev_type_info_t *dev_type_info )
     dev_type_info->dev_info_arr = (_sysdetect_dev_info_u *)arr;
 #else
     const char *message = "CUDA not configured, no CUDA device available";
-    int count = snprintf(dev_type_info->status, strlen(message) + 1, "%s", message);
+    int count = snprintf(dev_type_info->status, PAPI_MAX_STR_LEN, "%s", message);
     if (count >= PAPI_MAX_STR_LEN) {
         SUBDBG("Status string truncated.");
     }


### PR DESCRIPTION
## Pull Request Description
The `sysdetect` component makes a wrong usage of `snprintf`. In a few instances, `snprintf` is used to copy a string of size X to a string of size `PAPI_MAX_STR_LEN`. However, the `sysdetect` code sets the `n` argument of `snprintf`, indicating the target string length, to the length of the source string (i.e., X). Additionally, sometimes the code null-terminates the target string, which is not necessary because `snprintf` always null-terminates the target string.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
