### PR TITLE
Minor fixes for ROCm component

### DIFF
--- a/src/components/rocm/roc_profiler.c
+++ b/src/components/rocm/roc_profiler.c
@@ -530,7 +530,10 @@ init_event_table(void)
     }
 
     ntv_table.events = papi_calloc(ntv_table.count, sizeof(ntv_event_t));
-    assert(ntv_table.events);
+    if (ntv_table.events == NULL) {
+        papi_errno = PAPI_ENOMEM;
+        goto fn_fail;
+    }
 
     struct ntv_arg arg;
     arg.count = 0;
@@ -1972,7 +1975,9 @@ get_context_counters(unsigned int *events_id, unsigned int dev_id, cb_context_no
                 break;
             }
         }
-        assert(j < rocp_ctx->u.intercept.feature_count);
+        if (j < rocp_ctx->u.intercept.feature_count) {
+            return PAPI_ECMP;
+        }
         rocp_ctx->u.intercept.counters[j] += n->counters[i];
     }
 

--- a/src/components/rocm/roc_profiler.c
+++ b/src/components/rocm/roc_profiler.c
@@ -524,6 +524,7 @@ init_event_table(void)
             const char *error_string_p;
             hsa_status_string_p(rocp_errno, &error_string_p);
             snprintf(error_string, PAPI_MAX_STR_LEN, "%s", error_string_p);
+            papi_errno = PAPI_EMISC;
             goto fn_fail;
         }
     }
@@ -544,6 +545,7 @@ init_event_table(void)
             const char *error_string_p;
             hsa_status_string_p(rocp_errno, &error_string_p);
             snprintf(error_string, PAPI_MAX_STR_LEN, "%s", error_string_p);
+            papi_errno = PAPI_EMISC;
             goto fn_fail;
         }
     }
@@ -551,7 +553,6 @@ init_event_table(void)
   fn_exit:
     return papi_errno;
   fn_fail:
-    papi_errno = PAPI_EMISC;
     goto fn_exit;
 }
 

--- a/src/components/rocm/roc_profiler.c
+++ b/src/components/rocm/roc_profiler.c
@@ -1169,7 +1169,7 @@ static int fetch_dispatch_counter(unsigned long);
 static cb_context_node_t *alloc_context_node(int);
 static void free_context_node(cb_context_node_t *);
 static int get_context_node(int, cb_context_node_t **);
-static int get_context_counters(unsigned int *, unsigned int, cb_context_node_t *, rocp_ctx_t);
+static int get_context_counters(unsigned int, cb_context_node_t *, rocp_ctx_t);
 static void put_context_counters(rocprofiler_feature_t *, int, cb_context_node_t *);
 static void put_context_node(unsigned int, cb_context_node_t *);
 static int intercept_ctx_init(unsigned int *, int, rocp_ctx_t *);
@@ -1314,7 +1314,6 @@ int
 intercept_ctx_read(rocp_ctx_t rocp_ctx, long long **counts)
 {
     int papi_errno = PAPI_OK;
-    unsigned int *events_id = rocp_ctx->u.intercept.events_id;
 
     _papi_hwi_lock(_rocm_lock);
 
@@ -1348,7 +1347,7 @@ intercept_ctx_read(rocp_ctx_t rocp_ctx, long long **counts)
                 break;
             }
 
-            get_context_counters(events_id, dev_id, n, rocp_ctx);
+            get_context_counters(dev_id, n, rocp_ctx);
             dispatch_count = decrement_and_fetch_dispatch_counter(tid);
             free_context_node(n);
         }
@@ -1955,9 +1954,10 @@ decrement_and_fetch_dispatch_counter(unsigned long tid)
 }
 
 int
-get_context_counters(unsigned int *events_id, unsigned int dev_id, cb_context_node_t *n, rocp_ctx_t rocp_ctx)
+get_context_counters(unsigned int dev_id, cb_context_node_t *n, rocp_ctx_t rocp_ctx)
 {
     int papi_errno = PAPI_OK;
+    unsigned int *events_id = rocp_ctx->u.intercept.events_id;
 
     /* Here we get events_id ordered according to user's viewpoint and we want
      * to map these to events_id ordered according to callbacks' viewpoint. We


### PR DESCRIPTION
## Pull Request Description
This PR includes a set of minor fixes for the rocm component. These include the removal of `assert` statements, which are replaced by proper error handling logic.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
