### PR TITLE
cuda: Revert cuda component num_counters not supported by vendor

### DIFF
--- a/src/components/cuda/linux-cuda.c
+++ b/src/components/cuda/linux-cuda.c
@@ -72,6 +72,7 @@ papi_vector_t _cuda_vector = {
         .version = "0.1",
         .description = "CUDA profiling via NVIDIA CuPTI interfaces",
         .num_mpx_cntrs = PAPI_CUDA_MPX_COUNTERS,
+        .num_cntrs = PAPI_CUDA_MAX_COUNTERS,
         .default_domain = PAPI_DOM_USER,
         .default_granularity = PAPI_GRN_THR,
         .available_granularities = PAPI_GRN_THR,
@@ -122,10 +123,6 @@ static int cuda_init_component(int cidx)
     _cuda_vector.cmp_info.disabled = PAPI_EDELAY_INIT;
     sprintf(_cuda_vector.cmp_info.disabled_reason,
         "Not initialized. Access component events to initialize it.");
-
-    _cuda_vector.cmp_info.num_cntrs = PAPI_ECMP;
-    sprintf(_cuda_vector.cmp_info.misc_info, "Not supported by vendor.");
-
     return PAPI_EDELAY_INIT;
 }
 

--- a/src/papi.h
+++ b/src/papi.h
@@ -633,7 +633,6 @@ typedef void *vptr_t;
      char support_version[PAPI_MIN_STR_LEN]; /**< Version of the support library */
      char kernel_version[PAPI_MIN_STR_LEN];  /**< Version of the kernel PMC support driver */
      char disabled_reason[PAPI_HUGE_STR_LEN]; /**< Reason for failure of initialization */
-     char misc_info[PAPI_2MAX_STR_LEN];       /**< Generic message that component can set */
      int disabled;   /**< 0 if enabled, otherwise error code from initialization */
      int initialized;                        /**< Component is ready to use */
      int CmpIdx;				/**< Index into the vector array for this component; set at init time */

--- a/src/utils/papi_component_avail.c
+++ b/src/utils/papi_component_avail.c
@@ -141,13 +141,8 @@ main( int argc, char **argv )
 	  if (cmpinfo->disabled) continue;
 
 	  printf( "Name:   %-23s %s\n", cmpinfo->name ,cmpinfo->description);
-	  printf( "        %-23s Native: %d, Preset: %d, Counters: ", " ", cmpinfo->num_native_events);
-	  if (cmpinfo->num_cntrs == PAPI_ECMP) {
-		printf( "<%s>\n", cmpinfo->misc_info);
-	  }
-	  else {
-		printf( "%d\n", cmpinfo->num_cntrs);
-	  }
+	  printf( "        %-23s Native: %d, Preset: %d, Counters: %d\n",
+		  " ", cmpinfo->num_native_events, cmpinfo->num_preset_events, cmpinfo->num_cntrs);
 
      int pmus=0;
      for (i=0; i<PAPI_PMU_MAX; i++) {                          // Count pmus to print.


### PR DESCRIPTION
This PR reverts [PR 62: utils: papi_component_avail does not support cuda component counters](https://github.com/icl-utk-edu/papi/pull/62)

This is related to issues
- [cuda component overloads field for utility #71](https://github.com/icl-utk-edu/papi/issues/71)
- [Updated PAPI CUDA component returns default for number of counters #61](https://github.com/icl-utk-edu/papi/issues/61)