### PR TITLE
Update libpfm4

### DIFF
--- a/src/libpfm4/lib/pfmlib_amd64_perf_event.c
+++ b/src/libpfm4/lib/pfmlib_amd64_perf_event.c
@@ -75,7 +75,7 @@ pfm_amd64_get_perf_encoding(void *this, pfmlib_event_desc_t *e)
 		return ret;
 
 	if (e->count > 1) {
-		DPRINT("%s: unsupported count=%d\n", e->count);
+		DPRINT("unsupported count=%d\n", e->count);
 		return PFM_ERR_NOTSUPP;
 	}
 

--- a/src/libpfm4/lib/pfmlib_common.c
+++ b/src/libpfm4/lib/pfmlib_common.c
@@ -1191,7 +1191,7 @@ pfmlib_init_pmus(void)
 			continue;
 
 		if (pfmlib_is_blacklisted_pmu(p)) {
-			DPRINT("%d PMU blacklisted, skipping initialization\n");
+			DPRINT("%s PMU blacklisted, skipping initialization\n", p->name);
 			continue;
 		}
 		p->flags |= PFMLIB_PMU_FL_INIT;
@@ -1429,7 +1429,7 @@ pfmlib_parse_event_attr(char *str, pfmlib_event_desc_t *d)
 			ainfo->idx  = strtoull(s, &endptr, 0);
 			ainfo->equiv= NULL;
 			if (*endptr) {
-				DPRINT("raw umask (%s) is not a number\n");
+				DPRINT("raw umask (%s) is not a number\n", str);
 				return PFM_ERR_ATTR;
 			}
 

--- a/src/libpfm4/lib/pfmlib_intel_skx_unc_cha.c
+++ b/src/libpfm4/lib/pfmlib_intel_skx_unc_cha.c
@@ -57,8 +57,7 @@ display_cha(void *this, pfmlib_event_desc_t *e, void *val)
 
 	f.val = e->codes[1];
 
-	__pfm_vbprintf("[UNC_CHA_FILTER0=0x%"PRIx64" thread_id=%d source=0x%x state=0x%x"
-		       " state=0x%x]\n",
+	__pfm_vbprintf("[UNC_CHA_FILTER0=0x%"PRIx64" thread_id=%d source=0x%x state=0x%x]\n",
 			f.val,
 			f.skx_cha_filt0.tid,
 			f.skx_cha_filt0.sid,

--- a/src/libpfm4/lib/pfmlib_intel_x86.c
+++ b/src/libpfm4/lib/pfmlib_intel_x86.c
@@ -84,7 +84,7 @@ pfm_intel_x86_display_reg(void *this, pfmlib_event_desc_t *e)
 	if (pe[e->event].modmsk & _INTEL_X86_ATTR_T)
 		__pfm_vbprintf(" any=%d", reg.sel_anythr);
 
-	__pfm_vbprintf("]", e->fstr);
+	__pfm_vbprintf("]");
 
 	for (i = 1 ; i < e->count; i++)
 		__pfm_vbprintf(" [0x%"PRIx64"]", e->codes[i]);

--- a/src/libpfm4/lib/pfmlib_intel_x86_perf_event.c
+++ b/src/libpfm4/lib/pfmlib_intel_x86_perf_event.c
@@ -97,7 +97,7 @@ pfm_intel_x86_get_perf_encoding(void *this, pfmlib_event_desc_t *e)
 		return ret;
 
 	if (e->count > 2) {
-		DPRINT("%s: unsupported count=%d\n", e->count);
+		DPRINT("unsupported count=%d\n", e->count);
 		return PFM_ERR_NOTSUPP;
 	}
 	/* default PMU type */


### PR DESCRIPTION
## Pull Request Description
Original commit:

    Author: William Cohen <wcohen@redhat.com>
    Date:   Fri Jun 30 15:06:22 2023 -0400

        Correct the arguments in a number of printf statements

        Adjusted the printf statements to fix the following issues flagged by
        static analsysis:

         Error: PRINTF_ARGS (CWE-685): [#def66]
         libpfm-4.13.0/lib/pfmlib_intel_x86.c:87: extra_argument: This argument was not used by the format string: "e->fstr".
         #   85|                __pfm_vbprintf(" any=%d", reg.sel_anythr);
         #   86|
         #   87|->      __pfm_vbprintf("]", e->fstr);
         #   88|
         #   89|        for (i = 1 ; i < e->count; i++)

         Error: PRINTF_ARGS (CWE-685): [#def11]
         libpfm-4.13.0/lib/pfmlib_amd64_perf_event.c:78: missing_argument: No argument for format specifier "%d".
         #   76|
         #   77|        if (e->count > 1) {
         #   78|->              DPRINT("%s: unsupported count=%d\n", e->count);
         #   79|                return PFM_ERR_NOTSUPP;
         #   80|        }

         Error: PRINTF_ARGS (CWE-685): [#def14]
         libpfm-4.13.0/lib/pfmlib_common.c:1151: missing_argument: No argument for format specifier "%d".
         # 1149|
         # 1150|                if (pfmlib_is_blacklisted_pmu(p)) {
         # 1151|->                      DPRINT("%d PMU blacklisted, skipping initialization\n");
         # 1152|                        continue;
         # 1153|                }

         Error: PRINTF_ARGS (CWE-685): [#def15]
         libpfm-4.13.0/lib/pfmlib_common.c:1367: missing_argument: No argument for format specifier "%s".
         # 1365|                        ainfo->equiv= NULL;
         # 1366|                        if (*endptr) {
         # 1367|->                              DPRINT("raw umask (%s) is not a number\n");
         # 1368|                                return PFM_ERR_ATTR;
         # 1369|

         Error: PRINTF_ARGS (CWE-685): [#def34]
         libpfm-4.13.0/lib/pfmlib_intel_skx_unc_cha.c:60: missing_argument: No argument for format specifier "%x".
         #   58|        f.val = e->codes[1];
         #   59|
         #   60|->      __pfm_vbprintf("[UNC_CHA_FILTER0=0x%"PRIx64" thread_id=%d source=0x%x state=0x%x"
         #   61|                       " state=0x%x]\n",
         #   62|                        f.val,

         Error: PRINTF_ARGS (CWE-685): [#def83]
         libpfm-4.13.0/lib/pfmlib_intel_x86_perf_event.c:100: missing_argument: No argument for format specifier "%d".
         #   98|
         #   99|        if (e->count > 2) {
         #  100|->              DPRINT("%s: unsupported count=%d\n", e->count);
         #  101|                return PFM_ERR_NOTSUPP;
         #  102|        }

        Signed-off-by: William Cohen <wcohen@redhat.com>

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
