### PR TITLE
configure: fix tls detection

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -5232,7 +5232,7 @@ else
                            #include <unistd.h>
                            extern __thread int i;
                            static int res1, res2;
-                           void thread_main (void *arg) {
+                           void *thread_main (void *arg) {
                              i = (int)arg;
                              sleep (1);
                              if ((int)arg == 1)
@@ -5425,7 +5425,7 @@ else
                                        int gettid() {
                                          return syscall( SYS_gettid );
                                        }
-                                       int doThreadOne( void * v ) {
+                                       void *doThreadOne( void * v ) {
                                          struct tms tm;
                                          int status;
                                          while (!done)
@@ -5435,7 +5435,7 @@ else
                                          threadone = tm.tms_utime;
                                          return 0;
                                        }
-                                       int doThreadTwo( void * v ) {
+                                       void *doThreadTwo( void * v ) {
                                          struct tms tm;
                                          long i, j = 0xdeadbeef;
                                          int status;

--- a/src/configure.in
+++ b/src/configure.in
@@ -707,7 +707,7 @@ AC_ARG_WITH(tls,
                            #include <unistd.h>
                            extern __thread int i;
                            static int res1, res2;
-                           void thread_main (void *arg) {
+                           void *thread_main (void *arg) {
                              i = (int)arg;
                              sleep (1);
                              if ((int)arg == 1)
@@ -849,7 +849,7 @@ AC_ARG_WITH(virtualtimer,
                                        int gettid() {
                                          return syscall( SYS_gettid );
                                        } 
-                                       int doThreadOne( void * v ) {
+                                       void *doThreadOne( void * v ) {
                                          struct tms tm;
                                          int status;
                                          while (!done)
@@ -859,7 +859,7 @@ AC_ARG_WITH(virtualtimer,
                                          threadone = tm.tms_utime;
                                          return 0;
                                        }   
-                                       int doThreadTwo( void * v ) {
+                                       void *doThreadTwo( void * v ) {
                                          struct tms tm;
                                          long i, j = 0xdeadbeef;
                                          int status;


### PR DESCRIPTION
## Pull Request Description
Configure TLS detection tests were failing because of wrong usage of pthread_create(). Problem was caused by wrong definition of thread functions which require void *f(void *) instead of int f(void *) or void f(void *).

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
