### PR TITLE
ci: run tests with and without PAPI debug enabled

### DIFF
--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 
 COMPONENT=$1
-COMPILER=$2
+DEBUG=$2
+COMPILER=$3
 
 [ -z "$COMPILER" ] && COMPILER=gcc@11
 
@@ -43,9 +44,9 @@ if [ "$COMPONENT" = "infiniband_umad" ]; then
 fi
 
 if [ "$COMPONENT" = "perf_event" ]; then
-  ./configure --with-debug=yes --enable-warnings
+  ./configure --with-debug=$DEBUG --enable-warnings
 else
-  ./configure --with-debug=yes --enable-warnings --with-components=$COMPONENT
+  ./configure --with-debug=$DEBUG --enable-warnings --with-components=$COMPONENT
 fi
 
 make -j4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,35 +14,38 @@ jobs:
     strategy:
       matrix:
         component: [perf_event, lmsensors, io, net, powercap, appio, coretemp, stealtime]
+        debug: [yes, no]
       fail-fast: false
     runs-on: cpu_intel
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - name: Test
-        run: .github/workflows/ci.sh ${{matrix.component}}
+        run: .github/workflows/ci.sh ${{matrix.component}} ${{matrix.debug}}
   papi_component_nvidia:
     strategy:
       matrix:
         component: [cuda, nvml]
+        debug: [yes, no]
       fail-fast: false
     runs-on: gpu_nvidia
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - name: Test
-        run: .github/workflows/ci.sh ${{matrix.component}}
+        run: .github/workflows/ci.sh ${{matrix.component}} ${{matrix.debug}}
   papi_component_amd:
     strategy:
       matrix:
         component: [rocm, rocm_smi]
+        debug: [yes, no]
       fail-fast: false
     runs-on: gpu_amd
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - name: Test
-        run: .github/workflows/ci.sh ${{matrix.component}}
+        run: .github/workflows/ci.sh ${{matrix.component}} ${{matrix.debug}}
   papi_spack:
     runs-on: cpu
     timeout-minutes: 60


### PR DESCRIPTION
## Pull Request Description
Tests should make sure real use cases work as expected. Some tests might not working correctly if -O0 is used as optimization level in the compiler. For example, the ROCm runtime submits a kernel of 4 waves if the tests are built using -O0, which makes the tests fail.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
