### PR TITLE
sysdetect: add -ffree-form to silence error in ARM comp

### DIFF
--- a/src/components/sysdetect/tests/Makefile
+++ b/src/components/sysdetect/tests/Makefile
@@ -21,6 +21,8 @@ endif
 intel_compilers := ifort ifx
 cray_compilers := ftn crayftn
 
+FFLAGS += -ffree-form
+
 ifeq ($(notdir $(F77)),gfortran)
     FFLAGS +=-ffree-form -ffree-line-length-none
 else ifeq ($(notdir $(F77)),flang)


### PR DESCRIPTION
## Pull Request Description
Addresses issue #107 

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
