### PR TITLE
rocm: temporarely remove all tests from being built

### DIFF
--- a/src/components/rocm/tests/Makefile
+++ b/src/components/rocm/tests/Makefile
@@ -16,7 +16,7 @@ CXXFLAGS = -g -O0 -fopenmp
 
 rocm_tests: ALL
 
-ALL: sample_single_kernel_monitoring       \
+ALL: #sample_single_kernel_monitoring       \
      sample_single_thread_monitoring       \
      sample_multi_kernel_monitoring        \
      sample_multi_thread_monitoring        \


### PR DESCRIPTION
## Pull Request Description
Spack has issues building rocm tests because of a broken dependency in hip (openmp). To prevent Spack from failing to build PAPI when the rocm component is enabled, this commit temporarily removes the rocm component tests from being built. A better, and permanent, solution will follow soon.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
