### PR TITLE
rocm: fix snprintf handling

### DIFF
--- a/src/components/rocm/rocp.c
+++ b/src/components/rocm/rocp.c
@@ -136,7 +136,7 @@ static hsa_status_t (*rocp_remove_queue_cbsPtr)(void);
     (*hsa_status_stringPtr)(status, &init_err_str_ptr);         \
     int _exp = snprintf(init_err_str, PAPI_MAX_STR_LEN, "%s",   \
                         init_err_str_ptr);                      \
-    if (_exp > PAPI_MAX_STR_LEN) {                              \
+    if (_exp >= PAPI_MAX_STR_LEN) {                             \
         SUBDBG("Error string truncated");                       \
     }                                                           \
     init_err_str_ptr = init_err_str;                            \
@@ -152,7 +152,7 @@ static hsa_status_t (*rocp_remove_queue_cbsPtr)(void);
     (*rocp_error_stringPtr)(&init_err_str_ptr);                 \
     int _exp = snprintf(init_err_str, PAPI_MAX_STR_LEN, "%s",   \
                         init_err_str_ptr);                      \
-    if (_exp > PAPI_MAX_STR_LEN) {                              \
+    if (_exp >= PAPI_MAX_STR_LEN) {                             \
         SUBDBG("Error string truncated");                       \
     }                                                           \
     init_err_str_ptr = init_err_str;                            \
@@ -163,7 +163,7 @@ static hsa_status_t (*rocp_remove_queue_cbsPtr)(void);
 #define ROCP_REC_ERR_STR(string) do {                           \
     int _exp = snprintf(init_err_str, PAPI_MAX_STR_LEN, "%s",   \
                         string);                                \
-    if (_exp > PAPI_MAX_STR_LEN) {                              \
+    if (_exp >= PAPI_MAX_STR_LEN) {                             \
         SUBDBG("Error string truncated");                       \
     }                                                           \
     init_err_str_ptr = init_err_str;                            \


### PR DESCRIPTION
## Pull Request Description
The expected return value from snprintf, in the rocm component, is < PAPI_MAX_STR_LEN. If it is >= PAPI_MAX_STR_LEN, the input string was longer than the output string. This PR fixes the rocm component code to align it to the given description.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
