### PR TITLE
configure: Fix return values in start thread routines

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -5250,6 +5250,7 @@ else
 		                       res1 = (i == (int)arg);
                              else
 		                       res2 = (i == (int)arg);
+		             return NULL;
                            }
 	                       __thread int i;
                            int main () {
@@ -5378,7 +5379,7 @@ else
                                exit(1);
                              }
                              done = 1;
-	                         return j;
+			     return (void *) j;
                            }
 
                            int main( int argc, char ** argv ) {

--- a/src/configure.in
+++ b/src/configure.in
@@ -721,6 +721,7 @@ AC_ARG_WITH(tls,
 		                       res1 = (i == (int)arg);
                              else
 		                       res2 = (i == (int)arg);
+		             return NULL;
                            }
 	                       __thread int i;
                            int main () {
@@ -812,7 +813,7 @@ AC_ARG_WITH(virtualtimer,
                                exit(1);
                              }        
                              done = 1;
-	                         return j;
+			     return (void *) j;
                            } 
   
                            int main( int argc, char ** argv ) {


### PR DESCRIPTION
Thread start routines must return a `void *` value, and future compilers refuse to convert integers to pointers with just a warning (the `virtualtimer` probe).  Without this change, the probe always fails to compile with future compilers (such as GCC 14).

For the `tls` probe, return a null pointer for future-proofing, although current and upcoming C compilers do not treat this omission as an error.

Updates commit dd11311aadbd06ab6c76d ("configure: fix tls detection").

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC

## Pull Request Description


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
