### PR TITLE
rocm: allow component to resolve device ambiguity

### DIFF
--- a/src/components/rocm/roc_common.h
+++ b/src/components/rocm/roc_common.h
@@ -1,7 +1,10 @@
 #ifndef __ROC_COMMON_H__
 #define __ROC_COMMON_H__
 
+#define __HIP_PLATFORM_AMD__
+
 #include <hsa.h>
+#include <hip/hip_runtime.h>
 #include <dlfcn.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -31,6 +34,7 @@ extern hsa_status_t (*hsa_system_get_info_p)(hsa_system_info_t, void *);
 extern hsa_status_t (*hsa_agent_get_info_p)(hsa_agent_t, hsa_agent_info_t, void *);
 extern hsa_status_t (*hsa_queue_destroy_p)(hsa_queue_t *);
 extern hsa_status_t (*hsa_status_string_p)(hsa_status_t, const char **);
+extern hipError_t   (*hipGetDevicePtr)(int *);
 
 extern char error_string[PAPI_MAX_STR_LEN];
 extern device_table_t *device_table_p;

--- a/src/components/rocm/tests/multi_thread_monitoring.cpp
+++ b/src/components/rocm/tests/multi_thread_monitoring.cpp
@@ -40,9 +40,14 @@ static void *run(void *thread_num_arg)
         test_fail(__FILE__, __LINE__, "PAPI_create_eventset", papi_errno);
     }
 
+    hip_errno = hipSetDevice(thread_num);
+    if (hip_errno != hipSuccess) {
+        hip_test_fail(__FILE__, __LINE__, "hipSetDevice", hip_errno);
+    }
+
     for (int j = 0; j < NUM_EVENTS; ++j) {
         char named_event[PAPI_MAX_STR_LEN];
-        sprintf(named_event, "%s:device=%d", events[j], thread_num);
+        sprintf(named_event, "%s", events[j]);
         papi_errno = PAPI_add_named_event(eventset, (const char*) named_event);
         if (papi_errno != PAPI_OK && papi_errno != PAPI_ENOEVNT) {
             test_fail(__FILE__, __LINE__, "PAPI_add_named_event", papi_errno);
@@ -57,11 +62,6 @@ static void *run(void *thread_num_arg)
     }
 
     hipStream_t stream;
-    hip_errno = hipSetDevice(thread_num);
-    if (hip_errno != hipSuccess) {
-        hip_test_fail(__FILE__, __LINE__, "hipSetDevice", hip_errno);
-    }
-
     hip_errno = hipStreamCreate(&stream);
     if (hip_errno != hipSuccess) {
         hip_test_fail(__FILE__, __LINE__, "hipStreamCreate", hip_errno);


### PR DESCRIPTION
## Pull Request Description
Sometimes users don't want to specify the device id right away as this might be unknown. PAPI can figure out what device the user intends to monitor by looking at the selected device (through hipGetDevice) when the event is resolved with name_to_code.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
