### PR TITLE
Fix for ROCm SMI

### DIFF
--- a/src/components/rocm/tests/Makefile
+++ b/src/components/rocm/tests/Makefile
@@ -1,10 +1,10 @@
 NAME = rocm
 include ../../Makefile_comp_tests.target
 PAPI_ROCM_ROOT ?= /opt/rocm
-HIP_PATH ?= $(PAPI_ROCM_ROOT)/hip
 
-CC       = $(HIP_PATH)/bin/hipcc
-CXX      = $(HIP_PATH)/bin/hipcc
+HIPCC    = $(shell find $(PAPI_ROCM_ROOT) -iname hipcc | grep bin | head -n 1)
+CC       = $(HIPCC)
+CXX      = $(HIPCC)
 CPPFLAGS+= -I$(PAPI_ROCM_ROOT)/include          \
            -I$(PAPI_ROCM_ROOT)/include/hip      \
            -I$(PAPI_ROCM_ROOT)/include/hsa      \

--- a/src/components/rocm/tests/hl_intercept_multi_thread_monitoring.cpp
+++ b/src/components/rocm/tests/hl_intercept_multi_thread_monitoring.cpp
@@ -22,8 +22,12 @@ static void *run(void *thread_num_arg)
     }
 
     hipStream_t stream;
-    hipSetDevice(thread_num);
-    hipError_t hip_errno = hipStreamCreate(&stream);
+    hipError_t hip_errno = hipSetDevice(thread_num);
+    if (hip_errno != hipSuccess) {
+        hip_test_fail(__FILE__, __LINE__, "hipSetDevice", hip_errno);
+    }
+
+    hip_errno = hipStreamCreate(&stream);
     if (hip_errno != hipSuccess) {
         hip_test_fail(__FILE__, __LINE__, "hipStreamCreate", hip_errno);
     }

--- a/src/components/rocm/tests/hl_intercept_single_kernel_monitoring.cpp
+++ b/src/components/rocm/tests/hl_intercept_single_kernel_monitoring.cpp
@@ -23,7 +23,11 @@ int main(int argc, char *argv[])
     }
 
     hipStream_t stream;
-    hipSetDevice(0);
+    hip_errno = hipSetDevice(0);
+    if (hip_errno != hipSuccess) {
+        hip_test_fail(__FILE__, __LINE__, "hipSetDevice", hip_errno);
+    }
+
     hip_errno = hipStreamCreate(&stream);
     if (hip_errno != hipSuccess) {
         hip_test_fail(__FILE__, __LINE__, "hipStreamCreate", hip_errno);

--- a/src/components/rocm/tests/hl_intercept_single_thread_monitoring.cpp
+++ b/src/components/rocm/tests/hl_intercept_single_thread_monitoring.cpp
@@ -13,8 +13,12 @@ static void *run(void *thread_num_arg)
 {
     int thread_num = *(int *) thread_num_arg;
     hipStream_t stream;
-    hipSetDevice(thread_num);
-    hipError_t hip_errno = hipStreamCreate(&stream);
+    hipError_t hip_errno = hipSetDevice(thread_num);
+    if (hip_errno != hipSuccess) {
+        hip_test_fail(__FILE__, __LINE__, "hipSetDevice", hip_errno);
+    }
+
+    hip_errno = hipStreamCreate(&stream);
     if (hip_errno != hipSuccess) {
         hip_test_fail(__FILE__, __LINE__, "hipStreamCreate", hip_errno);
     }

--- a/src/components/rocm/tests/hl_sample_single_kernel_monitoring.cpp
+++ b/src/components/rocm/tests/hl_sample_single_kernel_monitoring.cpp
@@ -23,7 +23,11 @@ int main(int argc, char *argv[])
     }
 
     hipStream_t stream;
-    hipSetDevice(0);
+    hip_errno = hipSetDevice(0);
+    if (hip_errno != hipSuccess) {
+        hip_test_fail(__FILE__, __LINE__, "hipSetDevice", hip_errno);
+    }
+
     hip_errno = hipStreamCreate(&stream);
     if (hip_errno != hipSuccess) {
         hip_test_fail(__FILE__, __LINE__, "hipStreamCreate", hip_errno);

--- a/src/components/rocm/tests/hl_sample_single_thread_monitoring.cpp
+++ b/src/components/rocm/tests/hl_sample_single_thread_monitoring.cpp
@@ -13,8 +13,12 @@ static void *run(void *thread_num_arg)
 {
     int thread_num = *(int *) thread_num_arg;
     hipStream_t stream;
-    hipSetDevice(thread_num);
-    hipError_t hip_errno = hipStreamCreate(&stream);
+    hipError_t hip_errno = hipSetDevice(thread_num);
+    if (hip_errno != hipSuccess) {
+        hip_test_fail(__FILE__, __LINE__, "hipSetDevice", hip_errno);
+    }
+
+    hip_errno = hipStreamCreate(&stream);
     if (hip_errno != hipSuccess) {
         hip_test_fail(__FILE__, __LINE__, "hipStreamCreate", hip_errno);
     }

--- a/src/components/rocm/tests/matmul.cpp
+++ b/src/components/rocm/tests/matmul.cpp
@@ -130,12 +130,12 @@ void
 hip_do_matmul_cleanup(void **handle)
 {
     struct memory *handle_p = (struct memory *) (*handle);
-    hipFree(handle_p->h_A);
-    hipFree(handle_p->h_B);
-    hipFree(handle_p->h_C);
-    hipFree(handle_p->d_A);
-    hipFree(handle_p->d_B);
-    hipFree(handle_p->d_C);
+    (void)hipFree(handle_p->h_A);
+    (void)hipFree(handle_p->h_B);
+    (void)hipFree(handle_p->h_C);
+    (void)hipFree(handle_p->d_A);
+    (void)hipFree(handle_p->d_B);
+    (void)hipFree(handle_p->d_C);
     free(handle_p);
     *handle = NULL;
 }

--- a/src/configure
+++ b/src/configure
@@ -7167,7 +7167,7 @@ for comp in $components; do
           CFLAGS="$CFLAGS -DHAVE_ROCM"
       fi
 
-      if test "x`find $PAPI_ROCM_ROOT -name "rocm_smi.h"`" != "x" ; then
+      if test "x`find $PAPI_ROCMSMI_ROOT -name "rocm_smi.h"`" != "x" ; then
           CFLAGS="$CFLAGS -DHAVE_ROCM_SMI"
       fi
   fi

--- a/src/configure.in
+++ b/src/configure.in
@@ -2051,7 +2051,7 @@ for comp in $components; do
           CFLAGS="$CFLAGS -DHAVE_ROCM"
       fi
 
-      if test "x`find $PAPI_ROCM_ROOT -name "rocm_smi.h"`" != "x" ; then
+      if test "x`find $PAPI_ROCMSMI_ROOT -name "rocm_smi.h"`" != "x" ; then
           CFLAGS="$CFLAGS -DHAVE_ROCM_SMI"
       fi
   fi


### PR DESCRIPTION
## Pull Request Description
ROCm 6.0.0 causes the build process to fail with an error due to a bug in the rocm_smi header. The sysdetect component is always built by default in PAPI and it uses the rocm_smi headers when these are available through the PAPI_ROCM_ROOT environment variable. This PR isolates the problem to the rocm_smi component by looking for the headers in PAPI_ROCMSMI_ROOT instead. The reason PAPI_ROCM_ROOT was used previously is that the rocm_smi headers are normally installed under the same rocm installation directory as other packages (e.g. HSA and Rocprofiler).

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
