### PR TITLE
cuda: Fix papi_command_line segfault when passed non-existent event name

### DIFF
--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -1438,11 +1438,11 @@ int cuptip_control_create(cuptiu_event_table_t *event_names, cuptic_info_t thr_i
     if (papi_errno != PAPI_OK) {
         goto fn_exit;
     }
-    papi_errno = add_events_per_gpu(state, event_names);
+    papi_errno = nvpw_cuda_metricscontext_create(state);
     if (papi_errno != PAPI_OK) {
         goto fn_exit;
     }
-    papi_errno = nvpw_cuda_metricscontext_create(state);
+    papi_errno = add_events_per_gpu(state, event_names);
     if (papi_errno != PAPI_OK) {
         goto fn_exit;
     }


### PR DESCRIPTION
Before this fix `$ papi_command_line xxxx` causes segfault.

After this fix the segfault is replaced by 
```
This utility lets you add events from the command line interface to see if they work.

Failed adding: xxxx
because: Invalid argument
No events specified!
Try running something like: /home/anustuv/papidev/papi-AP2/papi/src/install/bin/papi_command_line PAPI_TOT_CYC
```

This happens because the cuda component dynamically adds events to its internal structure when `event_name_to_code` is called without checking validity, and returns an event code. Only at `PAPI_start` it complains if the event cannot be added to the lower layers.

Enumeration of all cuda events is a heavy operation and thus it does not do it unless explicitly requested.