### PR TITLE
ROCm event id refactor

### DIFF
--- a/src/components/rocm/roc_common.c
+++ b/src/components/rocm/roc_common.c
@@ -71,7 +71,7 @@ rocc_err_get_last(const char **err_string)
 }
 
 int
-rocc_dev_get_map(rocc_dev_get_map_cb query_dev_id, unsigned int *events_id, int num_events, rocc_bitmap_t *bitmap)
+rocc_dev_get_map(rocc_dev_get_map_cb query_dev_id, uint64_t *events_id, int num_events, rocc_bitmap_t *bitmap)
 {
     int i;
     rocc_bitmap_t device_map_acq = 0;

--- a/src/components/rocm/roc_common.c
+++ b/src/components/rocm/roc_common.c
@@ -77,7 +77,7 @@ rocc_dev_get_map(rocc_dev_get_map_cb query_dev_id, uint64_t *events_id, int num_
     rocc_bitmap_t device_map_acq = 0;
 
     for (i = 0; i < num_events; ++i) {
-        unsigned int dev_id;
+        int dev_id;
         if (query_dev_id(events_id[i], &dev_id)) {
             return PAPI_EMISC;
         }
@@ -166,9 +166,9 @@ rocc_dev_get_id(rocc_bitmap_t bitmap, int dev_count, int *device_id)
 }
 
 int
-rocc_dev_get_agent_id(hsa_agent_t agent, unsigned int *dev_id)
+rocc_dev_get_agent_id(hsa_agent_t agent, int *dev_id)
 {
-    for (*dev_id = 0; *dev_id < (unsigned int) device_table_p->count; ++(*dev_id)) {
+    for (*dev_id = 0; *dev_id < device_table_p->count; ++(*dev_id)) {
         if (memcmp(&device_table_p->devices[*dev_id], &agent, sizeof(agent)) == 0) {
             break;
         }

--- a/src/components/rocm/roc_common.c
+++ b/src/components/rocm/roc_common.c
@@ -177,6 +177,19 @@ rocc_dev_get_agent_id(hsa_agent_t agent, unsigned int *dev_id)
 }
 
 int
+rocc_dev_set(rocc_bitmap_t *bitmap, int i)
+{
+    *bitmap |= (1ULL << i);
+    return PAPI_OK;
+}
+
+int
+rocc_dev_check(rocc_bitmap_t bitmap, int i)
+{
+    return (bitmap & (1ULL << i));
+}
+
+int
 rocc_thread_get_id(unsigned long *tid)
 {
     *tid = thread_id_fn();

--- a/src/components/rocm/roc_common.h
+++ b/src/components/rocm/roc_common.h
@@ -44,6 +44,8 @@ int rocc_dev_release(rocc_bitmap_t bitmap);
 int rocc_dev_get_count(rocc_bitmap_t bitmap, int *num_devices);
 int rocc_dev_get_id(rocc_bitmap_t bitmap, int dev_count, int *device_id);
 int rocc_dev_get_agent_id(hsa_agent_t agent, unsigned int *dev_id);
+int rocc_dev_set(rocc_bitmap_t *bitmap, int i);
+int rocc_dev_check(rocc_bitmap_t bitmap, int i);
 
 int rocc_thread_get_id(unsigned long *tid);
 

--- a/src/components/rocm/roc_common.h
+++ b/src/components/rocm/roc_common.h
@@ -17,7 +17,7 @@
 #endif
 
 typedef int64_t rocc_bitmap_t;
-typedef int (*rocc_dev_get_map_cb)(uint64_t event_id, unsigned int *dev_id);
+typedef int (*rocc_dev_get_map_cb)(uint64_t event_id, int *dev_id);
 
 typedef struct {
     hsa_agent_t devices[PAPI_ROCM_MAX_DEV_COUNT];
@@ -43,7 +43,7 @@ int rocc_dev_acquire(rocc_bitmap_t bitmap);
 int rocc_dev_release(rocc_bitmap_t bitmap);
 int rocc_dev_get_count(rocc_bitmap_t bitmap, int *num_devices);
 int rocc_dev_get_id(rocc_bitmap_t bitmap, int dev_count, int *device_id);
-int rocc_dev_get_agent_id(hsa_agent_t agent, unsigned int *dev_id);
+int rocc_dev_get_agent_id(hsa_agent_t agent, int *dev_id);
 int rocc_dev_set(rocc_bitmap_t *bitmap, int i);
 int rocc_dev_check(rocc_bitmap_t bitmap, int i);
 

--- a/src/components/rocm/roc_common.h
+++ b/src/components/rocm/roc_common.h
@@ -17,7 +17,7 @@
 #endif
 
 typedef int64_t rocc_bitmap_t;
-typedef int (*rocc_dev_get_map_cb)(unsigned int event_id, unsigned int *dev_id);
+typedef int (*rocc_dev_get_map_cb)(uint64_t event_id, unsigned int *dev_id);
 
 typedef struct {
     hsa_agent_t devices[PAPI_ROCM_MAX_DEV_COUNT];
@@ -38,7 +38,7 @@ extern device_table_t *device_table_p;
 int rocc_init(void);
 int rocc_shutdown(void);
 int rocc_err_get_last(const char **error_string);
-int rocc_dev_get_map(rocc_dev_get_map_cb cb, unsigned int *events_id, int num_events, rocc_bitmap_t *bitmap);
+int rocc_dev_get_map(rocc_dev_get_map_cb cb, uint64_t *events_id, int num_events, rocc_bitmap_t *bitmap);
 int rocc_dev_acquire(rocc_bitmap_t bitmap);
 int rocc_dev_release(rocc_bitmap_t bitmap);
 int rocc_dev_get_count(rocc_bitmap_t bitmap, int *num_devices);

--- a/src/components/rocm/roc_dispatch.c
+++ b/src/components/rocm/roc_dispatch.c
@@ -64,6 +64,12 @@ rocd_evt_code_to_name(uint64_t event_code, char *name, int len)
 }
 
 int
+rocd_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info)
+{
+    return rocp_evt_code_to_info(event_code, info);
+}
+
+int
 rocd_err_get_last(const char **error_str)
 {
     return rocc_err_get_last(error_str);

--- a/src/components/rocm/roc_dispatch.c
+++ b/src/components/rocm/roc_dispatch.c
@@ -40,25 +40,25 @@ rocd_shutdown(void)
 }
 
 int
-rocd_evt_enum(unsigned int *event_code, int modifier)
+rocd_evt_enum(uint64_t *event_code, int modifier)
 {
     return rocp_evt_enum(event_code, modifier);
 }
 
 int
-rocd_evt_code_to_descr(unsigned int event_code, char *descr, int len)
+rocd_evt_code_to_descr(uint64_t event_code, char *descr, int len)
 {
     return rocp_evt_code_to_descr(event_code, descr, len);
 }
 
 int
-rocd_evt_name_to_code(const char *name, unsigned int *event_code)
+rocd_evt_name_to_code(const char *name, uint64_t *event_code)
 {
     return rocp_evt_name_to_code(name, event_code);
 }
 
 int
-rocd_evt_code_to_name(unsigned int event_code, char *name, int len)
+rocd_evt_code_to_name(uint64_t event_code, char *name, int len)
 {
     return rocp_evt_code_to_name(event_code, name, len);
 }
@@ -70,7 +70,7 @@ rocd_err_get_last(const char **error_str)
 }
 
 int
-rocd_ctx_open(unsigned int *events_id, int num_events, rocd_ctx_t *ctx)
+rocd_ctx_open(uint64_t *events_id, int num_events, rocd_ctx_t *ctx)
 {
     return rocp_ctx_open(events_id, num_events, ctx);
 }

--- a/src/components/rocm/roc_dispatch.h
+++ b/src/components/rocm/roc_dispatch.h
@@ -10,6 +10,7 @@
 #ifndef __ROC_DISPATCH_H__
 #define __ROC_DISPATCH_H__
 
+#include "papi.h"
 #include "roc_profiler_config.h"
 
 typedef struct rocd_ctx *rocd_ctx_t;
@@ -24,6 +25,7 @@ int rocd_evt_enum(uint64_t *event_code, int modifier);
 int rocd_evt_code_to_descr(uint64_t event_code, char *descr, int len);
 int rocd_evt_name_to_code(const char *name, uint64_t *event_code);
 int rocd_evt_code_to_name(uint64_t event_code, char *name, int len);
+int rocd_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info);
 
 /* error handling interfaces */
 int rocd_err_get_last(const char **error_str);

--- a/src/components/rocm/roc_dispatch.h
+++ b/src/components/rocm/roc_dispatch.h
@@ -20,16 +20,16 @@ int rocd_init(void);
 int rocd_shutdown(void);
 
 /* native event interfaces */
-int rocd_evt_enum(unsigned int *event_code, int modifier);
-int rocd_evt_code_to_descr(unsigned int event_code, char *descr, int len);
-int rocd_evt_name_to_code(const char *name, unsigned int *event_code);
-int rocd_evt_code_to_name(unsigned int event_code, char *name, int len);
+int rocd_evt_enum(uint64_t *event_code, int modifier);
+int rocd_evt_code_to_descr(uint64_t event_code, char *descr, int len);
+int rocd_evt_name_to_code(const char *name, uint64_t *event_code);
+int rocd_evt_code_to_name(uint64_t event_code, char *name, int len);
 
 /* error handling interfaces */
 int rocd_err_get_last(const char **error_str);
 
 /* profiling context handling interfaces */
-int rocd_ctx_open(unsigned int *event_id, int num_events, rocd_ctx_t *ctx);
+int rocd_ctx_open(uint64_t *event_id, int num_events, rocd_ctx_t *ctx);
 int rocd_ctx_close(rocd_ctx_t ctx);
 int rocd_ctx_start(rocd_ctx_t ctx);
 int rocd_ctx_stop(rocd_ctx_t ctx);

--- a/src/components/rocm/roc_profiler.c
+++ b/src/components/rocm/roc_profiler.c
@@ -781,6 +781,7 @@ get_ntv_events_cb(const rocprofiler_info_data_t info, void *ntv_arg)
  *
  */
 static int init_features(uint64_t *, int, rocprofiler_feature_t *);
+static int finalize_features(rocprofiler_feature_t *, int);
 static int sampling_ctx_init(uint64_t *, int, rocp_ctx_t *);
 static int sampling_ctx_finalize(rocp_ctx_t *);
 static int ctx_open(rocp_ctx_t);
@@ -1225,6 +1226,16 @@ init_features(uint64_t *events_id, int num_events, rocprofiler_feature_t *featur
     }
 
     return papi_errno;
+}
+
+int
+finalize_features(rocprofiler_feature_t *features, int feature_count)
+{
+    int i;
+    for (i = 0; i < feature_count; ++i) {
+        papi_free((char *) features[i].name);
+    }
+    return PAPI_OK;
 }
 
 static int sampling_ctx_get_dev_feature_count(rocp_ctx_t, int);

--- a/src/components/rocm/roc_profiler.c
+++ b/src/components/rocm/roc_profiler.c
@@ -550,8 +550,8 @@ static hsa_status_t count_ntv_events_cb(const rocprofiler_info_data_t, void *);
 static hsa_status_t get_ntv_events_cb(const rocprofiler_info_data_t, void *);
 
 struct ntv_arg {
-    int count;                    /* number of devices counted so far */
-    int dev_id;                   /* id of device */
+    int count;
+    int dev_id;
 };
 
 int

--- a/src/components/rocm/roc_profiler.c
+++ b/src/components/rocm/roc_profiler.c
@@ -1512,10 +1512,6 @@ verify_events(uint64_t *events_id, int num_events)
         return PAPI_OK;
     }
 
-    if (intercept_global_state.events_count != num_events) {
-        return PAPI_ECNFLCT;
-    }
-
     for (i = 0; i < num_events; ++i) {
         void *out;
         if (htable_find(htable_intercept, ntv_table_p->events[events_id[i]].feature, &out)) {

--- a/src/components/rocm/roc_profiler.h
+++ b/src/components/rocm/roc_profiler.h
@@ -15,13 +15,13 @@ int rocp_init(void);
 int rocp_shutdown(void);
 
 /* native event interfaces */
-int rocp_evt_enum(unsigned int *event_code, int modifier);
-int rocp_evt_code_to_descr(unsigned int event_code, char *descr, int len);
-int rocp_evt_name_to_code(const char *name, unsigned int *event_code);
-int rocp_evt_code_to_name(unsigned int event_code, char *name, int len);
+int rocp_evt_enum(uint64_t *event_code, int modifier);
+int rocp_evt_code_to_descr(uint64_t event_code, char *descr, int len);
+int rocp_evt_name_to_code(const char *name, uint64_t *event_code);
+int rocp_evt_code_to_name(uint64_t event_code, char *name, int len);
 
 /* profiling context handling interfaces */
-int rocp_ctx_open(unsigned int *events_id, int num_events, rocp_ctx_t *ctx);
+int rocp_ctx_open(uint64_t *events_id, int num_events, rocp_ctx_t *ctx);
 int rocp_ctx_close(rocp_ctx_t ctx);
 int rocp_ctx_start(rocp_ctx_t ctx);
 int rocp_ctx_stop(rocp_ctx_t ctx);

--- a/src/components/rocm/roc_profiler.h
+++ b/src/components/rocm/roc_profiler.h
@@ -7,6 +7,8 @@
 #ifndef __ROC_PROFILER_H__
 #define __ROC_PROFILER_H__
 
+#include "papi.h"
+
 typedef struct rocd_ctx *rocp_ctx_t;
 
 /* init and shutdown interfaces */
@@ -19,6 +21,7 @@ int rocp_evt_enum(uint64_t *event_code, int modifier);
 int rocp_evt_code_to_descr(uint64_t event_code, char *descr, int len);
 int rocp_evt_name_to_code(const char *name, uint64_t *event_code);
 int rocp_evt_code_to_name(uint64_t event_code, char *name, int len);
+int rocp_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info);
 
 /* profiling context handling interfaces */
 int rocp_ctx_open(uint64_t *events_id, int num_events, rocp_ctx_t *ctx);

--- a/src/components/rocm/roc_profiler_config.h
+++ b/src/components/rocm/roc_profiler_config.h
@@ -1,6 +1,8 @@
 #ifndef __ROC_PROFILER_CONFIG_H__
 #define __ROC_PROFILER_CONFIG_H__
 
+#include <stdint.h>
+
 #define PAPI_ROCM_MAX_COUNTERS (512)
 
 #define ROCM_PROFILE_SAMPLING_MODE (0x0)

--- a/src/components/rocm/rocm.c
+++ b/src/components/rocm/rocm.c
@@ -178,10 +178,10 @@ evt_get_count(int *count)
 {
     unsigned int event_code = 0;
 
-    if (rocd_evt_enum(&event_code, PAPI_ENUM_FIRST) == PAPI_OK) {
+    if (rocd_evt_enum((uint64_t *) &event_code, PAPI_ENUM_FIRST) == PAPI_OK) {
         ++(*count);
     }
-    while (rocd_evt_enum(&event_code, PAPI_ENUM_EVENTS) == PAPI_OK) {
+    while (rocd_evt_enum((uint64_t *) &event_code, PAPI_ENUM_EVENTS) == PAPI_OK) {
         ++(*count);
     }
 
@@ -585,7 +585,7 @@ rocm_ntv_enum_events(unsigned int *event_code, int modifier)
         goto fn_fail;
     }
 
-    papi_errno = rocd_evt_enum(event_code, modifier);
+    papi_errno = rocd_evt_enum((uint64_t *) event_code, modifier);
 
   fn_exit:
     SUBDBG("EXIT: %s\n", PAPI_strerror(papi_errno));
@@ -603,7 +603,7 @@ rocm_ntv_code_to_name(unsigned int event_code, char *name, int len)
         goto fn_fail;
     }
 
-    papi_errno = rocd_evt_code_to_name(event_code, name, len);
+    papi_errno = rocd_evt_code_to_name((uint64_t) event_code, name, len);
 
   fn_exit:
     SUBDBG("EXIT: %s\n", PAPI_strerror(papi_errno));
@@ -621,7 +621,7 @@ rocm_ntv_name_to_code(const char *name, unsigned int *code)
         goto fn_fail;
     }
 
-    papi_errno = rocd_evt_name_to_code(name, code);
+    papi_errno = rocd_evt_name_to_code(name, (uint64_t *) code);
 
   fn_exit:
     SUBDBG("EXIT: %s\n", PAPI_strerror(papi_errno));
@@ -639,7 +639,7 @@ rocm_ntv_code_to_descr(unsigned int event_code, char *descr, int len)
         goto fn_fail;
     }
 
-    papi_errno = rocd_evt_code_to_descr(event_code, descr, len);
+    papi_errno = rocd_evt_code_to_descr((uint64_t) event_code, descr, len);
 
   fn_exit:
     SUBDBG("EXIT: %s\n", PAPI_strerror(papi_errno));

--- a/src/components/rocm/rocm.c
+++ b/src/components/rocm/rocm.c
@@ -51,6 +51,7 @@ static int rocm_ntv_code_to_name(unsigned int event_code, char *name, int len);
 static int rocm_ntv_name_to_code(const char *name, unsigned int *event_code);
 static int rocm_ntv_code_to_descr(unsigned int event_code, char *descr,
                                   int len);
+static int rocm_ntv_code_to_info(unsigned int event_code, PAPI_event_info_t *info);
 
 typedef struct {
     int initialized;
@@ -118,6 +119,7 @@ papi_vector_t _rocm_vector = {
     .ntv_code_to_name = rocm_ntv_code_to_name,
     .ntv_name_to_code = rocm_ntv_name_to_code,
     .ntv_code_to_descr = rocm_ntv_code_to_descr,
+    .ntv_code_to_info = rocm_ntv_code_to_info,
 };
 
 static int check_n_initialize(void);
@@ -644,6 +646,24 @@ rocm_ntv_code_to_descr(unsigned int event_code, char *descr, int len)
     }
 
     papi_errno = rocd_evt_code_to_descr((uint64_t) event_code, descr, len);
+
+  fn_exit:
+    SUBDBG("EXIT: %s\n", PAPI_strerror(papi_errno));
+    return papi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int
+rocm_ntv_code_to_info(unsigned int event_code, PAPI_event_info_t *info)
+{
+    SUBDBG("ENTER: event_code: %u, info: %p\n", event_code, info);
+    int papi_errno = check_n_initialize();
+    if (papi_errno != PAPI_OK) {
+        goto fn_fail;
+    }
+
+    papi_errno = rocd_evt_code_to_info((uint64_t) event_code, info);
 
   fn_exit:
     SUBDBG("EXIT: %s\n", PAPI_strerror(papi_errno));

--- a/src/components/rocm/tests/Makefile
+++ b/src/components/rocm/tests/Makefile
@@ -12,7 +12,7 @@ CPPFLAGS+= -I$(PAPI_ROCM_ROOT)/include          \
            -I$(PAPI_ROCM_ROOT)/hsa/include/hsa  \
            $(INCLUDE)
 LDFLAGS += $(PAPILIB) $(TESTLIB) -pthread
-CXXFLAGS = -g -O0 -pthread
+CXXFLAGS = -g $(OPTFLAGS) -pthread
 
 rocm_tests: ALL
 


### PR DESCRIPTION
## Pull Request Description
This PR introduces event qualifier support in the ROCm component.

Also, solves issue #100

Main changes introduced by this PR are for `papi_component_avail`, that now shows a significantly smaller number of ROCm component events (these are the unique event names without any `:device=` or `:instance=` addition to the name) and `papi_native_avail`, that now shows `:device=` and `:instance=` as event qualifiers. Following an example for a system with two AMD GPUs:

```
$ utils/papi_component_avail
Available components and hardware information.
--------------------------------------------------------------------------------
PAPI version             : 7.0.1.0
Operating system         : Linux 6.1.62-1.el9.elrepo.x86_64
Vendor string and code   : AuthenticAMD (2, 0x2)
Model string and code    : AMD EPYC 7413 24-Core Processor (1, 0x1)
CPU revision             : 1.000000
CPUID                    : Family/Model/Stepping 25/1/1, 0x19/0x01/0x01
CPU Max MHz              : 3630
CPU Min MHz              : 1500
Total cores              : 96
SMT threads per core     : 2
Cores per socket         : 24
Sockets                  : 2
Cores per NUMA region    : 48
NUMA regions             : 2
Running in a VM          : no
Number Hardware Counters : 5
Max Multiplex Counters   : 384
Fast counter read (rdpmc): yes
--------------------------------------------------------------------------------

Compiled-in components:
Name:   perf_event              Linux perf_event CPU counters
Name:   perf_event_uncore       Linux perf_event CPU uncore and northbridge
Name:   rocm                    GPU events and metrics via AMD ROCm-PL API
Name:   sysdetect               System info detection component

Active components:
Name:   perf_event              Linux perf_event CPU counters
                                Native: 145, Preset: 27, Counters: 5
                                PMUs supported: perf, perf_raw, amd64_fam19h_zen3

Name:   perf_event_uncore       Linux perf_event CPU uncore and northbridge
                                Native: 4, Preset: 0, Counters: 7
                                PMUs supported: amd64_rapl, amd64_fam19h_zen3_l3

Name:   rocm                    GPU events and metrics via AMD ROCm-PL API
                                Native: 401, Preset: 0, Counters: 401

Name:   sysdetect               System info detection component
                                Native: 0, Preset: 0, Counters: 0


--------------------------------------------------------------------------------

$ utils/papi_native_avail
...
 Native Events in Component: rocm
===============================================================================
| rocm:::SQ_WAIT_INST_LDS                                                      |
|            Number of wave-cycles spent waiting for LDS instruction issue. In |
|            units of 4 cycles. (per-simd, nondeterministic)                   |
|     :device=0                                                                |
|            Mandatory device qualifier [0,1]                                  |
--------------------------------------------------------------------------------
| rocm:::TCP_TCP_TA_DATA_STALL_CYCLES                                          |
|            TCP stalls TA data interface. Now Windowed.                       |
|     :device=0                                                                |
|            Mandatory device qualifier [0,1]                                  |
|     :instance=0                                                              |
|            Mandatory instance qualifier in range [0 - 15]                    |
--------------------------------------------------------------------------------
| rocm:::GRBM_COUNT                                                            |
|            Tie High - Count Number of Clocks                                 |
|     :device=0                                                                |
|            Mandatory device qualifier [0,1]                                  |
--------------------------------------------------------------------------------
| rocm:::GRBM_GUI_ACTIVE                                                       |
|            The GUI is Active                                                 |
|     :device=0                                                                |
|            Mandatory device qualifier [0,1]                                  |
--------------------------------------------------------------------------------
| rocm:::GRBM_CP_BUSY                                                          |
|            Any of the Command Processor (CPG/CPC/CPF) blocks are busy.       |
|     :device=0                                                                |
|            Mandatory device qualifier [0,1]                                  |
--------------------------------------------------------------------------------
| rocm:::GRBM_SPI_BUSY                                                         |
|            Any of the Shader Pipe Interpolators (SPI) are busy in the shader |
|            engine(s).                                                        |
|     :device=0                                                                |
|            Mandatory device qualifier [0,1]                                  |
--------------------------------------------------------------------------------
| rocm:::TA_TA_BUSY                                                            |
|            TA block is busy. Perf_Windowing not supported for this counter.  |
|     :device=0                                                                |
|            Mandatory device qualifier [0,1]                                  |
|     :instance=0                                                              |
|            Mandatory instance qualifier in range [0 - 15]                    |
--------------------------------------------------------------------------------
| rocm:::TA_TOTAL_WAVEFRONTS                                                   |
|            Total number of wavefronts processed by TA.                       |
|     :device=0                                                                |
|            Mandatory device qualifier [0,1]                                  |
|     :instance=0                                                              |
|            Mandatory instance qualifier in range [0 - 15]                    |
--------------------------------------------------------------------------------
| rocm:::TA_BUFFER_WAVEFRONTS                                                  |
|            Number of buffer wavefronts processed by TA.                      |
|     :device=0                                                                |
|            Mandatory device qualifier [0,1]                                  |
|     :instance=0                                                              |
|            Mandatory instance qualifier in range [0 - 15]                    |
--------------------------------------------------------------------------------
| rocm:::TA_BUFFER_READ_WAVEFRONTS                                             |
|            Number of buffer read wavefronts processed by TA.                 |
|     :device=0                                                                |
|            Mandatory device qualifier [0,1]                                  |
|     :instance=0                                                              |
|            Mandatory instance qualifier in range [0 - 15]                    |
--------------------------------------------------------------------------------
| rocm:::TA_BUFFER_WRITE_WAVEFRONTS                                            |
|            Number of buffer write wavefronts processed by TA.                |
|     :device=0                                                                |
|            Mandatory device qualifier [0,1]                                  |
|     :instance=0                                                              |
|            Mandatory instance qualifier in range [0 - 15]                    |
--------------------------------------------------------------------------------
...
```

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
