### PR TITLE
Do not build PAPI and SDE lib with debug symbols by default

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -2512,12 +2512,14 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $OSVER" >&5
 $as_echo "$OSVER" >&6; }
 
+CFLAGS=""
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for perf_event workaround level" >&5
 $as_echo_n "checking for perf_event workaround level... " >&6; }
 
 # Check whether --with-assumed_kernel was given.
 if test "${with_assumed_kernel+set}" = set; then :
-  withval=$with_assumed_kernel; assumed_kernel=$withval; CFLAGS="$CFLAGS -DASSUME_KERNEL=\\\"$with_assumed_kernel\\\""
+  withval=$with_assumed_kernel; assumed_kernel=$withval; CFLAGS="-DASSUME_KERNEL=\\\"$with_assumed_kernel\\\""
 else
   assumed_kernel="autodetect"
 
@@ -2568,8 +2570,6 @@ fi
 $as_echo "$NEC" >&6; }
 
 
-
-CFLAGS="$CFLAGS -g"
 #If not set, set FFLAGS to null to prevent AC_PROG_F77 from defaulting it to -g -O2
 if test "x$FFLAGS" = "x"; then
   FFLAGS=""

--- a/src/configure.in
+++ b/src/configure.in
@@ -69,11 +69,13 @@ AC_ARG_WITH(OSVER,
             fi ])
 AC_MSG_RESULT($OSVER)
 
+CFLAGS=""
+
 AC_MSG_CHECKING(for perf_event workaround level)
 AC_ARG_WITH(assumed_kernel,
             [AS_HELP_STRING([--with-assumed-kernel=<ver>],
             [Assume kernel version is <ver> for purposes of workarounds])],
-		[assumed_kernel=$withval; CFLAGS="$CFLAGS -DASSUME_KERNEL=\\\"$with_assumed_kernel\\\""],
+		[assumed_kernel=$withval; CFLAGS="-DASSUME_KERNEL=\\\"$with_assumed_kernel\\\""],
                 [assumed_kernel="autodetect"]
 		)		
 AC_MSG_RESULT($assumed_kernel)
@@ -110,8 +112,6 @@ AC_ARG_WITH(nec,
 AC_MSG_RESULT($NEC)
 AC_SUBST(NEC)
 
-
-CFLAGS="$CFLAGS -g"
 #If not set, set FFLAGS to null to prevent AC_PROG_F77 from defaulting it to -g -O2
 if test "x$FFLAGS" = "x"; then
   FFLAGS=""

--- a/src/sde_lib/Makefile
+++ b/src/sde_lib/Makefile
@@ -1,7 +1,7 @@
 CC ?= gcc
 SDE_INC = -I. -I..
 SDE_LD = -ldl -pthread
-CFLAGS = -Wextra -Wall -O2 -g
+CFLAGS = -Wextra -Wall -O2
 
 %_d.o: %.c
 		$(CC) -c -Bdynamic -fPIC -shared -fvisibility=hidden $(CFLAGS) $(SDE_INC) $< -o $@
@@ -14,7 +14,7 @@ SOBJS=$(patsubst %.c,%_s.o,$(wildcard *.c))
 all: dynamic static
 
 dynamic: $(DOBJS)
-	$(CC) -Bdynamic -fPIC -shared -Wl,-soname -Wl,libsde.so -fvisibility=hidden -Wextra -Wall -g -O2 $(DOBJS) -lrt -ldl -pthread -o libsde.so.1.0
+	$(CC) -Bdynamic -fPIC -shared -Wl,-soname -Wl,libsde.so -fvisibility=hidden $(CFLAGS) $(DOBJS) -lrt -ldl -pthread -o libsde.so.1.0
 	rm -f *_d.o
 
 static: $(SOBJS)


### PR DESCRIPTION
## Pull Request Description
Only build PAPI with debug symbols if `--with-debug=(yes|mem)` is set.

Addresses issue #92 

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
