### PR TITLE
Updating CAT Makefile to use PAPI_DIR Enviornment Variable

### DIFF
--- a/src/counter_analysis_toolkit/Makefile
+++ b/src/counter_analysis_toolkit/Makefile
@@ -1,5 +1,5 @@
 ARCH?=X86
-PAPIDIR?=${HOME}/usr
+PAPIDIR?=${PAPI_DIR}
 USEMPI?=false
 LDFLAGS=-L$(PAPIDIR)/lib -lpapi -lm -lpthread -ldl -lrt
 INCFLAGS=-I$(PAPIDIR)/include


### PR DESCRIPTION
## Pull Request Description
The CAT Makefile originally used `${HOME}/usr` as the path to link to files such as `papi.h`. However, if a users environment is not setup properly this path will not find the correct files such as `papi.h`. 

Instead of `${HOME}/usr` to be searched, the environment variable `PAPI_DIR` will now be used. This mirrors what the documentation suggests to do after a user installs PAPI. See 4. at the following [link](https://github.com/icl-utk-edu/papi/wiki/Downloading-and-Installing-PAPI).

Tested by running `make` within the `counter_analysis_toolkit` directory on Guyot and subsequently running `./cat_collect -in event_list.txt -out OUT_DIR -branch`. With `event_list.txt` containing `PAPI_TOT_INS 0`. Output can be seen below:
```
81.50
81.00
78.00
596.25
730.50
730.00
336.50
469.00
469.75
147.00
9.00
```

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
