### PR TITLE
utils: Fix bogus "Disabled" message in papi_component_avail for the sde component.

### DIFF
--- a/src/utils/Makefile
+++ b/src/utils/Makefile
@@ -26,7 +26,7 @@ papi_command_line: papi_command_line.o $(PAPILIB) $(DOLOOPS)
 	$(CC) -o papi_command_line papi_command_line.o $(PAPILIB) $(DOLOOPS) $(LDFLAGS)
 
 papi_component_avail: papi_component_avail.o $(PAPILIB) print_header.o
-	$(CC) -o papi_component_avail papi_component_avail.o $(PAPILIB) print_header.o $(LDFLAGS)
+	$(CC) -o papi_component_avail papi_component_avail.o $(PAPILIB) print_header.o $(LDFLAGS) $(LIBSDEFLAGS)
 
 papi_cost: papi_cost.o $(PAPILIB) cost_utils.o
 	$(CC) -o papi_cost papi_cost.o cost_utils.o $(PAPILIB) -lm $(LDFLAGS)


### PR DESCRIPTION
## Pull Request Description
When the sde component is initialized, in the context of an application that uses PAPI, it looks for the availability of libsde symbols. The rationale is that if the application is not linked against libsde, there are no SDEs to read, so the component disables itself. Therefore, papi_component_avail, which does not export any SDEs itself, always reported the sde component as "Disabled". Adding the symbols to the utility resolves this problem.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
