### PR TITLE
sysdetect: fix bug where Makefile sets `-ffree-form` everywhere

### DIFF
--- a/src/components/sysdetect/tests/Makefile
+++ b/src/components/sysdetect/tests/Makefile
@@ -21,11 +21,9 @@ endif
 intel_compilers := ifort ifx
 cray_compilers := ftn crayftn
 
-FFLAGS += -ffree-form
-
 ifeq ($(notdir $(F77)),gfortran)
     FFLAGS +=-ffree-form -ffree-line-length-none
-else ifeq ($(notdir $(F77)),flang)
+else ifeq ($(patsubst %flang,,$(notdir $(F77))),)  # compiler name ends with flang
     FFLAGS +=-ffree-form
 else ifneq ($(findstring $(notdir $(F77)), $(intel_compilers)),)
     FFLAGS +=-free


### PR DESCRIPTION
To fix ARM compiler builds, #108 added these lines to the `Makefile` for `sysdetect` tests:

```diff
+ FFLAGS += -ffree-form
+
  ifeq ($(notdir $(F77)),gfortran)
      FFLAGS +=-ffree-form -ffree-line-length-none
  else ifeq ($(notdir $(F77)),flang)
      FFLAGS +=-ffree-form
  else ifneq ($(findstring $(notdir $(F77)), $(intel_compilers)),)
      FFLAGS +=-free
  else ifneq ($(findstring $(notdir $(F77)), $(cray_compilers)),)
      FFLAGS +=-ffree
  endif
```

but this adds `-ffree-form` to every compiler. This breaks [cray compiler builds for PAPI 7.1.0](https://gitlab.spack.io/spack/spack/-/jobs/9684882):

```
     1307    /home/gitlab-runner-protected-3/builds/Cj9btwqn/0/spack/spack/lib/
             spack/env/cce/ftn -ffree-form -ffree -I../../.. -o query_device_si
             mple_f query_device_simple_f.F ../../../libpapi.a
     1308    ftn-78 ftn: ERROR in command line
     1309      The -f option has an invalid argument, "free-form".
```

You can see that CCE gets both `-ffree-form` and `-ffree` there.

This patch removes the global `-ffree-form` and makes the flang condition above a bit more permissive, so that both `flang`, `armflang`, `amdflang`, or really anything ending in `flang` adds `-free-form`:

```diff
       FFLAGS +=-ffree-form -ffree-line-length-none
-  else ifeq ($(notdir $(F77)),flang)
+  else ifeq ($(patsubst %flang,,$(notdir $(F77))),)  # compiler name ends with flang
       FFLAGS +=-ffree-form
```

This should fix the bug that #108 fixed and it should also work on other compilers.

## Pull Request Description


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
