### PR TITLE
Minor fixes for ROCm component qualifiers

### DIFF
--- a/src/components/rocm/roc_profiler.c
+++ b/src/components/rocm/roc_profiler.c
@@ -358,13 +358,13 @@ rocp_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info)
             }
             *(devices + strlen(devices) - 1) = 0;
             sprintf(info->symbol, "%s:device=%i", ntv_table_p->events[inf.nameid].name, inf.device);
-            sprintf(info->long_descr, "%s masks:Mandatory device qualifier [%s]",
+            sprintf(info->long_descr, "%s, masks:Mandatory device qualifier [%s]",
                     ntv_table_p->events[inf.nameid].descr, devices);
             break;
         }
         case INSTAN_FLAG:
             sprintf(info->symbol, "%s:instance=%i", ntv_table_p->events[inf.nameid].name, inf.instance);
-            sprintf(info->long_descr, "%s masks:Mandatory instance qualifier in range [0-%i]",
+            sprintf(info->long_descr, "%s, masks:Mandatory instance qualifier in range [0-%i]",
                     ntv_table_p->events[inf.nameid].descr, ntv_table_p->events[inf.nameid].instances - 1);
             break;
         default:

--- a/src/components/rocm/roc_profiler.c
+++ b/src/components/rocm/roc_profiler.c
@@ -344,9 +344,20 @@ rocp_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info)
             sprintf(info->long_descr, "%s", ntv_table_p->events[inf.nameid].descr);
             break;
         case (DEVICE_FLAG | INSTAN_FLAG):
+        {
+            int i;
+            char devices[PAPI_MAX_STR_LEN] = { 0 };
+            for (i = 0; i < device_table_p->count; ++i) {
+                if (rocc_dev_check(ntv_table_p->events[inf.nameid].device_map, i)) {
+                    sprintf(devices + strlen(devices), "%i,", i);
+                }
+            }
+            *(devices + strlen(devices) - 1) = 0;
             sprintf(info->symbol, "%s:device=%i:instance=%i", ntv_table_p->events[inf.nameid].name, inf.device, inf.instance);
-            sprintf(info->long_descr, "%s", ntv_table_p->events[inf.nameid].descr);
+            sprintf(info->long_descr, "%s, masks:Mandatory device qualifier [%s]:Mandatory instance qualifier in range [0-%i]",
+                    ntv_table_p->events[inf.nameid].descr, devices, ntv_table_p->events[inf.nameid].instances - 1);
             break;
+        }
         case DEVICE_FLAG:
         {
             int i;


### PR DESCRIPTION
## Pull Request Description
The ROCm component `ntv_code_to_info` function does not behave consistently with other components (e.g., `perf_event`). This PR fixes the function behavior to align it to the CPU component.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
