### PR TITLE
cuda: Load cuda shared libraries from linked/rpath/LD_LIBRARY_PATH

### DIFF
--- a/src/components/cuda/cupti_common.h
+++ b/src/components/cuda/cupti_common.h
@@ -14,6 +14,7 @@
 #include "cupti_utils.h"
 #include "lcuda_debug.h"
 
+const char *linked_cudart_path;
 extern void *dl_cupti;
 
 extern unsigned int _cuda_lock;

--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -206,6 +206,10 @@ static int load_nvpw_sym(void)
         NULL,
     };
 
+    if (linked_cudart_path && !dl_nvpw) {
+        dl_nvpw = cuptic_load_dynamic_syms(linked_cudart_path, dlname, standard_paths);
+    }
+
     char *papi_cuda_root = getenv("PAPI_CUDA_ROOT");
     if (papi_cuda_root && !dl_nvpw) {
         dl_nvpw = cuptic_load_dynamic_syms(papi_cuda_root, dlname, standard_paths);


### PR DESCRIPTION
This PR adds the feature that the CUDA component loads the cuda toolkit version that is used by the application.
