### PR TITLE
Fixes for coverity reported issues in various files (redo of pull#46)

### DIFF
--- a/src/components/coretemp/linux-coretemp.c
+++ b/src/components/coretemp/linux-coretemp.c
@@ -455,18 +455,18 @@ _coretemp_init_component( int cidx )
      }
 
      do {
-        char *strCpy;
-        strCpy=strncpy(_coretemp_native_events[i].name,t->name,PAPI_MAX_STR_LEN);
-        if (strCpy == NULL) HANDLE_STRING_ERROR;
+        int retlen;
+        retlen = snprintf(_coretemp_native_events[i].name, PAPI_MAX_STR_LEN, "%s", t->name);
+        if (retlen <= 0 || retlen >= PAPI_MAX_STR_LEN) HANDLE_STRING_ERROR;
 
-        strCpy=strncpy(_coretemp_native_events[i].path,t->path,PATH_MAX);
-        if (strCpy == NULL) HANDLE_STRING_ERROR;
+        retlen = snprintf(_coretemp_native_events[i].path, PATH_MAX, "%s", t->path);
+        if (retlen <= 0 || retlen >= PATH_MAX) HANDLE_STRING_ERROR;
 
-        strCpy=strncpy(_coretemp_native_events[i].units,t->units,PAPI_MIN_STR_LEN);
-        if (strCpy == NULL) HANDLE_STRING_ERROR;
+        retlen = snprintf(_coretemp_native_events[i].units, PAPI_MIN_STR_LEN, "%s", t->units);
+        if (retlen <= 0 || retlen >= PAPI_MIN_STR_LEN) HANDLE_STRING_ERROR;
 
-        strCpy=strncpy(_coretemp_native_events[i].description,t->description,PAPI_MAX_STR_LEN);
-        if (strCpy == NULL) HANDLE_STRING_ERROR;
+        retlen = snprintf(_coretemp_native_events[i].description, PAPI_MAX_STR_LEN, "%s",t->description);
+        if (retlen <= 0 || retlen >= PAPI_MAX_STR_LEN) HANDLE_STRING_ERROR;
 
 	    _coretemp_native_events[i].stone = 0;
 	    _coretemp_native_events[i].resources.selector = i + 1;

--- a/src/components/coretemp/linux-coretemp.c
+++ b/src/components/coretemp/linux-coretemp.c
@@ -203,7 +203,8 @@ generateEventList(char *base_dir)
 	     retlen = snprintf(name, PAPI_MAX_STR_LEN, "%s:in%i_input", hwmonx->d_name, i);
 	     if (retlen <= 0 || PAPI_MAX_STR_LEN <= retlen) {
 	         SUBDBG("Unable to generate name %s:in%i_input\n", hwmonx->d_name, i);
-            closedir(d);
+		 closedir(dir);
+		 closedir(d);
 	         return ( PAPI_EINVAL );
 	     }
 

--- a/src/components/net/linux-net.c
+++ b/src/components/net/linux-net.c
@@ -51,6 +51,11 @@ papi_vector_t _net_vector;
 #define NET_INVALID_RESULT     -1
 
 
+// The following macro follows if a string function has an error. It should 
+// never happen; but it is necessary to prevent compiler warnings. We print 
+// something just in case there is programmer error in invoking the function.
+#define HANDLE_STRING_ERROR {fprintf(stderr,"%s:%i unexpected string function error.\n",__FILE__,__LINE__); exit(-1);}
+
 static NET_native_event_entry_t * _net_native_events=NULL;
 
 static int num_events       = 0;
@@ -343,8 +348,11 @@ _net_init_component( int cidx  )
     _net_native_events = (NET_native_event_entry_t*)
         papi_malloc(sizeof(NET_native_event_entry_t) * num_events);
     do {
-        strncpy(_net_native_events[i].name, t->name, PAPI_MAX_STR_LEN);
-        strncpy(_net_native_events[i].description, t->description, PAPI_MAX_STR_LEN);
+        int retlen;
+        retlen = snprintf(_net_native_events[i].name, PAPI_MAX_STR_LEN, "%s", t->name);
+        if (retlen <= 0 || retlen >= PAPI_MAX_STR_LEN) HANDLE_STRING_ERROR;
+        retlen = snprintf(_net_native_events[i].description, PAPI_MAX_STR_LEN, "%s", t->description);
+        if (retlen <= 0 || retlen >= PAPI_MAX_STR_LEN) HANDLE_STRING_ERROR;
         _net_native_events[i].resources.selector = i + 1;
         last    = t;
         t       = t->next;

--- a/src/components/sysdetect/linux_cpu_utils.c
+++ b/src/components/sysdetect/linux_cpu_utils.c
@@ -965,5 +965,6 @@ get_vendor_id( void )
         decode_vendor_string(vendor_string, &vendor_id);
     }
 
+    fclose(fp);
     return vendor_id;
 }

--- a/src/ctests/thrspecific.c
+++ b/src/ctests/thrspecific.c
@@ -73,6 +73,8 @@ Thread( void *arg )
 				printf( "Entry %d, Thread %#lx, Data Pointer %p, Value %d\n",
 						i, data.id[i], data.data[i], *( int * ) data.data[i] );
 			}
+			free(data.id);
+			free(data.data);
 			processing = 0;
 		}
 	}


### PR DESCRIPTION
## Rework of https://github.com/icl-utk-edu/papi/pull/46 commit messages to follow format guidelines

I reviewed coverity scan results for papi. There were a number of
areas flagged by coverity. This pull request addresses a small
portion of them. Specifically it addresses:

ctests/thrspecific.c: cleaning up allocated memory
sysdetect: properly closing file on all paths through code
linux-net: ensuring that strings are properly terminated
coretemp: ensuring that strings are properly terminated
coretemp: properly closing file on all paths through code

The commits are self contained and only do one thing for each commit. The also contain a description of what each commit is doing. However, the headers do not precisely follow the format of 'module: short description'.

I ran the tests for both the master git branch and this branch. I did not see any differences in the results.


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
