### PR TITLE
Update to Arguments for PAPIF_flops_rate, PAPIF_flips_rate, PAPIF_epc

### DIFF
--- a/src/papi_fwrappers.c
+++ b/src/papi_fwrappers.c
@@ -1348,16 +1348,16 @@ PAPI_FCALL( papif_ipc, PAPIF_IPC,
  *	
  *	@par Fortran Interface:
  *	\#include "fpapi.h" @n
- *	PAPIF_epc( C_STRING EventName, C_FLOAT real_time, C_FLOAT proc_time, C_LONG_LONG ref, C_LONG_LONG core, C_LONG_LONG evt, C_FLOAT epc, C_INT check )
+ *	PAPIF_epc( C_INT EventCode, C_FLOAT real_time, C_FLOAT proc_time, C_LONG_LONG ref, C_LONG_LONG core, C_LONG_LONG evt, C_FLOAT epc, C_INT check )
  *
  * @see PAPI_epc
  */
 PAPI_FCALL( papif_epc, PAPIF_EPC,
-			( int event, float *rtime, float *ptime, 
+			( int *EventCode, float *rtime, float *ptime, 
 			  long long *ref, long long *core, long long *evt, float *epc,
 			  int *check) )
 {
-	*check = PAPI_epc( event, rtime, ptime, ref, core, evt, epc );
+	*check = PAPI_epc( *EventCode, rtime, ptime, ref, core, evt, epc );
 }
 
 /** @class PAPIF_flips_rate
@@ -1366,15 +1366,15 @@ PAPI_FCALL( papif_epc, PAPIF_EPC,
  *
  *	@par Fortran Interface:
  *	\#include "fpapi.h" @n
- *	PAPIF_flips_rate ( C_STRING EventName, C_FLOAT real_time, C_FLOAT proc_time, C_LONG_LONG flpins, C_FLOAT mflips, C_INT check )
+ *	PAPIF_flips_rate ( C_INT EventCode, C_FLOAT real_time, C_FLOAT proc_time, C_LONG_LONG flpins, C_FLOAT mflips, C_INT check )
  *
  * @see PAPI_flips_rate
  */
 PAPI_FCALL( papif_flips_rate, PAPIF_FLIPS_RATE,
-			( int event, float *real_time, float *proc_time, long long *flpins,
+			( int *EventCode, float *real_time, float *proc_time, long long *flpins,
 			  float *mflips, int *check ) )
 {
-	*check = PAPI_flips_rate( event, real_time, proc_time, flpins, mflips );
+	*check = PAPI_flips_rate( *EventCode, real_time, proc_time, flpins, mflips );
 }
 
 /** @class PAPIF_flops_rate
@@ -1383,15 +1383,15 @@ PAPI_FCALL( papif_flips_rate, PAPIF_FLIPS_RATE,
  *
  *	@par Fortran Interface:
  *	\#include "fpapi.h" @n
- *  PAPIF_flops_rate( C_STRING EventName, C_FLOAT real_time, C_FLOAT proc_time, C_LONG_LONG flpops, C_FLOAT mflops, C_INT check )
+ *  PAPIF_flops_rate( C_INT EventCode, C_FLOAT real_time, C_FLOAT proc_time, C_LONG_LONG flpops, C_FLOAT mflops, C_INT check )
  *
  * @see PAPI_flops_rate
  */
 PAPI_FCALL( papif_flops_rate, PAPIF_FLOPS_RATE,
-			( int event, float *real_time, float *proc_time, long long *flpops,
+			( int *EventCode, float *real_time, float *proc_time, long long *flpops,
 			  float *mflops, int *check ) )
 {
-	*check = PAPI_flops_rate( event, real_time, proc_time, flpops, mflops );
+	*check = PAPI_flops_rate( *EventCode, real_time, proc_time, flpops, mflops );
 }
 
 /** @class PAPIF_rate_stop


### PR DESCRIPTION
## Pull Request Description
This PR updates the PAPI Fortran wrappers for: `PAPIF_flops_rate`, `PAPIF_flips_rate`, and `PAPIF_epc`.  All three of the aforementioned functions had a first argument of `int event`. However, setting `int event` equal to events such as `PAPI_FP_OPS` for `PAPIF_flops_rate`,  `PAPI_FP_INS` for `PAPIF_flips_rate`, and `PAPI_TOT_INS` for `PAPIF_epc` would result in an error being output, specifically -7. Which means the "Hardware event does not exist". This is not the correct behavior due to the events existing and the associated C low-level functions running correctly given the same input. 

To fix this issue, `int event` was changed to `int *EventCode` for `PAPIF_flops_rate`, `PAPIF_flips_rate`, and `PAPIF_epc`. As well as `*EventCode` being passed to the C function calls within the wrappers.

Two other minor updates are: 

-  Updated documentation for `PAPIF_flops_rate`, `PAPIF_flips_rate`, and `PAPIF_epc` within the `papi_fwrappers.c` source file. 
- Changed argument name from `event` to `EventCode`, the idea with this change is to keep the argument naming scheme similar to other PAPI functions such as `PAPIF_event_code_to_name`. 

Example code for `PAPIF_flops_rate` with the changes mentioned above:
```fortran
#include "fpapi.h"    
      program main
          use iso_c_binding
          integer(c_int) EventCode, check, retval
          real(c_float) real_time, proc_time, mflops, nfact
          integer(c_long_long) flpops

          EventCode = PAPI_FP_OPS

          retval = PAPI_VER_CURRENT
          call PAPIf_library_init(retval)
          if ( retval.NE.PAPI_VER_CURRENT) then
            write(*,*) retval
          end if

          call PAPIF_flops_rate(EventCode, real_time, proc_time,
     & flpops, mflops, check) 
          if ( check.NE.PAPI_OK) then
            write(*,*) check
          end if

          ! do some arbitrary work
          do n = 1, 10000
              nfact = (1.1 + 100)/n
          end do

          call PAPIF_flops_rate(EventCode, real_time, proc_time,
     & flpops, mflops, check) 
          if ( check.NE.PAPI_OK) then
              write(*,*) check
          end if

      end program main
```

Possible output is from running the above script on Guyot: 
```
Real Time: 3.79999983E-05
Proc Time: 3.70000016E-05
Flpops: 10000
Mflops:  270.270264    
Error Check: 0
```


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
