### PR TITLE
Cuda component init error handling

### DIFF
--- a/src/components/cuda/cupti_common.h
+++ b/src/components/cuda/cupti_common.h
@@ -91,7 +91,7 @@ void cuptic_disabled_reason_get(const char **pmsg);
 
 void *cuptic_load_dynamic_syms(const char *parent_path, const char *dlname, const char *search_subpaths[]);
 int cuptic_shutdown(void);
-int cuptic_device_get_count(void);
+int cuptic_device_get_count(int *num_gpus);
 int cuptic_init(void);
 int cuptic_is_runtime_perfworks_api(void);
 int cuptic_is_runtime_events_api(void);

--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -1391,7 +1391,12 @@ int cuptip_init(void)
         cuptic_disabled_reason_set("Unable to load CUDA library functions.");
         goto fn_fail;
     }
-    num_gpus = cuptic_device_get_count();
+
+    papi_errno = cuptic_device_get_count(&num_gpus);
+    if (papi_errno != PAPI_OK) {
+        goto fn_fail;
+    }
+
     if (num_gpus <= 0) {
         cuptic_disabled_reason_set("No GPUs found on system.");
         goto fn_fail;


### PR DESCRIPTION
## Pull Request Description
The cuda component init function now returns the proper cuda error message for the `disabled_reason` string. This allows PAPI users to pin point more precisely what went wrong with the component initialization. 

Example of system not properly configured:
```
$ utils/papi_component_avail
Available components and hardware information.
--------------------------------------------------------------------------------
PAPI version             : 7.0.1.0
Operating system         : Linux 6.1.62-1.el9.elrepo.x86_64
Vendor string and code   : AuthenticAMD (2, 0x2)
Model string and code    : AMD EPYC 7742 64-Core Processor (49, 0x31)
CPU revision             : 0.000000
CPUID                    : Family/Model/Stepping 23/49/0, 0x17/0x31/0x00
CPU Max MHz              : 2250
CPU Min MHz              : 1500
Total cores              : 256
SMT threads per core     : 2
Cores per socket         : 64
Sockets                  : 2
Cores per NUMA region    : 32
NUMA regions             : 8
Running in a VM          : no
Number Hardware Counters : 5
Max Multiplex Counters   : 384
Fast counter read (rdpmc): yes
--------------------------------------------------------------------------------

Compiled-in components:
Name:   perf_event              Linux perf_event CPU counters
Name:   perf_event_uncore       Linux perf_event CPU uncore and northbridge
Name:   cuda                    CUDA profiling via NVIDIA CuPTI interfaces
   \-> Disabled: system not yet initialized
Name:   sysdetect               System info detection component

Active components:
Name:   perf_event              Linux perf_event CPU counters
                                Native: 141, Preset: 17, Counters: 5
                                PMUs supported: perf, perf_raw, amd64_fam17h_zen2

Name:   perf_event_uncore       Linux perf_event CPU uncore and northbridge
                                Native: 1, Preset: 0, Counters: 3
                                PMUs supported: amd64_rapl

Name:   sysdetect               System info detection component
                                Native: 0, Preset: 0, Counters: 0


--------------------------------------------------------------------------------
```
## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
