### PR TITLE
lmsensors: Add lib/ to explicit search path to .so loader

### DIFF
--- a/src/components/lmsensors/README.md
+++ b/src/components/lmsensors/README.md
@@ -26,8 +26,7 @@ Example:
 Within PAPI\_LMSENSORS\_ROOT, we expect the following standard directories:
 
     PAPI_LMSENSORS_ROOT/include or PAPI_LMSENSORS_ROOT/include/sensors
-    PAPI_LMSENSORS_ROOT/lib64
-
+    PAPI_LMSENSORS_ROOT/lib64   or PAPI_LMSENSROS_ROOT/lib
 ***
 ## FAQ
 

--- a/src/components/lmsensors/linux-lmsensors.c
+++ b/src/components/lmsensors/linux-lmsensors.c
@@ -399,6 +399,12 @@ link_lmsensors_libraries ()
       dl1 = dlopen(path_name, RTLD_NOW | RTLD_GLOBAL);             // Try to open that path.
    }
 
+   // Step 4: Try another explicit install default.
+   if (dl1 == NULL && lmsensors_root != NULL) {                          // if root given, try it.
+      snprintf(path_name, PATH_MAX, "%s/lib/libsensors.so", lmsensors_root);   // PAPI Root check.
+      dl1 = dlopen(path_name, RTLD_NOW | RTLD_GLOBAL);             // Try to open that path.
+   }
+
    // Check for failure.
    if (dl1 == NULL) {
       snprintf(_lmsensors_vector.cmp_info.disabled_reason, PAPI_MAX_STR_LEN, "libsensors.so not found.");

--- a/src/components/lmsensors/linux-lmsensors.c
+++ b/src/components/lmsensors/linux-lmsensors.c
@@ -395,7 +395,7 @@ link_lmsensors_libraries ()
 
    // Step 3: Try the explicit install default. 
    if (dl1 == NULL && lmsensors_root != NULL) {                          // if root given, try it.
-      snprintf(path_name, 1024, "%s/lib64/libsensors.so", lmsensors_root);   // PAPI Root check.
+      snprintf(path_name, PATH_MAX, "%s/lib64/libsensors.so", lmsensors_root);   // PAPI Root check.
       dl1 = dlopen(path_name, RTLD_NOW | RTLD_GLOBAL);             // Try to open that path.
    }
 


### PR DESCRIPTION
This behaviour observed on ICL Leconte

```
$ module load lm-sensors
$ export PAPI_LMSENSORS_ROOT=$ICL_LM_SENSORS_ROOT
$ ./configure --with-components="lmsensors" && make && make install
$ utils/papi_component_avail
```
Shows the output
```
...
Name:   lmsensors               Linux LMsensor statistics
   \-> Disabled: libsensors.so not found.
```

The problem happens because the component searches for `libsensors.so` in `$PAPI_LMSENSORS_ROOT/lib64` while the so exists in `$PAPI_LMSENSORS_ROOT/lib`

This PR fixes this problem by adding `lib` to the search path for the so file.

After this fix the output of `papi_component_avail` shows
```
...
Name:   lmsensors               lm-sensors provides tools for monitoring the hardware health
...
Name:   lmsensors               lm-sensors provides tools for monitoring the hardware health
                                Native: 170, Preset: 0, Counters: 170
```