### PR TITLE
papi.h: Fix warnings for -Wstrict-prototypes

### DIFF
--- a/src/papi.h
+++ b/src/papi.h
@@ -1221,7 +1221,7 @@ typedef enum {
    int PAPI_flops_rate(int event, float *rtime, float *ptime, long long * flpops, float *mflops); /**< simplified call to get Mflops/s (floating point operation rate), real and processor time */
    int PAPI_ipc(float *rtime, float *ptime, long long * ins, float *ipc); /**< gets instructions per cycle, real and processor time */
    int PAPI_epc(int event, float *rtime, float *ptime, long long *ref, long long *core, long long *evt, float *epc); /**< gets (named) events per cycle, real and processor time, reference and core cycles */
-   int PAPI_rate_stop(); /**< stops a running event set of a rate function */
+   int PAPI_rate_stop(void); /**< stops a running event set of a rate function */
 
    int PAPI_enum_dev_type(int enum_modifier, void **handle); /**< return the handler for the next device type available */
    int PAPI_get_dev_type_attr(void *handle, PAPI_dev_type_attr_e attr, void *value); /**< return the value of the queried attribute for the device type handle */
@@ -1238,7 +1238,7 @@ typedef enum {
    int PAPI_hl_region_begin(const char* region); /**< read performance events at the beginning of a region */
    int PAPI_hl_read(const char* region); /**< read performance events inside of a region and store the difference to the corresponding beginning of the region */
    int PAPI_hl_region_end(const char* region); /**< read performance events at the end of a region and store the difference to the corresponding beginning of the region */
-   int PAPI_hl_stop(); /**< stops a running high-level event set */
+   int PAPI_hl_stop(void); /**< stops a running high-level event set */
 /** @} */
 
 


### PR DESCRIPTION
Warnings seen while compiling with gcc 7.5.0

```
/home/anustuv/papidev/papi-AP2/papi/src/install/include/papi.h:1224:4: warning: function declaration isn't a prototype [-Wstrict-prototypes]
    int PAPI_rate_stop(); /**< stops a running event set of a rate function */
    ^~~
/home/anustuv/papidev/papi-AP2/papi/src/install/include/papi.h:1241:4: warning: function declaration isn't a prototype [-Wstrict-prototypes]
    int PAPI_hl_stop(); /**< stops a running high-level event set */
    ^~~
```