### PR TITLE
cuda: fix get linked shared library link error gcc 10.0

### DIFF
--- a/src/components/cuda/cupti_common.c
+++ b/src/components/cuda/cupti_common.c
@@ -15,6 +15,7 @@
 
 static void *dl_drv, *dl_rt;
 
+const char *linked_cudart_path;
 void *dl_cupti;
 
 unsigned int _cuda_lock;

--- a/src/components/cuda/cupti_common.h
+++ b/src/components/cuda/cupti_common.h
@@ -14,7 +14,7 @@
 #include "cupti_utils.h"
 #include "lcuda_debug.h"
 
-const char *linked_cudart_path;
+extern const char *linked_cudart_path;
 extern void *dl_cupti;
 
 extern unsigned int _cuda_lock;


### PR DESCRIPTION
Fix link error for gcc >= 10.0