### PR TITLE
Cuda Component Refactor

### DIFF
--- a/src/components/cuda/README_internal.md
+++ b/src/components/cuda/README_internal.md
@@ -1,0 +1,38 @@
+# Cuda Component Native Events in PAPI
+
+At current the Cuda component uses bits to create an Event identifier. The following internal README will be used to breakdown the encoding format.
+
+
+# Event Identifier Encoding Format
+
+## Unused bits
+As of 04/30/24, there are a total of 34 unused bits. These bits can be used to create a new qualifier or can be used to extended the number of bits for an existing qualifier.
+
+## Device
+7 bits are allocated for the device which accounts for 128 total devices on a node (e.g. [0 - 127 devices]).
+
+## Qlmask
+2 bits are allocated for the qualifier mask. 
+
+## Nameid
+21 bits are allocated for the nameid which will roughly account for greater than 2 million Cuda native events per device on a node.
+
+## Calculations for Bit Masks and Shifts
+| #DEFINE    | Bits |
+| -------- | ------- |
+| EVENTS_WIDTH  | `(sizeof(uint64_t) * 8)`    |
+| DEVICE_WIDTH | `( 7)`   |
+| QLMASK_WIDTH    | `( 2)`   |
+| NAMEID_WIDTH  | `(21)`    |
+| DEVICE_WIDTH | `( 7)`   |
+| UNUSED_WIDTH   | `(EVENTS_WIDTH - DEVICE_WIDTH - QLMASK_WIDTH - NAMEID_WIDTH)`   |
+| DEVICE_SHIFT  | `(EVENTS_WIDTH - UNUSED_WIDTH - DEVICE_WIDTH)`    |
+| QLMASK_SHIFT | `(DEVICE_SHIFT - QLMASK_WIDTH)`   |
+| NAMEID_SHIFT    | `(QLMASK_SHIFT - NAMEID_WIDTH)`   |
+| DEVICE_MASK  | `((0xFFFFFFFFFFFFFFFF >> (EVENTS_WIDTH - DEVICE_WIDTH)) << DEVICE_SHIFT)`    |
+| QLMASK_MASK | `((0xFFFFFFFFFFFFFFFF >> (EVENTS_WIDTH - QLMASK_WIDTH)) << QLMASK_SHIFT)`   |
+| NAMEID_MASK   | `((0xFFFFFFFFFFFFFFFF >> (EVENTS_WIDTH - NAMEID_WIDTH)) << NAMEID_SHIFT)`   |
+| DEVICE_FLAG  | `DEVICE_FLAG  (0x2)`   |
+
+
+**NOTE**: If adding a new qualifier, you must add it to the above [Calculations for Bit Masks and Shifts](#calculations-for-bit-masks-and-shifts) section and account for this addition within `cupti_profiler.c`. 

--- a/src/components/cuda/cupti_common.c
+++ b/src/components/cuda/cupti_common.c
@@ -656,3 +656,32 @@ int cuptic_device_release(cuptiu_event_table_t *evt_table)
     _papi_hwi_unlock(_cuda_lock);
     return PAPI_OK;
 }
+
+int cuptiu_dev_get_map(cuptiu_dev_get_map_cb query_dev_id, uint64_t *events_id, int num_events, cuptiu_bitmap_t *bitmap)
+{
+    int i;
+    cuptiu_bitmap_t device_map_acq = 0;
+
+    for (i = 0; i < num_events; ++i) {
+        int dev_id;
+        if (query_dev_id(events_id[i], &dev_id)) {
+            return PAPI_EMISC;
+        }
+
+        device_map_acq |= (1 << dev_id);
+    }
+
+    *bitmap = device_map_acq;
+    return PAPI_OK;
+}
+
+int cuptiu_dev_set(cuptiu_bitmap_t *bitmap, int i)
+{
+    *bitmap |= (1ULL << i);
+    return PAPI_OK;
+}
+
+int cuptiu_dev_check(cuptiu_bitmap_t bitmap, int i)
+{
+    return (bitmap & (1ULL << i));
+}

--- a/src/components/cuda/cupti_common.c
+++ b/src/components/cuda/cupti_common.c
@@ -657,12 +657,28 @@ int cuptic_device_release(cuptiu_event_table_t *evt_table)
     return PAPI_OK;
 }
 
+/** @class cuptiu_dev_set
+  * @brief For a Cuda native event, set the device ID.
+  *
+  * @param *bitmap
+  *   Device map.
+  * @param i
+  *   Device ID.
+*/
 int cuptiu_dev_set(cuptiu_bitmap_t *bitmap, int i)
 {
     *bitmap |= (1ULL << i);
     return PAPI_OK;
 }
 
+/** @class cuptiu_dev_check
+  * @brief For a Cuda native event, check for a valid device ID.
+  *
+  * @param *bitmap
+  *   Device map.
+  * @param i
+  *   Device ID.
+*/
 int cuptiu_dev_check(cuptiu_bitmap_t bitmap, int i)
 {
     return (bitmap & (1ULL << i));

--- a/src/components/cuda/cupti_common.c
+++ b/src/components/cuda/cupti_common.c
@@ -657,24 +657,6 @@ int cuptic_device_release(cuptiu_event_table_t *evt_table)
     return PAPI_OK;
 }
 
-int cuptiu_dev_get_map(cuptiu_dev_get_map_cb query_dev_id, uint64_t *events_id, int num_events, cuptiu_bitmap_t *bitmap)
-{
-    int i;
-    cuptiu_bitmap_t device_map_acq = 0;
-
-    for (i = 0; i < num_events; ++i) {
-        int dev_id;
-        if (query_dev_id(events_id[i], &dev_id)) {
-            return PAPI_EMISC;
-        }
-
-        device_map_acq |= (1 << dev_id);
-    }
-
-    *bitmap = device_map_acq;
-    return PAPI_OK;
-}
-
 int cuptiu_dev_set(cuptiu_bitmap_t *bitmap, int i)
 {
     *bitmap |= (1ULL << i);

--- a/src/components/cuda/cupti_common.h
+++ b/src/components/cuda/cupti_common.h
@@ -109,6 +109,5 @@ int cuptic_device_release(cuptiu_event_table_t *evt_table);
 
 int cuptiu_dev_set(cuptiu_bitmap_t *bitmap, int i);
 int cuptiu_dev_check(cuptiu_bitmap_t bitmap, int i);
-int cuptiu_dev_get_map(cuptiu_dev_get_map_cb query_dev_id, uint64_t *events_id, int num_events, cuptiu_bitmap_t *bitmap);
 
 #endif /* __CUPTI_COMMON_H__ */

--- a/src/components/cuda/cupti_common.h
+++ b/src/components/cuda/cupti_common.h
@@ -107,4 +107,8 @@ int cuptic_ctxarr_destroy(cuptic_info_t *pinfo);
 int cuptic_device_acquire(cuptiu_event_table_t *evt_table);
 int cuptic_device_release(cuptiu_event_table_t *evt_table);
 
+int cuptiu_dev_set(cuptiu_bitmap_t *bitmap, int i);
+int cuptiu_dev_check(cuptiu_bitmap_t bitmap, int i);
+int cuptiu_dev_get_map(cuptiu_dev_get_map_cb query_dev_id, uint64_t *events_id, int num_events, cuptiu_bitmap_t *bitmap);
+
 #endif /* __CUPTI_COMMON_H__ */

--- a/src/components/cuda/cupti_common.h
+++ b/src/components/cuda/cupti_common.h
@@ -107,6 +107,7 @@ int cuptic_ctxarr_destroy(cuptic_info_t *pinfo);
 int cuptic_device_acquire(cuptiu_event_table_t *evt_table);
 int cuptic_device_release(cuptiu_event_table_t *evt_table);
 
+/* functions to handle device qualifiers */
 int cuptiu_dev_set(cuptiu_bitmap_t *bitmap, int i);
 int cuptiu_dev_check(cuptiu_bitmap_t bitmap, int i);
 

--- a/src/components/cuda/cupti_dispatch.c
+++ b/src/components/cuda/cupti_dispatch.c
@@ -239,6 +239,16 @@ int cuptid_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info)
     return cuptip_evt_code_to_info(event_code, info);
 }
 
+int cuptid_evt_code_to_name(uint64_t event_code, char *name, int len)
+{
+    return cuptip_evt_code_to_name(event_code, name, len);
+}
+
+int cuptid_evt_name_to_code(const char *name, uint64_t *event_code)
+{
+    return cuptip_evt_name_to_code(name, event_code);
+}
+
 void cuptid_event_table_destroy(ntv_event_table_t *evt_table)
 {
     cuptiu_event_table_destroy(evt_table);

--- a/src/components/cuda/cupti_dispatch.c
+++ b/src/components/cuda/cupti_dispatch.c
@@ -249,6 +249,11 @@ int cuptid_evt_name_to_code(const char *name, uint64_t *event_code)
     return cuptip_evt_name_to_code(name, event_code);
 }
 
+int cuptid_get_num_qualified_evts(int *count, uint64_t event_code)
+{
+    return cuptip_get_num_qualified_evts(count, event_code);
+}
+
 void cuptid_event_table_destroy(ntv_event_table_t *evt_table)
 {
     cuptiu_event_table_destroy(evt_table);

--- a/src/components/cuda/cupti_dispatch.c
+++ b/src/components/cuda/cupti_dispatch.c
@@ -219,27 +219,19 @@ int cuptid_evt_enum(uint64_t *event_code, int modifier)
     return PAPI_ECMP;
 }
 
-int cuptid_event_name_to_descr(char *evt_name, char *descr)
-{
-    if (cuptic_is_runtime_perfworks_api()) {
-
-#if defined(API_PERFWORKS)
-        return cuptip_event_name_to_descr(evt_name, descr);
-#endif
-
-    } else if (cuptic_is_runtime_events_api()) {
-
-#if defined(API_EVENTS)
-        return cuptie_event_name_to_descr(evt_name, descr);
-#endif
-
-    }
-    return PAPI_ECMP;
-}
-
 int cuptid_evt_code_to_descr(uint64_t event_code, char *descr, int len)
 {
-    return cuptip_evt_code_to_descr(event_code, descr, len);
+    if (cuptic_is_runtime_perfworks_api()) {
+#if defined(API_PERFWORKS)
+        return cuptip_evt_code_to_descr(event_code, descr, len);
+#endif
+    } 
+    else if (cuptic_is_runtime_events_api()) {
+#if defined(API_EVENTS)
+        return cuptie_event_code_to_descr(event_code, descr, len);
+#endif
+    }
+    return PAPI_ECMP;
 }
 
 int cuptid_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info)

--- a/src/components/cuda/cupti_dispatch.c
+++ b/src/components/cuda/cupti_dispatch.c
@@ -257,9 +257,9 @@ int cuptid_event_table_find_name(ntv_event_table_t evt_table, const char *evt_na
     return cuptiu_event_table_find_name(evt_table, evt_name, found_rec);
 }
 
-int cuptid_event_table_insert_record(ntv_event_table_t evt_table, const char *evt_name, unsigned int evt_code, int evt_pos)
+int cuptid_event_table_insert_record(ntv_event_table_t evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices)
 {
-    return cuptiu_event_table_insert_record(evt_table, evt_name, evt_code, evt_pos);
+    return cuptiu_event_table_insert_record(evt_table, evt_name, evt_code, evt_pos, num_devices);
 }
 
 int cuptid_event_table_get_item(ntv_event_table_t evt_table, unsigned int evt_idx, ntv_event_t *record)

--- a/src/components/cuda/cupti_dispatch.c
+++ b/src/components/cuda/cupti_dispatch.c
@@ -237,6 +237,13 @@ int cuptid_event_name_to_descr(char *evt_name, char *descr)
     return PAPI_ECMP;
 }
 
+int cuptid_evt_name_to_info(char *evt_name, PAPI_event_info_t *info) 
+{
+
+    return cuptip_evt_name_to_info(evt_name, info);
+
+}
+
 void cuptid_event_table_destroy(ntv_event_table_t *evt_table)
 {
     cuptiu_event_table_destroy(evt_table);
@@ -257,9 +264,9 @@ int cuptid_event_table_find_name(ntv_event_table_t evt_table, const char *evt_na
     return cuptiu_event_table_find_name(evt_table, evt_name, found_rec);
 }
 
-int cuptid_event_table_insert_record(ntv_event_table_t evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices)
+int cuptid_event_table_insert_record(ntv_event_table_t evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices, char *qualifiers)
 {
-    return cuptiu_event_table_insert_record(evt_table, evt_name, evt_code, evt_pos, num_devices);
+    return cuptiu_event_table_insert_record(evt_table, evt_name, evt_code, evt_pos, num_devices, qualifiers);
 }
 
 int cuptid_event_table_get_item(ntv_event_table_t evt_table, unsigned int evt_idx, ntv_event_t *record)

--- a/src/components/cuda/cupti_dispatch.c
+++ b/src/components/cuda/cupti_dispatch.c
@@ -201,18 +201,18 @@ int cuptid_control_reset(cuptid_ctl_t cupti_ctl)
     return PAPI_ECMP;
 }
 
-int cuptid_event_enum(cuptiu_event_table_t *all_evt_names)
+int cuptid_evt_enum(uint64_t *event_code, int modifier)
 {
     if (cuptic_is_runtime_perfworks_api()) {
 
 #if defined(API_PERFWORKS)
-        return cuptip_event_enum(all_evt_names);
+        return cuptip_evt_enum(event_code, modifier);
 #endif
 
     } else if (cuptic_is_runtime_events_api()) {
 
 #if defined(API_EVENTS)
-        return cuptie_event_enum(all_evt_names);
+        return cuptie_evt_enum(event_code, modifier);
 #endif
 
     }
@@ -237,11 +237,14 @@ int cuptid_event_name_to_descr(char *evt_name, char *descr)
     return PAPI_ECMP;
 }
 
-int cuptid_evt_name_to_info(char *evt_name, PAPI_event_info_t *info) 
+int cuptid_evt_code_to_descr(uint64_t event_code, char *descr, int len)
 {
+    return cuptip_evt_code_to_descr(event_code, descr, len);
+}
 
-    return cuptip_evt_name_to_info(evt_name, info);
-
+int cuptid_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info)
+{
+    return cuptip_evt_code_to_info(event_code, info);
 }
 
 void cuptid_event_table_destroy(ntv_event_table_t *evt_table)
@@ -264,9 +267,9 @@ int cuptid_event_table_find_name(ntv_event_table_t evt_table, const char *evt_na
     return cuptiu_event_table_find_name(evt_table, evt_name, found_rec);
 }
 
-int cuptid_event_table_insert_record(ntv_event_table_t evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices, char *qualifiers, const char *cuda_name)
+int cuptid_event_table_insert_record(ntv_event_table_t evt_table, const char *evt_name, unsigned int evt_code, int evt_pos)
 {
-    return cuptiu_event_table_insert_record(evt_table, evt_name, evt_code, evt_pos, num_devices, qualifiers, cuda_name);
+    return cuptiu_event_table_insert_record(evt_table, evt_name, evt_code, evt_pos);
 }
 
 int cuptid_event_table_get_item(ntv_event_table_t evt_table, unsigned int evt_idx, ntv_event_t *record)

--- a/src/components/cuda/cupti_dispatch.c
+++ b/src/components/cuda/cupti_dispatch.c
@@ -264,9 +264,9 @@ int cuptid_event_table_find_name(ntv_event_table_t evt_table, const char *evt_na
     return cuptiu_event_table_find_name(evt_table, evt_name, found_rec);
 }
 
-int cuptid_event_table_insert_record(ntv_event_table_t evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices, char *qualifiers)
+int cuptid_event_table_insert_record(ntv_event_table_t evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices, char *qualifiers, const char *cuda_name)
 {
-    return cuptiu_event_table_insert_record(evt_table, evt_name, evt_code, evt_pos, num_devices, qualifiers);
+    return cuptiu_event_table_insert_record(evt_table, evt_name, evt_code, evt_pos, num_devices, qualifiers, cuda_name);
 }
 
 int cuptid_event_table_get_item(ntv_event_table_t evt_table, unsigned int evt_idx, ntv_event_t *record)

--- a/src/components/cuda/cupti_dispatch.h
+++ b/src/components/cuda/cupti_dispatch.h
@@ -33,7 +33,6 @@ int cuptid_evt_code_to_descr(uint64_t event_code, char *descr, int len);
 int cuptid_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info);
 int cuptid_evt_code_to_name(uint64_t event_code, char *name, int len);
 int cuptid_evt_name_to_code(const char *name, uint64_t *event_code);
-int cuptid_event_name_to_descr(char *evt_name, char *descr);
 
 void cuptid_event_table_destroy(ntv_event_table_t *evt_table);
 int cuptid_event_table_create(ntv_event_table_t *evt_table);

--- a/src/components/cuda/cupti_dispatch.h
+++ b/src/components/cuda/cupti_dispatch.h
@@ -41,4 +41,5 @@ int cuptid_event_table_find_name(ntv_event_table_t evt_table, const char *evt_na
 int cuptid_event_table_insert_record(ntv_event_table_t evt_table, const char *evt_name, unsigned int evt_code, int evt_pos);
 int cuptid_event_table_get_item(ntv_event_table_t evt_table, unsigned int evt_idx, ntv_event_t *record);
 
+int cuptid_get_num_qualified_evts(int *count, uint64_t event_code);
 #endif /* __CUPTI_DISPATCH_H__ */

--- a/src/components/cuda/cupti_dispatch.h
+++ b/src/components/cuda/cupti_dispatch.h
@@ -27,15 +27,17 @@ int cuptid_control_start(cuptid_ctl_t ctl);
 int cuptid_control_stop(cuptid_ctl_t ctl);
 int cuptid_control_read(cuptid_ctl_t ctl, long long *values);
 int cuptid_control_reset(cuptid_ctl_t ctl);
-int cuptid_event_enum(ntv_event_table_t all_evt_names);
+
+int cuptid_evt_enum(uint64_t *event_code, int modifier);
+int cuptid_evt_code_to_descr(uint64_t event_code, char *descr, int len);
+int cuptid_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info);
 int cuptid_event_name_to_descr(char *evt_name, char *descr);
-int cuptid_evt_name_to_info(char *evt_name, PAPI_event_info_t *info);
 
 void cuptid_event_table_destroy(ntv_event_table_t *evt_table);
 int cuptid_event_table_create(ntv_event_table_t *evt_table);
 int cuptid_event_table_select_by_idx(ntv_event_table_t src, int count, int *idcs, ntv_event_table_t *pevt_names);
 int cuptid_event_table_find_name(ntv_event_table_t evt_table, const char *evt_name, ntv_event_t *found_rec);
-int cuptid_event_table_insert_record(ntv_event_table_t evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices, char *qualifiers, const char *cuda_name);
+int cuptid_event_table_insert_record(ntv_event_table_t evt_table, const char *evt_name, unsigned int evt_code, int evt_pos);
 int cuptid_event_table_get_item(ntv_event_table_t evt_table, unsigned int evt_idx, ntv_event_t *record);
 
 #endif /* __CUPTI_DISPATCH_H__ */

--- a/src/components/cuda/cupti_dispatch.h
+++ b/src/components/cuda/cupti_dispatch.h
@@ -29,12 +29,13 @@ int cuptid_control_read(cuptid_ctl_t ctl, long long *values);
 int cuptid_control_reset(cuptid_ctl_t ctl);
 int cuptid_event_enum(ntv_event_table_t all_evt_names);
 int cuptid_event_name_to_descr(char *evt_name, char *descr);
+int cuptid_evt_name_to_info(char *evt_name, PAPI_event_info_t *info);
 
 void cuptid_event_table_destroy(ntv_event_table_t *evt_table);
 int cuptid_event_table_create(ntv_event_table_t *evt_table);
 int cuptid_event_table_select_by_idx(ntv_event_table_t src, int count, int *idcs, ntv_event_table_t *pevt_names);
 int cuptid_event_table_find_name(ntv_event_table_t evt_table, const char *evt_name, ntv_event_t *found_rec);
-int cuptid_event_table_insert_record(ntv_event_table_t evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices);
+int cuptid_event_table_insert_record(ntv_event_table_t evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices, char *qualifiers);
 int cuptid_event_table_get_item(ntv_event_table_t evt_table, unsigned int evt_idx, ntv_event_t *record);
 
 #endif /* __CUPTI_DISPATCH_H__ */

--- a/src/components/cuda/cupti_dispatch.h
+++ b/src/components/cuda/cupti_dispatch.h
@@ -31,6 +31,8 @@ int cuptid_control_reset(cuptid_ctl_t ctl);
 int cuptid_evt_enum(uint64_t *event_code, int modifier);
 int cuptid_evt_code_to_descr(uint64_t event_code, char *descr, int len);
 int cuptid_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info);
+int cuptid_evt_code_to_name(uint64_t event_code, char *name, int len);
+int cuptid_evt_name_to_code(const char *name, uint64_t *event_code);
 int cuptid_event_name_to_descr(char *evt_name, char *descr);
 
 void cuptid_event_table_destroy(ntv_event_table_t *evt_table);

--- a/src/components/cuda/cupti_dispatch.h
+++ b/src/components/cuda/cupti_dispatch.h
@@ -34,7 +34,7 @@ void cuptid_event_table_destroy(ntv_event_table_t *evt_table);
 int cuptid_event_table_create(ntv_event_table_t *evt_table);
 int cuptid_event_table_select_by_idx(ntv_event_table_t src, int count, int *idcs, ntv_event_table_t *pevt_names);
 int cuptid_event_table_find_name(ntv_event_table_t evt_table, const char *evt_name, ntv_event_t *found_rec);
-int cuptid_event_table_insert_record(ntv_event_table_t evt_table, const char *evt_name, unsigned int evt_code, int evt_pos);
+int cuptid_event_table_insert_record(ntv_event_table_t evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices);
 int cuptid_event_table_get_item(ntv_event_table_t evt_table, unsigned int evt_idx, ntv_event_t *record);
 
 #endif /* __CUPTI_DISPATCH_H__ */

--- a/src/components/cuda/cupti_dispatch.h
+++ b/src/components/cuda/cupti_dispatch.h
@@ -35,7 +35,7 @@ void cuptid_event_table_destroy(ntv_event_table_t *evt_table);
 int cuptid_event_table_create(ntv_event_table_t *evt_table);
 int cuptid_event_table_select_by_idx(ntv_event_table_t src, int count, int *idcs, ntv_event_table_t *pevt_names);
 int cuptid_event_table_find_name(ntv_event_table_t evt_table, const char *evt_name, ntv_event_t *found_rec);
-int cuptid_event_table_insert_record(ntv_event_table_t evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices, char *qualifiers);
+int cuptid_event_table_insert_record(ntv_event_table_t evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices, char *qualifiers, const char *cuda_name);
 int cuptid_event_table_get_item(ntv_event_table_t evt_table, unsigned int evt_idx, ntv_event_t *record);
 
 #endif /* __CUPTI_DISPATCH_H__ */

--- a/src/components/cuda/cupti_events.c
+++ b/src/components/cuda/cupti_events.c
@@ -50,7 +50,7 @@ int cuptie_control_reset(cuptie_control_t ctl)
     return PAPI_ENOIMPL;
 }
 
-int cuptie_event_enum(cuptiu_event_table_t *all_evt_names)
+int cuptie_evt_enum(uint64_t *event_code, int modifier)
 {
     return PAPI_ENOIMPL;
 }

--- a/src/components/cuda/cupti_events.c
+++ b/src/components/cuda/cupti_events.c
@@ -55,8 +55,7 @@ int cuptie_evt_enum(uint64_t *event_code, int modifier)
     return PAPI_ENOIMPL;
 }
 
-int cuptie_event_name_to_descr(const char *evt_name, char *description)
-{
+int cuptie_event_code_to_descr(uint64_t event_code, char *descr, int len) {
     return PAPI_ENOIMPL;
 }
 

--- a/src/components/cuda/cupti_events.h
+++ b/src/components/cuda/cupti_events.h
@@ -21,7 +21,7 @@ int cuptie_control_stop(cuptie_control_t ctl);
 int cuptie_control_read(cuptie_control_t ctl, long long *values);
 int cuptie_control_reset(cuptie_control_t ctl);
 int cuptie_evt_enum(uint64_t *event_code, int modifier);
-int cuptie_event_name_to_descr(const char *evt_name, char *description);
+int cuptie_event_code_to_descr(uint64_t event_code, char *descr, int len);
 int cuptie_shutdown(void);
 
 #endif  /* __CUPTI_EVENTS_H__ */

--- a/src/components/cuda/cupti_events.h
+++ b/src/components/cuda/cupti_events.h
@@ -9,6 +9,8 @@
 
 #include "cupti_utils.h"
 
+#include <stdint.h>
+
 typedef void *cuptie_control_t;
 
 int cuptie_init(void);
@@ -18,7 +20,7 @@ int cuptie_control_start(cuptie_control_t ctl);
 int cuptie_control_stop(cuptie_control_t ctl);
 int cuptie_control_read(cuptie_control_t ctl, long long *values);
 int cuptie_control_reset(cuptie_control_t ctl);
-int cuptie_event_enum(cuptiu_event_table_t *all_evt_names);
+int cuptie_evt_enum(uint64_t *event_code, int modifier);
 int cuptie_event_name_to_descr(const char *evt_name, char *description);
 int cuptie_shutdown(void);
 

--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -1214,15 +1214,7 @@ int cuptip_event_enum(cuptiu_event_table_t *all_evt_names)
     }
 
     /* Get total number of devices available and format output */
-    for (gpu_id = 0; gpu_id < num_gpus; gpu_id++) {
-        if (gpu_id != num_gpus - 1) {
-            length += sprintf(num_devices + length, "%c,", gpu_id + '0');       
-        }
-        else {
-            length += sprintf(num_devices + length, "%c", gpu_id + '0');
-        } 
-    }
-    sprintf(formatted_devices,"<%s>", num_devices);
+    cuptiu_get_num_devices(num_gpus, formatted_devices);
 
     for (gpu_id = 0; gpu_id < num_gpus; gpu_id++) {
         LOGDBG("Getting metric names for gpu %d\n", gpu_id);
@@ -1788,6 +1780,24 @@ int cuptiu_get_qualifier_name(const char *evt_name, char *qualifier_name, int le
         }
         snprintf( qualifier_name, len, "%s", evt_name );
     }
+
+    return PAPI_OK;
+}
+
+
+int cuptiu_get_num_devices(int number_of_gpus, char *formatted_devices) {
+    int gpu_id, length = 0;
+    char num_devices[number_of_gpus];
+
+    for (gpu_id = 0; gpu_id < number_of_gpus; gpu_id++) {
+        if (gpu_id != num_gpus - 1) {
+            length += sprintf( num_devices + length, "%c,", gpu_id + '0' );       
+        }
+        else {
+            length += sprintf( num_devices + length, "%c", gpu_id + '0' );
+        } 
+    }
+    sprintf( formatted_devices,"<%s>", num_devices );
 
     return PAPI_OK;
 }

--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -21,14 +21,14 @@
 
 /**
  * Event identifier encoding format:
- * +---------------------------------+-------+-------+--+------------+
- * |         unused                  |  dev  | inst  |  |   nameid   |
- * +---------------------------------+-------+-------+--+------------+
+ * +---------------------------------+-------+----+------------+
+ * |         unused                  |  dev  | ql |   nameid   |
+ * +---------------------------------+-------+----+------------+
  *
  * unused    : 34 bits 
  * device    : 7  bits ([0 - 127] devices)
  * qlmask    : 2  bits (qualifier mask)
- * nameid    : 21: bits ([0 - 263,231] event names)
+ * nameid    : 21: bits (roughly > 2 million event names)
  */
 #define EVENTS_WIDTH (sizeof(uint64_t) * 8)
 #define DEVICE_WIDTH ( 7)
@@ -42,7 +42,6 @@
 #define QLMASK_MASK  ((0xFFFFFFFFFFFFFFFF >> (EVENTS_WIDTH - QLMASK_WIDTH)) << QLMASK_SHIFT)
 #define NAMEID_MASK  ((0xFFFFFFFFFFFFFFFF >> (EVENTS_WIDTH - NAMEID_WIDTH)) << NAMEID_SHIFT)
 #define DEVICE_FLAG  (0x2)
-#define INSTAN_FLAG  (0x1)
 
 typedef struct {
     int device;

--- a/src/components/cuda/cupti_profiler.h
+++ b/src/components/cuda/cupti_profiler.h
@@ -20,7 +20,6 @@ int cuptip_control_read(cuptip_control_t state, long long *values);
 int cuptip_control_reset(cuptip_control_t state);
 int cuptip_event_name_to_descr(const char *evt_name, char *description);
 int cuptip_evt_enum(uint64_t *event_code, int modifier);
-int get_ntv_events(cuptiu_event_table_t *evt_table, const char *evt_name, unsigned int evt_code, int evt_pos);
 int cuptip_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info);
 int cuptip_evt_code_to_descr(uint64_t event_code, char *descr, int len);
 int init_event_table(void);

--- a/src/components/cuda/cupti_profiler.h
+++ b/src/components/cuda/cupti_profiler.h
@@ -20,7 +20,7 @@ int cuptip_control_read(cuptip_control_t state, long long *values);
 int cuptip_control_reset(cuptip_control_t state);
 int cuptip_event_enum(cuptiu_event_table_t *all_evt_names);
 int cuptip_event_name_to_descr(const char *evt_name, char *description);
-int cuptiu_get_basename(const char *evt_name, char *base, int len);
+int cuptiu_get_qualifier_name(const char *evt_name, char *qualifier_name, int len);
 int reconstruct_name(const char *name, char *base, int len);
 int cuptip_shutdown(void);
 #endif  /* __CUPTI_PROFILER_H__ */

--- a/src/components/cuda/cupti_profiler.h
+++ b/src/components/cuda/cupti_profiler.h
@@ -21,8 +21,8 @@ int cuptip_control_reset(cuptip_control_t state);
 int cuptip_event_enum(cuptiu_event_table_t *all_evt_names);
 int cuptip_event_name_to_descr(const char *evt_name, char *description);
 int cuptip_evt_name_to_info(const char *evt_name, PAPI_event_info_t *info);
-int cuptiu_get_parsed_evt_name(const char *evt_name, char *qualifier_name, int len);
+int cuptiu_format_evt_name(const char *evt_name, char *qualifier_name, char *qualifier, int len);
 int cuptiu_get_num_devices(int number_of_gpus, char *formatted_devices);
-int cuptiu_collect_qualifiers(int num_of_events,  const char * const*all_event_names, char **array_of_quals);
+int cuptiu_collect_qualifiers(int num_of_events,  const char * const*all_event_names, cuptiu_event_info_t *head, int len);
 int cuptip_shutdown(void);
 #endif  /* __CUPTI_PROFILER_H__ */

--- a/src/components/cuda/cupti_profiler.h
+++ b/src/components/cuda/cupti_profiler.h
@@ -26,4 +26,6 @@ int cuptip_evt_code_to_name(uint64_t event_code, char *name, int len);
 int cuptip_evt_name_to_code(const char *name, uint64_t *event_code);
 int init_event_table(void);
 int cuptip_shutdown(void);
+
+int cuptip_get_num_qualified_evts(int *count, uint64_t event_code);
 #endif  /* __CUPTI_PROFILER_H__ */

--- a/src/components/cuda/cupti_profiler.h
+++ b/src/components/cuda/cupti_profiler.h
@@ -20,8 +20,10 @@ int cuptip_control_read(cuptip_control_t state, long long *values);
 int cuptip_control_reset(cuptip_control_t state);
 int cuptip_event_enum(cuptiu_event_table_t *all_evt_names);
 int cuptip_event_name_to_descr(const char *evt_name, char *description);
+int cuptip_evt_name_to_info(const char *evt_name, PAPI_event_info_t *info);
 int cuptiu_get_qualifier_name(const char *evt_name, char *qualifier_name, int len);
 int cuptiu_get_num_devices(int number_of_gpus, char *formatted_devices);
+int cuptiu_collect_qualifiers(int num_of_events,  const char * const*all_event_names, char **array_of_quals);
 int reconstruct_name(const char *name, char *base, int len);
 int cuptip_shutdown(void);
 #endif  /* __CUPTI_PROFILER_H__ */

--- a/src/components/cuda/cupti_profiler.h
+++ b/src/components/cuda/cupti_profiler.h
@@ -21,6 +21,7 @@ int cuptip_control_reset(cuptip_control_t state);
 int cuptip_event_enum(cuptiu_event_table_t *all_evt_names);
 int cuptip_event_name_to_descr(const char *evt_name, char *description);
 int cuptiu_get_qualifier_name(const char *evt_name, char *qualifier_name, int len);
+int cuptiu_get_num_devices(int number_of_gpus, char *formatted_devices);
 int reconstruct_name(const char *name, char *base, int len);
 int cuptip_shutdown(void);
 #endif  /* __CUPTI_PROFILER_H__ */

--- a/src/components/cuda/cupti_profiler.h
+++ b/src/components/cuda/cupti_profiler.h
@@ -24,6 +24,5 @@ int cuptip_evt_name_to_info(const char *evt_name, PAPI_event_info_t *info);
 int cuptiu_get_qualifier_name(const char *evt_name, char *qualifier_name, int len);
 int cuptiu_get_num_devices(int number_of_gpus, char *formatted_devices);
 int cuptiu_collect_qualifiers(int num_of_events,  const char * const*all_event_names, char **array_of_quals);
-int reconstruct_name(const char *name, char *base, int len);
 int cuptip_shutdown(void);
 #endif  /* __CUPTI_PROFILER_H__ */

--- a/src/components/cuda/cupti_profiler.h
+++ b/src/components/cuda/cupti_profiler.h
@@ -18,11 +18,11 @@ int cuptip_control_start(cuptip_control_t state);
 int cuptip_control_stop(cuptip_control_t state);
 int cuptip_control_read(cuptip_control_t state, long long *values);
 int cuptip_control_reset(cuptip_control_t state);
-int cuptip_event_enum(cuptiu_event_table_t *all_evt_names);
 int cuptip_event_name_to_descr(const char *evt_name, char *description);
-int cuptip_evt_name_to_info(const char *evt_name, PAPI_event_info_t *info);
-int cuptiu_format_evt_name(const char *evt_name, char *qualifier_name, char *qualifier, int len);
-int cuptiu_get_num_devices(int number_of_gpus, char *formatted_devices);
-int cuptiu_collect_qualifiers(int num_of_events,  const char * const*all_event_names, cuptiu_event_info_t *head, int len);
+int cuptip_evt_enum(uint64_t *event_code, int modifier);
+int get_ntv_events(cuptiu_event_table_t *evt_table, const char *evt_name, unsigned int evt_code, int evt_pos);
+int cuptip_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info);
+int cuptip_evt_code_to_descr(uint64_t event_code, char *descr, int len);
+int init_event_table(void);
 int cuptip_shutdown(void);
 #endif  /* __CUPTI_PROFILER_H__ */

--- a/src/components/cuda/cupti_profiler.h
+++ b/src/components/cuda/cupti_profiler.h
@@ -20,5 +20,7 @@ int cuptip_control_read(cuptip_control_t state, long long *values);
 int cuptip_control_reset(cuptip_control_t state);
 int cuptip_event_enum(cuptiu_event_table_t *all_evt_names);
 int cuptip_event_name_to_descr(const char *evt_name, char *description);
+int cuptiu_get_basename(const char *evt_name, char *base, int len);
+int reconstruct_name(const char *name, char *base, int len);
 int cuptip_shutdown(void);
 #endif  /* __CUPTI_PROFILER_H__ */

--- a/src/components/cuda/cupti_profiler.h
+++ b/src/components/cuda/cupti_profiler.h
@@ -18,7 +18,7 @@ int cuptip_control_start(cuptip_control_t state);
 int cuptip_control_stop(cuptip_control_t state);
 int cuptip_control_read(cuptip_control_t state, long long *values);
 int cuptip_control_reset(cuptip_control_t state);
-int cuptip_event_name_to_descr(const char *evt_name, char *description);
+
 int cuptip_evt_enum(uint64_t *event_code, int modifier);
 int cuptip_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info);
 int cuptip_evt_code_to_descr(uint64_t event_code, char *descr, int len);

--- a/src/components/cuda/cupti_profiler.h
+++ b/src/components/cuda/cupti_profiler.h
@@ -22,6 +22,8 @@ int cuptip_event_name_to_descr(const char *evt_name, char *description);
 int cuptip_evt_enum(uint64_t *event_code, int modifier);
 int cuptip_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info);
 int cuptip_evt_code_to_descr(uint64_t event_code, char *descr, int len);
+int cuptip_evt_code_to_name(uint64_t event_code, char *name, int len);
+int cuptip_evt_name_to_code(const char *name, uint64_t *event_code);
 int init_event_table(void);
 int cuptip_shutdown(void);
 #endif  /* __CUPTI_PROFILER_H__ */

--- a/src/components/cuda/cupti_profiler.h
+++ b/src/components/cuda/cupti_profiler.h
@@ -21,7 +21,7 @@ int cuptip_control_reset(cuptip_control_t state);
 int cuptip_event_enum(cuptiu_event_table_t *all_evt_names);
 int cuptip_event_name_to_descr(const char *evt_name, char *description);
 int cuptip_evt_name_to_info(const char *evt_name, PAPI_event_info_t *info);
-int cuptiu_get_qualifier_name(const char *evt_name, char *qualifier_name, int len);
+int cuptiu_get_parsed_evt_name(const char *evt_name, char *qualifier_name, int len);
 int cuptiu_get_num_devices(int number_of_gpus, char *formatted_devices);
 int cuptiu_collect_qualifiers(int num_of_events,  const char * const*all_event_names, char **array_of_quals);
 int cuptip_shutdown(void);

--- a/src/components/cuda/cupti_utils.c
+++ b/src/components/cuda/cupti_utils.c
@@ -85,7 +85,7 @@ fn_exit:
     return papi_errno;
 }
 
-int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char *evt_name, unsigned int evt_code, int evt_pos)
+int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices)
 {
     int papi_errno = PAPI_OK;
 
@@ -101,6 +101,9 @@ int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char
     strcpy(evt_rec->name, evt_name);
     evt_rec->evt_code = evt_code;
     evt_rec->evt_pos = evt_pos;
+    if (num_devices != NULL)
+        strcpy(evt_rec->devices, num_devices);
+
     /* Insert entry in string hash table */
     if (HTABLE_SUCCESS != htable_insert(evt_table->htable, evt_name, evt_rec)) {
         return PAPI_ENOMEM;
@@ -130,7 +133,7 @@ int cuptiu_event_table_select_by_idx(cuptiu_event_table_t *src, int count, int *
             cuptiu_event_table_destroy(&target);
             goto fn_fail;
         }
-        papi_errno = cuptiu_event_table_insert_record(target, evt_rec->name, evt_rec->evt_code, evt_rec->evt_pos);
+        papi_errno = cuptiu_event_table_insert_record(target, evt_rec->name, evt_rec->evt_code, evt_rec->evt_pos, NULL);
         if (papi_errno != PAPI_OK) {
             cuptiu_event_table_destroy(&target);
             goto fn_fail;

--- a/src/components/cuda/cupti_utils.c
+++ b/src/components/cuda/cupti_utils.c
@@ -85,7 +85,7 @@ fn_exit:
     return papi_errno;
 }
 
-int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices)
+int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices, char *qualifiers)
 {
     int papi_errno = PAPI_OK;
 
@@ -103,6 +103,8 @@ int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char
     evt_rec->evt_pos = evt_pos;
     if (num_devices != NULL)
         strcpy(evt_rec->devices, num_devices);
+    if (qualifiers != NULL)
+        strcpy(evt_rec->quals, qualifiers);
 
     /* Insert entry in string hash table */
     if (HTABLE_SUCCESS != htable_insert(evt_table->htable, evt_name, evt_rec)) {
@@ -133,7 +135,7 @@ int cuptiu_event_table_select_by_idx(cuptiu_event_table_t *src, int count, int *
             cuptiu_event_table_destroy(&target);
             goto fn_fail;
         }
-        papi_errno = cuptiu_event_table_insert_record(target, evt_rec->name, evt_rec->evt_code, evt_rec->evt_pos, NULL);
+        papi_errno = cuptiu_event_table_insert_record(target, evt_rec->name, evt_rec->evt_code, evt_rec->evt_pos, NULL, NULL);
         if (papi_errno != PAPI_OK) {
             cuptiu_event_table_destroy(&target);
             goto fn_fail;

--- a/src/components/cuda/cupti_utils.c
+++ b/src/components/cuda/cupti_utils.c
@@ -85,7 +85,7 @@ fn_exit:
     return papi_errno;
 }
 
-int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices, char *qualifiers)
+int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices, char *qualifiers, const char *cuda_name)
 {
     int papi_errno = PAPI_OK;
 
@@ -98,6 +98,18 @@ int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char
     }
     /* Insert record in array */
     cuptiu_event_t *evt_rec = evt_table->evts + evt_table->count * evt_table->sizeof_rec;
+    /* loop through linked list and insert records */
+    /*
+    if (head != NULL) {
+        temp = head;
+        while (temp != NULL) {
+            evt_rec->evt_code = evt_code;
+            evt_rec->
+
+        }
+    }
+    */
+    /* Add metadata for event  */
     strcpy(evt_rec->name, evt_name);
     evt_rec->evt_code = evt_code;
     evt_rec->evt_pos = evt_pos;
@@ -105,6 +117,8 @@ int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char
         strcpy(evt_rec->devices, num_devices);
     if (qualifiers != NULL)
         strcpy(evt_rec->quals, qualifiers);
+    if (cuda_name != NULL)
+        strcpy(evt_rec->cuda_evt_name, cuda_name);
 
     /* Insert entry in string hash table */
     if (HTABLE_SUCCESS != htable_insert(evt_table->htable, evt_name, evt_rec)) {
@@ -135,7 +149,7 @@ int cuptiu_event_table_select_by_idx(cuptiu_event_table_t *src, int count, int *
             cuptiu_event_table_destroy(&target);
             goto fn_fail;
         }
-        papi_errno = cuptiu_event_table_insert_record(target, evt_rec->name, evt_rec->evt_code, evt_rec->evt_pos, NULL, NULL);
+        papi_errno = cuptiu_event_table_insert_record(target, evt_rec->name, evt_rec->evt_code, evt_rec->evt_pos, NULL, NULL, NULL);
         if (papi_errno != PAPI_OK) {
             cuptiu_event_table_destroy(&target);
             goto fn_fail;

--- a/src/components/cuda/cupti_utils.c
+++ b/src/components/cuda/cupti_utils.c
@@ -85,7 +85,7 @@ fn_exit:
     return papi_errno;
 }
 
-int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices, char *qualifiers, const char *cuda_name)
+int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char *evt_name, unsigned int evt_code, int evt_pos)
 {
     int papi_errno = PAPI_OK;
 
@@ -98,28 +98,9 @@ int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char
     }
     /* Insert record in array */
     cuptiu_event_t *evt_rec = evt_table->evts + evt_table->count * evt_table->sizeof_rec;
-    /* loop through linked list and insert records */
-    /*
-    if (head != NULL) {
-        temp = head;
-        while (temp != NULL) {
-            evt_rec->evt_code = evt_code;
-            evt_rec->
-
-        }
-    }
-    */
-    /* Add metadata for event  */
     strcpy(evt_rec->name, evt_name);
     evt_rec->evt_code = evt_code;
     evt_rec->evt_pos = evt_pos;
-    if (num_devices != NULL)
-        strcpy(evt_rec->devices, num_devices);
-    if (qualifiers != NULL)
-        strcpy(evt_rec->quals, qualifiers);
-    if (cuda_name != NULL)
-        strcpy(evt_rec->cuda_evt_name, cuda_name);
-
     /* Insert entry in string hash table */
     if (HTABLE_SUCCESS != htable_insert(evt_table->htable, evt_name, evt_rec)) {
         return PAPI_ENOMEM;
@@ -149,7 +130,7 @@ int cuptiu_event_table_select_by_idx(cuptiu_event_table_t *src, int count, int *
             cuptiu_event_table_destroy(&target);
             goto fn_fail;
         }
-        papi_errno = cuptiu_event_table_insert_record(target, evt_rec->name, evt_rec->evt_code, evt_rec->evt_pos, NULL, NULL, NULL);
+        papi_errno = cuptiu_event_table_insert_record(target, evt_rec->name, evt_rec->evt_code, evt_rec->evt_pos);
         if (papi_errno != PAPI_OK) {
             cuptiu_event_table_destroy(&target);
             goto fn_fail;

--- a/src/components/cuda/cupti_utils.h
+++ b/src/components/cuda/cupti_utils.h
@@ -11,7 +11,7 @@
 
 typedef struct event_record_s {
     char name[PAPI_2MAX_STR_LEN];
-    char cuda_event_names[PAPI_2MAX_STR_LEN];
+    char cuda_evt_name[PAPI_2MAX_STR_LEN];
     char devices[PAPI_2MAX_STR_LEN];
     char quals[PAPI_2MAX_STR_LEN];
     unsigned int evt_code;
@@ -19,6 +19,18 @@ typedef struct event_record_s {
     double value;
     char desc[PAPI_2MAX_STR_LEN];
 } cuptiu_event_t;
+
+typedef struct node {
+    char cuda_evt_name[PAPI_MAX_STR_LEN];
+    char name[PAPI_2MAX_STR_LEN];
+    char formatted_name[PAPI_MAX_STR_LEN];
+    char devices[PAPI_MAX_STR_LEN];
+    char list_of_qualifiers[PAPI_2MAX_STR_LEN];
+    unsigned int evt_code;
+    unsigned int evt_pos;
+    char desc[PAPI_2MAX_STR_LEN];
+    struct node * next;
+} cuptiu_event_info_t;
 
 typedef struct event_table_s {
     unsigned int sizeof_rec;
@@ -32,7 +44,7 @@ typedef struct event_table_s {
 int cuptiu_event_table_create(int sizeof_rec, cuptiu_event_table_t **pevt_table);
 int cuptiu_event_table_create_init_capacity(int capacity, int sizeof_rec, cuptiu_event_table_t **pevt_table);
 void cuptiu_event_table_destroy(cuptiu_event_table_t **pevt_table);
-int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices, char *qualifiers);
+int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices, char *qualifiers, const char *cuda_name);
 int cuptiu_event_table_select_by_idx(cuptiu_event_table_t *src, int count, int *idcs, cuptiu_event_table_t **pevt_names);
 int cuptiu_event_table_find_name(cuptiu_event_table_t *evt_table, const char *evt_name, cuptiu_event_t **found_rec);
 int cuptiu_event_table_get_item(cuptiu_event_table_t *evt_table, int evt_idx, cuptiu_event_t **record);

--- a/src/components/cuda/cupti_utils.h
+++ b/src/components/cuda/cupti_utils.h
@@ -13,7 +13,6 @@
 typedef int64_t cuptiu_bitmap_t;
 typedef int (*cuptiu_dev_get_map_cb)(uint64_t event_id, int *dev_id);
 
-
 typedef struct event_record_s {
     char name[PAPI_2MAX_STR_LEN];
     unsigned int evt_code;

--- a/src/components/cuda/cupti_utils.h
+++ b/src/components/cuda/cupti_utils.h
@@ -11,7 +11,9 @@
 
 typedef struct event_record_s {
     char name[PAPI_2MAX_STR_LEN];
+    char cuda_event_names[PAPI_2MAX_STR_LEN];
     char devices[PAPI_2MAX_STR_LEN];
+    char quals[PAPI_2MAX_STR_LEN];
     unsigned int evt_code;
     unsigned int evt_pos;
     double value;
@@ -30,7 +32,7 @@ typedef struct event_table_s {
 int cuptiu_event_table_create(int sizeof_rec, cuptiu_event_table_t **pevt_table);
 int cuptiu_event_table_create_init_capacity(int capacity, int sizeof_rec, cuptiu_event_table_t **pevt_table);
 void cuptiu_event_table_destroy(cuptiu_event_table_t **pevt_table);
-int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices);
+int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices, char *qualifiers);
 int cuptiu_event_table_select_by_idx(cuptiu_event_table_t *src, int count, int *idcs, cuptiu_event_table_t **pevt_names);
 int cuptiu_event_table_find_name(cuptiu_event_table_t *evt_table, const char *evt_name, cuptiu_event_t **found_rec);
 int cuptiu_event_table_get_item(cuptiu_event_table_t *evt_table, int evt_idx, cuptiu_event_t **record);

--- a/src/components/cuda/cupti_utils.h
+++ b/src/components/cuda/cupti_utils.h
@@ -11,31 +11,17 @@
 
 typedef struct event_record_s {
     char name[PAPI_2MAX_STR_LEN];
-    char cuda_evt_name[PAPI_2MAX_STR_LEN];
-    char devices[PAPI_2MAX_STR_LEN];
-    char quals[PAPI_2MAX_STR_LEN];
     unsigned int evt_code;
     unsigned int evt_pos;
     double value;
     char desc[PAPI_2MAX_STR_LEN];
 } cuptiu_event_t;
 
-typedef struct node {
-    char cuda_evt_name[PAPI_MAX_STR_LEN];
-    char name[PAPI_2MAX_STR_LEN];
-    char formatted_name[PAPI_MAX_STR_LEN];
-    char devices[PAPI_MAX_STR_LEN];
-    char list_of_qualifiers[PAPI_2MAX_STR_LEN];
-    unsigned int evt_code;
-    unsigned int evt_pos;
-    char desc[PAPI_2MAX_STR_LEN];
-    struct node * next;
-} cuptiu_event_info_t;
-
 typedef struct event_table_s {
     unsigned int sizeof_rec;
     unsigned int count;
     unsigned int capacity;
+    cuptiu_event_t *events;
     void *evts;
     void *htable;
 } cuptiu_event_table_t;
@@ -44,7 +30,7 @@ typedef struct event_table_s {
 int cuptiu_event_table_create(int sizeof_rec, cuptiu_event_table_t **pevt_table);
 int cuptiu_event_table_create_init_capacity(int capacity, int sizeof_rec, cuptiu_event_table_t **pevt_table);
 void cuptiu_event_table_destroy(cuptiu_event_table_t **pevt_table);
-int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices, char *qualifiers, const char *cuda_name);
+int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char *evt_name, unsigned int evt_code, int evt_pos);
 int cuptiu_event_table_select_by_idx(cuptiu_event_table_t *src, int count, int *idcs, cuptiu_event_table_t **pevt_names);
 int cuptiu_event_table_find_name(cuptiu_event_table_t *evt_table, const char *evt_name, cuptiu_event_t **found_rec);
 int cuptiu_event_table_get_item(cuptiu_event_table_t *evt_table, int evt_idx, cuptiu_event_t **record);

--- a/src/components/cuda/cupti_utils.h
+++ b/src/components/cuda/cupti_utils.h
@@ -8,6 +8,11 @@
 #define __CUPTI_UTILS_H__
 
 #include <papi.h>
+#include <stdint.h>
+
+typedef int64_t cuptiu_bitmap_t;
+typedef int (*cuptiu_dev_get_map_cb)(uint64_t event_id, int *dev_id);
+
 
 typedef struct event_record_s {
     char name[PAPI_2MAX_STR_LEN];
@@ -15,6 +20,7 @@ typedef struct event_record_s {
     unsigned int evt_pos;
     double value;
     char desc[PAPI_2MAX_STR_LEN];
+    cuptiu_bitmap_t device_map;
 } cuptiu_event_t;
 
 typedef struct event_table_s {

--- a/src/components/cuda/cupti_utils.h
+++ b/src/components/cuda/cupti_utils.h
@@ -11,6 +11,7 @@
 
 typedef struct event_record_s {
     char name[PAPI_2MAX_STR_LEN];
+    char devices[PAPI_2MAX_STR_LEN];
     unsigned int evt_code;
     unsigned int evt_pos;
     double value;
@@ -29,7 +30,7 @@ typedef struct event_table_s {
 int cuptiu_event_table_create(int sizeof_rec, cuptiu_event_table_t **pevt_table);
 int cuptiu_event_table_create_init_capacity(int capacity, int sizeof_rec, cuptiu_event_table_t **pevt_table);
 void cuptiu_event_table_destroy(cuptiu_event_table_t **pevt_table);
-int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char *evt_name, unsigned int evt_code, int evt_pos);
+int cuptiu_event_table_insert_record(cuptiu_event_table_t *evt_table, const char *evt_name, unsigned int evt_code, int evt_pos, char *num_devices);
 int cuptiu_event_table_select_by_idx(cuptiu_event_table_t *src, int count, int *idcs, cuptiu_event_table_t **pevt_names);
 int cuptiu_event_table_find_name(cuptiu_event_table_t *evt_table, const char *evt_name, cuptiu_event_t **found_rec);
 int cuptiu_event_table_get_item(cuptiu_event_table_t *evt_table, int evt_idx, cuptiu_event_t **record);

--- a/src/components/cuda/linux-cuda.c
+++ b/src/components/cuda/linux-cuda.c
@@ -236,7 +236,7 @@ static int cuda_ntv_name_to_code(const char *name, unsigned int *event_code)
     else {
         _papi_hwi_lock(COMPONENT_LOCK);
         *event_code = global_event_names->count;
-        papi_errno = cuptid_event_table_insert_record(global_event_names, name, global_event_names->count, 0, NULL, NULL);
+        papi_errno = cuptid_event_table_insert_record(global_event_names, name, global_event_names->count, 0, NULL, NULL, NULL);
         _papi_hwi_unlock(COMPONENT_LOCK);
     }
 fn_exit:
@@ -304,10 +304,6 @@ static int cuda_ntv_code_to_info(unsigned int event_code, PAPI_event_info_t *inf
         goto fn_exit;
     }
     papi_errno = cuptid_evt_name_to_info(evt_name, info);
-    if (papi_errno != PAPI_OK) {
-        printf("There is an issue with evt_name_to_info.");
-        goto fn_exit;
-    }
 fn_exit:
     return papi_errno;
 }

--- a/src/components/cuda/linux-cuda.c
+++ b/src/components/cuda/linux-cuda.c
@@ -234,7 +234,7 @@ static int cuda_ntv_name_to_code(const char *name, unsigned int *event_code)
     else {
         _papi_hwi_lock(COMPONENT_LOCK);
         *event_code = global_event_names->count;
-        papi_errno = cuptid_event_table_insert_record(global_event_names, name, global_event_names->count, 0);
+        papi_errno = cuptid_event_table_insert_record(global_event_names, name, global_event_names->count, 0, NULL);
         _papi_hwi_unlock(COMPONENT_LOCK);
     }
 fn_exit:


### PR DESCRIPTION
## Pull Request Description
This pull request addresses adding a device qualifier to the Cuda component. This will greatly decrease the number of native events that are output when running `./papi_native_avail`. For example, if running on Guyot which has a total of eight A100 NVIDIA GPUs. The total number of native events that are output is 2,105,856 with output currently being formatted as: 

```
===============================================================================
| cuda:::dram__bytes.avg:device=0                                              |     
|            # of bytes accessed in DRAM. Units=(bytes) Numpass=1              |     
--------------------------------------------------------------------------------
```

With adding a device qualifier to the Cuda component with this pull request, we would see the total number of native events on Guyot decreased to 263,232 with the updated output formatted as:

```
===============================================================================
| cuda:::dram__bytes.avg                                                       |
|            # of bytes accessed in DRAM. Units=(bytes) Numpass=1              |
|     :device=0                                                                |
|            Mandatory device qualifier [0,1,2,3,4,5,6,7]                      |
--------------------------------------------------------------------------------
```

Other example outputs will be shown below.

Hopper1 has a single NVIDIA GH200 GPU and output for that system appears as follows:
```
===============================================================================
| cuda:::FE_A.TriageCompute.gr__cycles_active.avg                              |
|            # of cycles where GR was active. Units=(sys_clks) Numpass=1       |
|     :device=0                                                                |
|            Mandatory device qualifier [0]                                    |
--------------------------------------------------------------------------------
```

Leconte has eight NVIDIA Tesla V100 GPUs and output for that system appears as follows:

```
===============================================================================
| cuda:::dram__bytes.avg                                                       |
|            # of bytes accessed in DRAM. Units=(bytes) Numpass=1              |
|     :device=0                                                                |
|            Mandatory device qualifier [0,1,2,3,4,5,6,7]                      |
--------------------------------------------------------------------------------
```

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
