### PR TITLE
Changing gcc version for rocm compatibility

### DIFF
--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -3,7 +3,7 @@
 COMPONENT=$1
 COMPILER=$2
 
-[ -z "$COMPILER" ] && COMPILER=gcc@10 
+[ -z "$COMPILER" ] && COMPILER=gcc@11
 
 source /etc/profile
 set +x

--- a/.github/workflows/spack.sh
+++ b/.github/workflows/spack.sh
@@ -2,7 +2,7 @@
 
 COMPILER=$1
 
-[ -z "$COMPILER" ] && COMPILER=gcc@10 
+[ -z "$COMPILER" ] && COMPILER=gcc@11
 
 source /etc/profile
 set +x


### PR DESCRIPTION
## Pull Request Description

The upgrade to rocm 5.5/5.7 requires a newer gcc version in the CI.  Updating to gcc@11.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
