### PR TITLE
smoke_tests: fix Makefile

### DIFF
--- a/src/smoke_tests/Makefile
+++ b/src/smoke_tests/Makefile
@@ -3,9 +3,10 @@ EXECUTABLES = simple threads
 
 CC ?= gcc
 
-PAPIROOT ?= /path/to/papi/install/prefix
-CFLAGS ?= -O0 -pthread -I$(PAPIROOT)/include
-LIBS = -L$(PAPIROOT)/lib  -lm -ldl -lpapi -Wl,-rpath=$(PAPIROOT)/lib
+PAPI_ROOT := $(shell dirname $(shell dirname $(shell which papi_component_avail)))
+CFLAGS ?= -O0 -pthread -I$(PAPI_ROOT)/include
+CPPFLAGS = -I$(PAPI_ROOT)/include
+LIBS = -L$(PAPI_ROOT)/lib  -lm -ldl -lpapi -Wl,-rpath=$(PAPI_ROOT)/lib -pthread
 
 all: $(EXECUTABLES)
 


### PR DESCRIPTION
## Pull Request Description
Makefile file was missing a PAPI_ROOT path and also an additional -pthread in the linker flags.


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
