### PR TITLE
powercap: ignore the psys entry

### DIFF
--- a/src/components/powercap/linux-powercap.c
+++ b/src/components/powercap/linux-powercap.c
@@ -238,7 +238,7 @@ static int _powercap_init_component( int cidx )
       if (strErr > sizeof(event_path)) HANDLE_STRING_ERROR;
       // not a valid pkg event path so continue
 
-      if (access(event_path, F_OK) == -1) { continue; }
+      if (access(event_path, R_OK) == -1) { continue; }
 
       strErr=snprintf(powercap_ntv_events[num_events].name, sizeof(powercap_ntv_events[num_events].name), "%s:ZONE%d", pkg_event_names[e], s);
       powercap_ntv_events[num_events].name[sizeof(powercap_ntv_events[num_events].name)-1]=0;
@@ -286,7 +286,7 @@ static int _powercap_init_component( int cidx )
         if (strErr > sizeof(event_path)) HANDLE_STRING_ERROR;
 
         // not a valid pkg event path so continue
-        if (access(event_path, F_OK) == -1) { continue; }
+        if (access(event_path, R_OK) == -1) { continue; }
 
         strErr=snprintf(powercap_ntv_events[num_events].name, sizeof(powercap_ntv_events[num_events].name), "%s:ZONE%d_SUBZONE%d", component_event_names[e], s, c);
         powercap_ntv_events[num_events].name[sizeof(powercap_ntv_events[num_events].name)-1]=0;


### PR DESCRIPTION
This is a bit of a workaround for newer Intel CPUs that, in addition to the traditional "package-<n>" entries in /sys/class/powercap/, also contain a "psys" entry that controls the platform domain (see, e.g., https://lkml.kernel.org/lkml/1458516392-2130-3-git-send-email-srinivas.pandruvada@linux.intel.com/).

PAPI currently assumes that entries starting with "intel-rapl:0" correspond to socket 0 and "intel-rapl:1" to socket 1.  With "psys" around that unfortunately need not be the case; on at least one system relevant to DOE (I can't post the details as it's not public yet) intel-rapl:0 corresponds to socket 0, intel-rapl:1 corresponds to *psys*, and intel-rapl:2 corresponds to socket 1 (what a mess!).  What currently happens is that PAPI entirely misses the counters for socket 1.

This PR works around the problem by exhaustively searching for the right "intel-rapl:<n>" directory.  It preserves the current PAPI assumption that ZONE0 events correspond to socket 0 and ZONE1 to socket 1.  On the other hand, it completely ignores the "psys" entry, while one could argue that the data it contains should ideally be made available as well...

I also included a somewhat related fix to check that the files inside /sys/class/powercap/intel-rapl:<n> directories not only exist, but are readable.  On recent Linux kernels, "energy_uj" is by default readable by root only, which is something that PAPI fails to detect, resulting in 0 being returned for that counter without any indication of a problem. That seemed like an error to me but I actually don't know what PAPI's policy is on counters that exist but are unreadable by the current user.

## Pull Request Description


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
