### PR TITLE
Adding support for optional individual file flag to papi_hl_output_writer.py

### DIFF
--- a/src/high-level/scripts/papi_hl_output_writer.py
+++ b/src/high-level/scripts/papi_hl_output_writer.py
@@ -78,7 +78,7 @@ def merge_json_files(source):
   return json_object
 
 def parse_source_file(source_file):
-    """Take JSON file (source_file) and convert it to a python dictionary.
+    """Take a JSON file (source_file) and convert it to a python dictionary.
     Additionally add extra metadata such as mpi rank.
 
     Arguments:

--- a/src/high-level/scripts/papi_hl_output_writer.py
+++ b/src/high-level/scripts/papi_hl_output_writer.py
@@ -31,12 +31,12 @@ event_rate_names = OrderedDict([
       ('PAPI_DP_OPS','Double precision MFLOPS/s')
     ])
 
-def merge_json_files(source):
+def merge_json_files(source_dir):
   json_object = {}
   events_stored = False
 
   #get measurement files
-  file_list = os.listdir(source)
+  file_list = os.listdir(source_dir)
   file_list.sort()
   rank_cnt = 0
   json_rank = OrderedDict()
@@ -51,7 +51,7 @@ def merge_json_files(source):
       rank = rank_cnt
 
     #open measurement file
-    file_name = str(source) + "/" + str(item)
+    file_name = str(source_dir) + "/" + str(item)
 
     try:
       with open(file_name) as json_file:
@@ -78,14 +78,6 @@ def merge_json_files(source):
   return json_object
 
 def parse_source_file(source_file):
-    """Take a JSON file (source_file) and convert it to a python dictionary.
-    Additionally add extra metadata such as mpi rank.
-
-    Arguments:
-        source_file -- JSON file generated from PAPI high level API functions.
-    Returns:
-        Python dictionary.
-    """
     json_data = {}
     json_rank = OrderedDict()
     events_stored = False
@@ -506,10 +498,10 @@ def write_json_file(data, file_name):
     outfile.write(to_unicode(str_))
     print (str_)
 
-def main(format, type, notation, source = None, source_file = None):
+def main(format, type, notation, source_dir = None, source_file = None):
     if (format == "json"):
-        if source != None:
-            json = merge_json_files(source)
+        if source_dir != None:
+            json = merge_json_files(source_dir)
         else:
             json = parse_source_file(source_file)
 
@@ -531,7 +523,7 @@ def main(format, type, notation, source = None, source_file = None):
 
 def parse_args():
   parser = argparse.ArgumentParser()
-  parser.add_argument('--source', type=str, required=False,
+  parser.add_argument('--source_dir', type=str, required=False,
                       help='Measurement directory of raw data.')
   parser.add_argument('--source_file', type=str, required=False,
                       help='Individual file containing measurements of raw data.')
@@ -543,11 +535,11 @@ def parse_args():
                       help='Output notation: raw or derived.')
   
   # check to make sure a value has not been passed for both filename and source
-  if (parser.parse_args().source != None and
+  if (parser.parse_args().source_dir != None and
       parser.parse_args().source_file != None):
       # executes if both conditions are true
-      print("Cannot pass values to both source and source_file."
-            " Value must be passed to either source or source_file.")
+      print("Cannot pass values to both source_dir and source_file."
+            " Value must be passed to either source_dir or source_file.")
       parser.print_help()
       parser.exit()
 
@@ -559,19 +551,19 @@ def parse_args():
           parser.print_help()
           parser.exit()
   # check if papi directory exists
-  elif parser.parse_args().source != None:
-      source = str(parser.parse_args().source)
-      if os.path.isdir(source) == False:
-          print("Measurement directory '{}' does not exist!\n".format(source))
+  elif parser.parse_args().source_dir != None:
+      source_dir = str(parser.parse_args().source_dir)
+      if os.path.isdir(source_dir) == False:
+          print("Measurement directory '{}' does not exist!\n".format(source_dir))
           parser.print_help()
           parser.exit()
+  # output if neither source_file or source_dir are supplied
   else:
-    print("Path to either a JSON file or a" 
-          " dictionary which contains a JSON file is required.")
+    print("Path to either a JSON file (--source_file) or a" 
+          " dictionary (--source_dir) which contains a JSON file is required.")
     parser.print_help()
     parser.exit()
     
-
   # check format
   output_format = str(parser.parse_args().format)
   if output_format != "json":
@@ -600,7 +592,7 @@ def parse_args():
 if __name__ == '__main__':
   args = parse_args()
   main(format=args.format,
-       source=args.source,
+       source_dir=args.source_dir,
        source_file=args.source_file,
        type=args.type,
        notation=args.notation)

--- a/src/high-level/scripts/papi_hl_output_writer.py
+++ b/src/high-level/scripts/papi_hl_output_writer.py
@@ -546,8 +546,10 @@ def parse_args():
   if (parser.parse_args().source != None and
       parser.parse_args().source_file != None):
       # executes if both conditions are true
-      raise ValueError("Cannot pass values to both source and source_file."
-                       " Value must be passed to either source or source_file.")
+      print("Cannot pass values to both source and source_file."
+            " Value must be passed to either source or source_file.")
+      parser.print_help()
+      parser.exit()
 
   # check to see if file exists
   if parser.parse_args().source_file != None:
@@ -564,8 +566,11 @@ def parse_args():
           parser.print_help()
           parser.exit()
   else:
-    raise ValueError("Provide a path to either a JSON file or a" 
-                     " dictionary which contains a JSON file.")
+    print("Path to either a JSON file or a" 
+          " dictionary which contains a JSON file is required.")
+    parser.print_help()
+    parser.exit()
+    
 
   # check format
   output_format = str(parser.parse_args().format)

--- a/src/high-level/scripts/papi_hl_output_writer.py
+++ b/src/high-level/scripts/papi_hl_output_writer.py
@@ -75,9 +75,44 @@ def merge_json_files(source):
   
   json_object['ranks'] = json_rank
 
-  # print json.dumps(json_object,indent=2, sort_keys=False,
-  #                  separators=(',', ': '), ensure_ascii=False)
   return json_object
+
+def parse_source_file(source_file):
+    """Take JSON file (source_file) and convert it to a python dictionary.
+    Additionally add extra metadata such as mpi rank.
+
+    Arguments:
+        source_file -- JSON file generated from PAPI high level API functions.
+    Returns:
+        Python dictionary.
+    """
+    json_data = {}
+    json_rank = OrderedDict()
+    events_stored = False
+
+    # determine mpi rank based on file name (rank_#)
+    rank = source_file.split('_', 1)[1]
+    rank = source_file.rsplit('.', 1)[0]
+
+    # open json file provided by user
+    f = open(source_file)
+
+    # return ordered dictionary
+    data = json.load(f, object_pairs_hook = OrderedDict)
+
+    #store global data
+    if events_stored == False:
+      global event_definitions
+      event_definitions = data['event_definitions']
+      events_stored = True
+
+    # get all threads
+    json_rank[str(rank)] = OrderedDict()
+    json_rank[str(rank)]['threads'] = data['threads']
+
+    json_data['ranks'] = json_rank 
+
+    return json_data
 
 class Sum_Counter(object):
   def __init__(self):
@@ -471,45 +506,66 @@ def write_json_file(data, file_name):
     outfile.write(to_unicode(str_))
     print (str_)
 
+def main(format, type, notation, source = None, source_file = None):
+    if (format == "json"):
+        if source != None:
+            json = merge_json_files(source)
+        else:
+            json = parse_source_file(source_file)
 
-def main(source, format, type, notation):
-  if (format == "json"):
-    json = merge_json_files(source)
+        if type == 'detail':
+            if notation == 'derived':
+                write_json_file(derive_json_object(json), 'papi.json')
+            else:
+                write_json_file(json, 'papi.json')
 
-    if type == 'detail':
-      if notation == 'derived':
-        write_json_file(derive_json_object(json), 'papi.json')
-      else:
-        write_json_file(json, 'papi.json')
-
-    #summarize data over regions with the same name, threads and ranks
-    if type == 'summary':
-      if notation == 'derived':
-        write_json_file(sum_json_object(json, True), 'papi_sum.json')
-      else:
-        write_json_file(sum_json_object(json), 'papi_sum.json')
-
-  else:
-    print("Format not supported!")
+        #summarize data over regions with the same name, threads and ranks
+        if type == 'summary':
+            if notation == 'derived':
+                write_json_file(sum_json_object(json, True), 'papi_sum.json')
+            else:
+                write_json_file(sum_json_object(json), 'papi_sum.json')
+    else:
+        print("Format not supported!")
 
 
 def parse_args():
   parser = argparse.ArgumentParser()
-  parser.add_argument('--source', type=str, required=False, default="papi_hl_output",
+  parser.add_argument('--source', type=str, required=False,
                       help='Measurement directory of raw data.')
+  parser.add_argument('--source_file', type=str, required=False,
+                      help='Individual file containing measurements of raw data.')
   parser.add_argument('--format', type=str, required=False, default='json', 
                       help='Output format, e.g. json.')
   parser.add_argument('--type', type=str, required=False, default='summary', 
                       help='Output type: detail or summary.')
   parser.add_argument('--notation', type=str, required=False, default='derived', 
                       help='Output notation: raw or derived.')
+  
+  # check to make sure a value has not been passed for both filename and source
+  if (parser.parse_args().source != None and
+      parser.parse_args().source_file != None):
+      # executes if both conditions are true
+      raise ValueError("Cannot pass values to both source and source_file."
+                       " Value must be passed to either source or source_file.")
 
+  # check to see if file exists
+  if parser.parse_args().source_file != None:
+      source_file = str(parser.parse_args().source_file)
+      if not os.path.isfile(source_file):
+          print("The file named '{}' does not exist!\n".format(source_file))
+          parser.print_help()
+          parser.exit()
   # check if papi directory exists
-  source = str(parser.parse_args().source)
-  if os.path.isdir(source) == False:
-    print("Measurement directory '{}' does not exist!\n".format(source))
-    parser.print_help()
-    parser.exit()
+  elif parser.parse_args().source != None:
+      source = str(parser.parse_args().source)
+      if os.path.isdir(source) == False:
+          print("Measurement directory '{}' does not exist!\n".format(source))
+          parser.print_help()
+          parser.exit()
+  else:
+    raise ValueError("Provide a path to either a JSON file or a" 
+                     " dictionary which contains a JSON file.")
 
   # check format
   output_format = str(parser.parse_args().format)
@@ -540,5 +596,6 @@ if __name__ == '__main__':
   args = parse_args()
   main(format=args.format,
        source=args.source,
+       source_file=args.source_file,
        type=args.type,
        notation=args.notation)


### PR DESCRIPTION
## Pull Request Description
This PR adds an additional flag to `papi_hl_output_writer.py` titled `source_file`. This allows a user the flexibility to pass either a directory such as `papi_hl_output` which contains one or more `.json` files or a single `.json` file such as `rank_082041.json`. 

A few examples will be outlined below.

- Case 1: Passing an individual file to `papi_hl_output_writer.py`:
```
## code 
python3 papi_hl_output_writer.py --source_file rank_082041.json --notation=derived --type=summary
## output
{
    "computation": {
        "Region count": 1,
        "Real time in s": 0.0,
        "IPC": 0.43
    }
}
```
- Case 2: Error handling if a user passes an individual file and a directory to `papi_hl_output_writer.py`:
```
## code 
python3 papi_hl_output_writer.py --source papi_hl_output --source_file papi_hl_output/rank_082041.json --notation=derived --type=summary
## error output 
Cannot pass values to both source_dir and source_file. Value must be passed to either source_dir or source_file.
usage: papi_hl_output_writer.py [-h] [--source_dir SOURCE_DIR] [--source_file SOURCE_FILE] [--format FORMAT] [--type TYPE] [--notation NOTATION]

options:
  -h, --help            show this help message and exit
  --source_dir SOURCE_DIR
                        Measurement directory of raw data.
  --source_file SOURCE_FILE
                        Individual file containing measurements of raw data.
  --format FORMAT       Output format, e.g. json.
  --type TYPE           Output type: detail or summary.
  --notation NOTATION   Output notation: raw or derived.
```
- Case 3: Error handling if a user does not pass an individual file or a directory to `papi_hl_output_writer.py`:
```
## code
python3 papi_hl_output_writer.py --notation=derived --type=summary
## error output
Path to either a JSON file (--source_file) or a dictionary (--source_dir) which contains a JSON file is required.
usage: papi_hl_output_writer.py [-h] [--source_dir SOURCE_DIR] [--source_file SOURCE_FILE] [--format FORMAT] [--type TYPE] [--notation NOTATION]

options:
  -h, --help            show this help message and exit
  --source_dir SOURCE_DIR
                        Measurement directory of raw data.
  --source_file SOURCE_FILE
                        Individual file containing measurements of raw data.
  --format FORMAT       Output format, e.g. json.
  --type TYPE           Output type: detail or summary.
  --notation NOTATION   Output notation: raw or derived.
```

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
