### PR TITLE
Updates to Individual Component README's to Fix Markdown Links

### DIFF
--- a/src/components/appio/README.md
+++ b/src/components/appio/README.md
@@ -2,9 +2,9 @@
 
 The APPIO component enables PAPI to access application level file and socket I/O information. 
 
-* [Enabling the APPIO Component](#markdown-header-enabling-the-appio-component)
-* [Known Limitations](#markdown-header-known-limitations)
-* [FAQ](#markdown-header-faq)
+* [Enabling the APPIO Component](#enabling-the-appio-component)
+* [Known Limitations](#known-limitations)
+* [FAQ](#faq)
 
 ***
 ## Enabling the APPIO Component
@@ -35,7 +35,7 @@ Threads are handled using thread-specific structures in the backend. However, no
 ***
 ## FAQ
 
-1. [Testing](#markdown-header-testing)
+1. [Testing](#testing)
 
 ## Testing
 Tests lie in the tests/ sub-directory. All test take no argument.

--- a/src/components/bgpm/README.md
+++ b/src/components/bgpm/README.md
@@ -2,7 +2,7 @@
 
 Five components have been added to PAPI to support hardware performance monitoring for the BG/Q platform; in particular the BG/Q network, the I/O system, the Compute Node Kernel in addition to the processing core. 
 
-* [Enabling the BGPM Component](#markdown-header-enabling-the-bgpm-component)
+* [Enabling the BGPM Component](#enabling-the-bgpm-component)
 
 ***
 ## Enabling the BGPM Component

--- a/src/components/coretemp/README.md
+++ b/src/components/coretemp/README.md
@@ -2,7 +2,7 @@
 
 The CORETEMP component enables PAPI-C to access hardware monitoring sensors through the coretemp sysfs interface. This component will dynamically create a native events table for all the sensors that can be found under /sys/class/hwmon/hwmon[0-9]+.
 
-* [Enabling the CORETEMP Component](#markdown-header-enabling-the-coretemp-component)
+* [Enabling the CORETEMP Component](#enabling-the-coretemp-component)
 
 ***
 ## Enabling the CORETEMP Component

--- a/src/components/coretemp_freebsd/README.md
+++ b/src/components/coretemp_freebsd/README.md
@@ -2,7 +2,7 @@
 
 The CORETEMP_FREEBSD component is intended to access CPU On-Die Thermal Sensors in the Intel Core architecture in a FreeBSD machine using the coretemp.ko kernel module. The returned values represent Kelvin degrees.
 
-* [Enabling the CORETEMP_FREEBSD Component](#markdown-header-enabling-the-coretemp_freebsd-component)
+* [Enabling the CORETEMP_FREEBSD Component](#enabling-the-coretemp_freebsd-component)
 
 ***
 ## Enabling the CORETEMP_FREEBSD Component

--- a/src/components/cuda/README.md
+++ b/src/components/cuda/README.md
@@ -2,10 +2,10 @@
 
 The CUDA component exposes counters and controls for NVIDIA GPUs.
 
-* [Enabling the CUDA Component](#markdown-header-enabling-the-cuda-component)
-* [Environment Variables](#markdown-header-environment-variables)
-* [Known Limitations](#markdown-header-known-limitations)
-* [FAQ](#markdown-header-faq)
+* [Enabling the CUDA Component](#enabling-the-cuda-component)
+* [Environment Variables](#environment-variables)
+* [Known Limitations](#known-limitations)
+* [FAQ](#faq)
 ***
 ## Enabling the CUDA Component
 
@@ -82,9 +82,11 @@ This can be set using export; e.g.
 
 ## FAQ
 
-1. [Unusual installations](#markdown-header-unusual-installations)
-2. [CUDA contexts](#markdown-header-cuda-contexts)
-3. [CUDA toolkit versions](#markdown-header-cuda-toolkit-versions)
+1. [Unusual installations](#unusual-installations)
+2. [CUDA contexts](#cuda-contexts)
+3. [CUDA toolkit versions](#cuda-toolkit-versions)
+4. [Custom library paths](#custom-library-paths)
+5. [Compute capability 7.0 with CUDA toolkit version 11.0](#compute-capability-70-with-cuda-toolkit-version-110)
 
 ## Unusual installations
 Three libraries are required for the PAPI CUDA component. `libcuda.so`,
@@ -109,7 +111,7 @@ The CUDA component can profile using contexts created by `cuCtxCreate` or primar
 ## CUDA toolkit versions
 Once your binaries are compiled, it is possible to swap the CUDA toolkit versions without needing to recompile the source. Simply update `PAPI_CUDA_ROOT` to point to the path where the cuda toolkit version can be found. You might need to update `LD_LIBRARY_PATH` as well.
 
-## Custom Library paths
+## Custom library paths
 PAPI CUDA component loads the CUDA driver library from the system installed path. It loads the other libraries from `$PAPI_CUDA_ROOT`. If that is not set, then it tries to load them from system paths.
 
 However, it is possible to load each of these libraries from custom paths by setting each of the following environment variables to point to the desired files. These are,

--- a/src/components/emon/README.md
+++ b/src/components/emon/README.md
@@ -2,7 +2,7 @@
 
 The EMON component provide access to Evniromental MONitoring power data on BG/Q systems. 
 
-* [Enabling the EMON Component](#markdown-header-enabling-the-emon-component)
+* [Enabling the EMON Component](#enabling-the-emon-component)
 
 ***
 ## Enabling the EMON Component

--- a/src/components/example/README.md
+++ b/src/components/example/README.md
@@ -2,7 +2,7 @@
 
 The EXAMPLE component demos the component interface and implements three example counters.
 
-* [Enabling the EXAMPLE Component](#markdown-header-enabling-the-example-component)
+* [Enabling the EXAMPLE Component](#enabling-the-example-component)
 
 ***
 ## Enabling the EXAMPLE Component

--- a/src/components/host_micpower/README.md
+++ b/src/components/host_micpower/README.md
@@ -5,8 +5,8 @@ The component makes use of the MicAccessAPI distributed with the Intel Manycore 
 (http://software.intel.com/en-us/articles/intel-manycore-platform-software-stack-mpss)
 Specifically in the intel-mic-sysmgmt package.
 
-* [Enabling the HOST\_MICPOWER Component](#markdown-header-enabling-the-host_micpower-component)
-* [FAQ](#markdown-header-faq)
+* [Enabling the HOST\_MICPOWER Component](#enabling-the-host_micpower-component)
+* [FAQ](#faq)
 
 ***
 ## Enabling the HOST\_MICPOWER Component

--- a/src/components/infiniband/README.md
+++ b/src/components/infiniband/README.md
@@ -3,8 +3,8 @@
 The INFINIBAND component uses the sysfs interface to access infiniband
 performance counters from user space.
 
-* [Enabling the INFINIBAND Component](#markdown-header-enabling-the-infiniband-component)
-* [FAQ](#markdown-header-faq)
+* [Enabling the INFINIBAND Component](#enabling-the-infiniband-component)
+* [FAQ](#faq)
 
 ***
 ## Enabling the INFINIBAND Component

--- a/src/components/io/README.md
+++ b/src/components/io/README.md
@@ -2,8 +2,8 @@
 
 The IO component enables PAPI to access the io statistics exported by the Linux kernel through the /proc pseudo-file system (file /proc/self/io).
 
-* [Enabling the IO Component](#markdown-header-enabling-the-io-component)
-* [FAQ](#markdown-header-faq)
+* [Enabling the IO Component](#enabling-the-io-component)
+* [FAQ](#faq)
 
 ***
 ## Enabling the IO Component

--- a/src/components/libmsr/README.md
+++ b/src/components/libmsr/README.md
@@ -2,9 +2,9 @@
 
 The LIBMSR component supports measuring and capping power usage on recent Intel architectures using the RAPL interface exposed through MSRs (model-specific registers).
 
-* [Enabling the LIBMSR Component](#markdown-header-enabling-the-libmsr-component)
-* [Environment Variables](#markdown-header-environment-variables)
-* [FAQ](#markdown-header-faq)
+* [Enabling the LIBMSR Component](#enabling-the-libmsr-component)
+* [Environment Variables](#environment-variables)
+* [FAQ](#faq)
 
 ***
 ## Enabling the LIBMSR Component
@@ -31,12 +31,12 @@ Within PAPI\_LIBMSR\_ROOT, we expect the following standard directories:
 ***
 ## FAQ
 
-1. [Background](#markdown-header-background)
-2. [Enable Access to the MSRs](#markdown-header-enable-access-to-the-msrs)
-3. [Compile the LIBMSR Library to Access the MSRs](#markdown-header-compile-the-libmsr-library-to-access-the-msrs)
-4. [Testing PAPI with LIBMSR Enabled](#markdown-header-testing-papi-with-libmsr-enabled)
-5. [List LIBMSR Supported Events](#markdown-header-list-libmsr-supported-events)
-6. [Use the PAPI LIBMSR Component](#markdown-header-use-the-papi-libmsr-component)
+1. [Background](#background)
+2. [Enable Access to the MSRs](#enable-access-to-the-msrs-model-specific-registers)
+3. [Compile the LIBMSR Library to Access the MSRs](#compile-the-libmsr-library-to-access-the-msrs)
+4. [Testing PAPI with LIBMSR Enabled](#testing-papi-with-libmsr-enabled)
+5. [List LIBMSR Supported Events](#list-libmsr-supported-events)
+6. [Use the PAPI LIBMSR Component](#use-the-papi-libmsr-component)
 
 ## Background
 This libmsr component is an initial version, and has been tested

--- a/src/components/lmsensors/README.md
+++ b/src/components/lmsensors/README.md
@@ -2,9 +2,9 @@
 
 The LMSENSORS Component enables PAPI to access hardware monitoring sensors through the libsensors library. This component requires lmsensors version >= 3.0.0.
 
-* [Enabling the LMSENSORS Component](#markdown-header-enabling-the-lmsensors-component)
-* [Environment Variables](#markdown-header-environment-variables)
-* [FAQ](#markdown-header-faq)
+* [Enabling the LMSENSORS Component](#enabling-the-lmsensors-component)
+* [Environment Variables](#environment-variables)
+* [FAQ](#faq)
 
 ***
 ## Enabling the LMSENSORS Component
@@ -30,8 +30,8 @@ Within PAPI\_LMSENSORS\_ROOT, we expect the following standard directories:
 ***
 ## FAQ
 
-1. [Unusual installations](#markdown-header-unusual-installations)
-2. [List LMSENSORS Supported Events](#markdown-header-list-lmsensors-supported-events)
+1. [Unusual installations](#unusual-installations)
+2. [List LMSENSORS Supported Events](#list-lmsensors-supported-events)
 
 ## Unusual installations
 

--- a/src/components/lustre/README.md
+++ b/src/components/lustre/README.md
@@ -2,7 +2,7 @@
 
 The LUSTRE component enables PAPI to access IO statistics provided by the Lustre filesystem.
 
-* [Enabling the LUSTRE Component](#markdown-header-enabling-the-lustre-component)
+* [Enabling the LUSTRE Component](#enabling-the-lustre-component)
 
 ***
 ## Enabling the LUSTRE Component

--- a/src/components/micpower/README.md
+++ b/src/components/micpower/README.md
@@ -2,8 +2,8 @@
 
 The MICPOWER component enables PAPI to access power readings reported on Intel MIC cards.
 
-* [Enabling the MICPOWER Component](#markdown-header-enabling-the-micpower-component)
-* [FAQ](#markdown-header-faq)
+* [Enabling the MICPOWER Component](#enabling-the-micpower-component)
+* [FAQ](#faq)
 
 ***
 ## Enabling the MICPOWER Component

--- a/src/components/mx/README.md
+++ b/src/components/mx/README.md
@@ -2,7 +2,7 @@
 
 The MX component enables PAPI to access counters provided by Myricom MX (Myrinet Express).
 
-* [Enabling the MX Component](#markdown-header-enabling-the-mx-component)
+* [Enabling the MX Component](#enabling-the-mx-component)
 
 ***
 ## Enabling the MX Component

--- a/src/components/net/README.md
+++ b/src/components/net/README.md
@@ -2,8 +2,8 @@
 
 The NET component enables PAPI to access the network statistics exported by the Linux kernel through the /proc pseudo-file system (file /proc/net/dev).
 
-* [Enabling the NET Component](#markdown-header-enabling-the-net-component)
-* [FAQ](#markdown-header-faq)
+* [Enabling the NET Component](#enabling-the-net-component)
+* [FAQ](#faq)
 
 ***
 ## Enabling the NET Component

--- a/src/components/net/README.md
+++ b/src/components/net/README.md
@@ -51,7 +51,5 @@ Note: The Linux network statistics are updated by code that resides in the file 
 * Network Stats Anomaly
   http://collectl.sourceforge.net/NetworkStats.html
 
-* OccasNETnally corrupted network stats in /proc/net/dev
-  http://kerneltrap.org/mailarchive/linux-netdev/2008/1/14/566936
-  http://kerneltrap.org/mailarchive/linux-netdev/2008/1/14/567512
+*  /proc/net/dev which lists the various network devices configured on the system, complete with transmit and receive statistics.
 

--- a/src/components/nvml/README.md
+++ b/src/components/nvml/README.md
@@ -4,10 +4,10 @@ The NVML (NVIDIA Management Library) component exposes hardware management
 counters and controls for NVIDIA GPUs, such as power consumption, fan speed and
 temperature readings; it also allows capping of power consumption.
 
-* [Enabling the NVML Component](#markdown-header-enabling-the-nvml-component)
-* [Environment Variables](#markdown-header-environment-variables)
-* [Known Limitations](#markdown-header-known-limitations)
-* [FAQ](#markdown-header-faq)
+* [Enabling the NVML Component](#enabling-the-nvml-component)
+* [Environment Variables](#environment-variables)
+* [Known Limitations](#known-limitations)
+* [FAQ](#faq)
 ***
 ## Enabling the NVML Component
 
@@ -51,7 +51,7 @@ power limits; such permissions are typically granted by your sysadmin.
 
 ## FAQ
 
-1. [Unusual installations](#markdown-header-unusual-installations)
+1. [Unusual installations](#unusual-installations)
 
 ## Unusual installations
 One library is required for the PAPI NVML component: `libnvidia-ml.so`.  

--- a/src/components/pcp/README.md
+++ b/src/components/pcp/README.md
@@ -5,10 +5,10 @@ Performance Metrics Domain Agent (PMDA) perfevent. This allows monitoring
 of IBM Power 9 'nest' events via PCP without elevated privileges. This 
 component was developed and tested using PCP version 3.12.2. 
 
-* [Enabling the PCP Component](#markdown-header-enabling-the-pcp-component)
-* [Environment Variables](#markdown-header-environment-variables)
-* [Known Limitations](#markdown-header-known-limitations)
-* [FAQ](#markdown-header-faq)
+* [Enabling the PCP Component](#enabling-the-pcp-component)
+* [Environment Variables](#environment-variables)
+* [Known Limitations](#known-limitations)
+* [FAQ](#faq)
 ***
 ## Enabling the PCP Component
 
@@ -102,7 +102,7 @@ PCP_EVENT_NAME:cpu63.
 ***
 ## FAQ
 
-1. [Unusual installations](#markdown-header-unusual-installations)
+1. [Unusual installations](#unusual-installations)
 
 ## Unusual installations
 For the PCP component to be operational, it must find the dynamic library

--- a/src/components/perf_event/README.md
+++ b/src/components/perf_event/README.md
@@ -2,7 +2,7 @@
 
 The PERF\_EVENT component enables PAPI to access perf\_event CPU counters.
 
-* [Enabling the PERF\_EVENT Component](#markdown-header-enabling-the-perf-event-component)
+* [Enabling the PERF\_EVENT Component](#enabling-the-perf_event-component)
 
 ***
 ## Enabling the PERF\_EVENT Component

--- a/src/components/perf_event_uncore/README.md
+++ b/src/components/perf_event_uncore/README.md
@@ -2,8 +2,8 @@
 
 The PERF\_EVENT_UNCORE component enables PAPI to access perf\_event CPU uncore and northbridge.
 
-* [Enabling the PERF\_EVENT\_UNCORE Component](#markdown-header-enabling-the-perf-event-uncore-component)
-* [FAQ](#markdown-header-faq)
+* [Enabling the PERF\_EVENT\_UNCORE Component](#enabling-the-perf_event_uncore-component)
+* [FAQ](#faq)
 
 ***
 ## Enabling the PERF\_EVENT\_UNCORE Component
@@ -16,7 +16,7 @@ to the user, and whether they are disabled, and when they are disabled why.
 
 ## FAQ
 
-1. [Measuring Uncore Events](#markdown-header-measuring-uncore-events)
+1. [Measuring Uncore Events](#measuring-uncore-events)
 
 ## Measuring Uncore Events
 

--- a/src/components/powercap/README.md
+++ b/src/components/powercap/README.md
@@ -2,9 +2,9 @@
 
 The POWERCAP component supports measuring and capping power usage on recent Intel architectures (Sandybridge or later) using the powercap interface exposed through the Linux kernel.
 
-* [Enabling the POWERCAP Component](#markdown-header-enabling-the-powercap-component)
-* [Known Limitations](#markdown-header-known-limitations)
-* [FAQ](#markdown-header-faq)
+* [Enabling the POWERCAP Component](#enabling-the-powercap-component)
+* [Known Limitations](#known-limitations)
+* [FAQ](#faq)
 
 ***
 ## Enabling the POWERCAP Component
@@ -29,7 +29,7 @@ Use chmod to set site-appropriate access permissions (e.g. 766) for /sys/class/p
 
 ## FAQ
 
-1. [Measuring and Capping Power](#markdown-header-measuring-and-capping-power)
+1. [Measuring and Capping Power](#measuring-and-capping-power)
 
 ## Measuring and Capping Power
 

--- a/src/components/powercap_ppc/README.md
+++ b/src/components/powercap_ppc/README.md
@@ -4,9 +4,9 @@ The POWERCAP\_PPC component supports measuring and capping power usage
 on recent IBM PowerPC architectures (Power9 and later) using the powercap
 interface exposed through the Linux kernel.
 
-* [Enabling the POWERCAP\_PPC Component](#markdown-header-enabling-the-powercap-ppc-component)
-* [Known Limitations](#markdown-header-known-limitations)
-* [FAQ](#markdown-header-faq)
+* [Enabling the POWERCAP\_PPC Component](#enabling-the-powercap_ppc-component)
+* [Known Limitations](#known-limitations)
+* [FAQ](#faq)
 
 ***
 ## Enabling the POWERCAP\_PPC Component
@@ -31,7 +31,7 @@ Use chmod to set site-appropriate access permissions (e.g. 664) for /sys/firmwar
 
 ## FAQ
 
-1. [Measuring and Capping Power](#markdown-header-measuring-and-capping-power)
+1. [Measuring and Capping Power](#measuring-and-capping-power)
 
 ## Measuring and Capping Power
 

--- a/src/components/rapl/README.md
+++ b/src/components/rapl/README.md
@@ -2,8 +2,8 @@
 
 The RAPL component enables PAPI to access Linux RAPL energy measurements.
 
-* [Enabling the RAPL Component](#markdown-header-enabling-the-rapl-component)
-* [Known Limitations](#markdown-header-known-limitations)
+* [Enabling the RAPL Component](#enabling-the-rapl-component)
+* [Known Limitations](#known-limitations)
 
 ***
 ## Enabling the RAPL Component

--- a/src/components/rocm/README.md
+++ b/src/components/rocm/README.md
@@ -4,10 +4,10 @@ The ROCM component exposes numerous performance events on AMD GPUs.
 The component is an adapter to the ROCm profiling library (ROC-profiler) which is included in a standard ROCM release.
 
 
-* [Enabling the ROCM Component](#markdown-header-enabling-the-rocm-component)
-* [Environment Variables](#markdown-header-environment-variables)
-* [Known Limitations](#markdown-header-known-limitations)
-* [FAQ](#markdown-header-faq)
+* [Enabling the ROCM Component](#enabling-the-rocm-component)
+* [Environment Variables](#environment-variables)
+* [Known Limitations](#known-limitations)
+* [FAQ](#faq)
 ***
 ## Enabling the ROCM Component
 
@@ -105,12 +105,12 @@ setting the ROCP\_TOOL\_LIB to the PAPI library as follows:
 ***
 ## FAQ
 
-1. [Unusual installations](#markdown-header-unusual-installations)
+1. [Unusual installations](#unusual-installations)
 
 ## Unusual installations
 For the ROCM component to be operational, it must find the dynamic libraries `libhsa-runtime64.so` and `librocprofiler64.so`. These are normally found in the above standard directories. If these libraries are not found (or are not functional) then the component will be listed as "disabled" with a reason explaining the problem. If libraries were not found, then they are not in the expected places.
 
-2. [Device isolation](#markdown-device-isolation)
+2. [Device isolation](#device-isolation)
 
 ## Device isolation
 Compute clusters resource managers can isolate GPU devices, on compute nodes,

--- a/src/components/rocm/README.md
+++ b/src/components/rocm/README.md
@@ -134,4 +134,4 @@ of the device should be used for this mapping (see hipDeviceGetUuid and
 HSA\_AMD\_AGENT\_INFO\_UUID).
 
 The AMD isolation mechanism is described in more details here:
-https://rocm.docs.amd.com/en/latest/understand/gpu_isolation.html
+https://rocmdocs.amd.com/en/latest/conceptual/gpu-isolation.html

--- a/src/components/rocm_smi/README.md
+++ b/src/components/rocm_smi/README.md
@@ -4,12 +4,12 @@ The ROCM_SMI (System Management Interface) component exposes hardware management
 counters and controls for AMD GPUs, such as power consumption, fan speed and
 temperature readings; it also allows capping of power consumption.
 
-* [Enabling the ROCM_SMI Component](#markdown-header-enabling-the-rocm_smi-component)
-* [Environment Variables](#markdown-header-environment-variables)
-* [Known Limitations](#markdown-header-known-limitations)
-* [FAQ](#markdown-header-faq)
+* [Enabling the ROCM_SMI Component](#enabling-the-rocm_smi-component)
+* [Environment Variables](#environment-variables)
+* [Known Limitations](#known-limitations)
+* [FAQ](#faq)
 ***
-## Enabling the ROCM Component
+## Enabling the ROCM_SMI Component
 
 To enable reading or writing of ROCM_SMI counters the user needs to link
 against a PAPI library that was configured with the ROCM_SMI component enabled.
@@ -44,7 +44,7 @@ Within PAPI_ROCMSMI_ROOT, we expect the following standard directories:
 ***
 ## FAQ
 
-1. [Unusual installations](#markdown-header-unusual-installations)
+1. [Unusual installations](#unusual-installations)
 
 ## Unusual installations
 For the ROCM_SMI component to be operational, it must find the dynamic

--- a/src/components/sde/README.md
+++ b/src/components/sde/README.md
@@ -2,9 +2,8 @@
 
 The SDE component enables PAPI to read Software Defined Events (SDEs) exported by third party libraries.
 
-* [Enabling the SDE Component](#markdown-header-enabling-the-sde-component)
-* [Environment Variables](#markdown-header-environment-variables)
-* [FAQ](#markdown-header-faq)
+* [Enabling the SDE Component](#enabling-the-sde-component)
+* [FAQ](#faq)
 
 ## Enabling the SDE Component
 

--- a/src/components/sensors_ppc/README.md
+++ b/src/components/sensors_ppc/README.md
@@ -2,9 +2,9 @@
 
 The SENSORS\_PPC component supports reading system metrics on recent IBM PowerPC architectures (Power9 and later) using the OCC memory exposed through the Linux kernel.
 
-* [Enabling the SENSORS\_PPC Component](#markdown-header-enabling-the-sensors-ppc-component)
-* [Known Limitations](#markdown-header-known-limitations)
-* [FAQ](#markdown-header-faq)
+* [Enabling the SENSORS\_PPC Component](#enabling-the-sensors_ppc-component)
+* [Known Limitations](#known-limitations)
+* [FAQ](#faq)
 
 ***
 ## Enabling the SENSORS\_PPC Component
@@ -31,7 +31,7 @@ And finally, have your user added to said group, granting you read access.
 
 ## FAQ
 
-1. [Measuring System](#markdown-header-measuring-system)
+1. [Measuring System](#measuring-system)
 
 ## Measuring System
 

--- a/src/components/stealtime/README.md
+++ b/src/components/stealtime/README.md
@@ -2,7 +2,7 @@
 
 The STEALTIME component enables PAPI to access stealtime filesystem statistics.
 
-* [Enabling the STEALTIME Component](#markdown-header-enabling-the-stealtime-component)
+* [Enabling the STEALTIME Component](#enabling-the-stealtime-component)
 
 ***
 ## Enabling the STEALTIME Component

--- a/src/components/sysdetect/README.md
+++ b/src/components/sysdetect/README.md
@@ -7,7 +7,7 @@ similarly to other components, which means that hardware information for
 a specific device might not be available at runtime if, e.g., the device
 runtime software is not installed.
 
-* [Enabling the SYSDETECT Component](#markdown-header-enabling-the-sysdetect-component)
+* [Enabling the SYSDETECT Component](#enabling-the-sysdetect-component)
 
 ## Enabling the SYSDETECT Component
 

--- a/src/components/vmware/README.md
+++ b/src/components/vmware/README.md
@@ -2,7 +2,7 @@
 
 The VMWARE component supports reading vmguest and pseudo counters.
 
-* [Enabling the VMWARE Component] (#markdown-header-enabling-the-vmware-component)
+* [Enabling the VMWARE Component](#enabling-the-vmware-component)
 
 ***
 ## Enabling the VMWARE Component


### PR DESCRIPTION
## Pull Request Description
Update the README markdown header links for each component listed within the following [table](https://github.com/icl-utk-edu/papi/wiki/PAPI-Overview#list-of-components). The original header links within each README, were dead links and therefore selecting one resulted in not jumping to the desired section. This was caused by using the following syntax _(#markdown-header-name-of-section)_. Simply removing _#markdown-header_ fixes this issue. 

Tested on Guyot, by previewing and selecting updated markdown header links. Each updated README had the correct behavior of jumping to the correct section that was selected.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
