### PR TITLE
cat: fix compile-time error

### DIFF
--- a/src/counter_analysis_toolkit/flops.c
+++ b/src/counter_analysis_toolkit/flops.c
@@ -832,6 +832,7 @@ void exec_flops( int precision, int EventSet, FILE *fp ) {
 #endif
           break;
       default:
+          ;
     }
 
     return;


### PR DESCRIPTION
On some older versions of GCC (10.3.0), not having at least a 'break' in a switch-case statement can yield the compiler warning: "label at end of compound statement"

These changes fix this error and have been tested on the AMD Zen3 architecture.

## Pull Request Description


## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
