### PR TITLE
rapl: support for icelake-sp

### DIFF
--- a/src/components/rapl/linux-rapl.c
+++ b/src/components/rapl/linux-rapl.c
@@ -465,6 +465,7 @@ _rapl_init_component( int cidx )
 		case 63:	/* Haswell-EP */
 		case 79:	/* Broadwell-EP */
 		case 85:	/* Skylake-X */
+		case 106:	/* Icelake-SP */
 			package_avail=1;
 			pp0_avail=1;
 			pp1_avail=0;


### PR DESCRIPTION
## Pull Request Description

The `rapl` component currently does not support the Intel Icelake-SP platform as it is missing in the lookup table. I just added the corresponding entry.
Tested on a dual-socket Intel Xeon Gold 6338 system. 

According to the Intel SDM and the Kernel source code, the `PP0` (power consumption of the CPU cores) should be supported on the Icelake architecture. However, on my test system, it is unsupported and does not even show up in `/sys/bus/event_source/devices/power/events/`.  The corresponding MSR is readable but constantly reports zero.
I still suggest setting `pp0_avail=1` for Icelake to be consistent with the kernel. 



## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
