### PR TITLE
rocm_smi: fix warning "variable might be used uninitialized"

### DIFF
--- a/src/components/rocm_smi/rocs.c
+++ b/src/components/rocm_smi/rocs.c
@@ -910,7 +910,7 @@ init_event_table(void)
     int ntv_events_count;
     papi_errno = get_ntv_events_count(&ntv_events_count);
     if (papi_errno != PAPI_OK) {
-        goto fn_fail;
+        return papi_errno;
     }
 
     ntv_event_t *ntv_events = papi_calloc(ntv_events_count, sizeof(*ntv_events));


### PR DESCRIPTION
## Pull Request Description
`ntv_events` might be uninitialised when the error handling section is entered in `init_event_table()`. Make sure that `ntv_events` is always initialised when error handling is performed.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
