### PR TITLE
Update:Use fgets in place of fscanf functions to avoid possible buffer overflows

### DIFF
--- a/src/components/sysdetect/linux_cpu_utils.c
+++ b/src/components/sysdetect/linux_cpu_utils.c
@@ -557,6 +557,7 @@ get_cache_type( const char *dirname, int *value )
 {
     char filename[BUFSIZ];
     char type_string[BUFSIZ];
+    char buffer[BUFSIZ];
     int type;
 
     sprintf(filename, "/sys/devices/system/cpu/cpu0/cache/%s/type",
@@ -568,12 +569,14 @@ get_cache_type( const char *dirname, int *value )
         return CPU_ERROR;
     }
 
-    char *result = fgets(type_string, BUFSIZ, fff);
+    char *result = fgets(buffer, BUFSIZ, fff);
     fclose(fff);
     if (result == NULL) {
         MEMDBG("Could not read cache type\n");
         return CPU_ERROR;
     }
+
+    sscanf(buffer,"%s",type_string);
 
     if (!strcmp(type_string, "Data")) {
         type = PAPI_MH_TYPE_DATA;

--- a/src/linux-memory.c
+++ b/src/linux-memory.c
@@ -1172,6 +1172,7 @@ generic_get_memory_info( PAPI_hw_info_t *hw_info )
 	char filename[BUFSIZ],type_string[BUFSIZ];
 	char *str_result;
 	char write_policy_string[BUFSIZ],allocation_policy_string[BUFSIZ];
+	char buffer[BUFSIZ];
 	struct dirent *d;
 	int max_level=0;
 	int level_count,level_index;
@@ -1247,12 +1248,13 @@ generic_get_memory_info( PAPI_hw_info_t *hw_info )
 			MEMDBG("Cannot open type\n");
 			goto unrecoverable_error;
 		}
-		str_result=fgets(type_string, BUFSIZ, fff);
+		str_result=fgets(buffer, BUFSIZ, fff);
 		fclose(fff);
 		if (str_result==NULL) {
 			MEMDBG("Could not read cache type\n");
 			goto unrecoverable_error;
 		}
+		sscanf(buffer,"%s",type_string);
 		if (!strcmp(type_string,"Data")) {
 			type=PAPI_MH_TYPE_DATA;
 		}
@@ -1274,12 +1276,13 @@ generic_get_memory_info( PAPI_hw_info_t *hw_info )
 			MEMDBG("Cannot open write_policy\n");
 			goto get_allocation_policy;
 		}
-		str_result=fgets(write_policy_string, BUFSIZ, fff);
+		str_result=fgets(buffer, BUFSIZ, fff);
 		fclose(fff);
 		if (str_result==NULL) {
 			MEMDBG("Could not read cache write_policy\n");
 			goto get_allocation_policy;
 		}
+		sscanf(buffer,"%s",write_policy_string);
 		if (!strcmp(write_policy_string,"WriteThrough")) {
 			write_policy=PAPI_MH_TYPE_WT;
 		}
@@ -1300,12 +1303,13 @@ get_allocation_policy:
 			MEMDBG("Cannot open allocation_policy\n");
 			goto get_size;
 		}
-		str_result=fgets(allocation_policy_string, BUFSIZ, fff);
+		str_result=fgets(buffer, BUFSIZ, fff);
 		fclose(fff);
 		if (str_result==NULL) {
 			MEMDBG("Could not read cache allocation_policy\n");
 			goto get_size;
 		}
+		sscanf(buffer,"%s",allocation_policy_string);
 		if (!strcmp(allocation_policy_string,"ReadAllocate")) {
 			allocation_policy=PAPI_MH_TYPE_RD_ALLOC;
 		}


### PR DESCRIPTION
Dear @gcongiu , @adanalis 
Dear papi library development team,

There was a bug in the buffer overflow fix below.
Use fgets in place of fscanf functions to avoid possible buffer overflows
https://github.com/icl-utk-edu/papi/commit/ec2aa022fee2a1d0decf1d5b2e7e28a4ca2cf794

The buffer overflow fix rewrites fscanf() to fgets(), 
but there is a difference in the specifications between fscanf() and fgets(): 
in fscanf(), "\n" is not read, but in fgets(), "\n" is also read, 
so it seems necessary to remove the unnecessary "\n" to do the same.
For this reason, generic_get_memory_info() could not obtain cache information 
strings from allocation_policy, type, and write_policy under 
the /sys/devices/system/cpu/cpu0/cache/index[012] directory as expected.

The buffer overflow update fix allows us to do the same thing as fscanf() 
by rewriting fscanf() to fgets()+sscanf().

Please review and merge these patches

Best regards.
Masahiko Yamada

## Pull Request Description

Update:Use fgets in place of fscanf functions to avoid possible buffer overflows

modify components/sysdetect/linux_cpu_utils.c
modify linux-memory.c

A problem occurred on cavium Thunderx2 that could not retrieve cache information 
from the/sys/devices/system/cpu/cpu0/cache directory.
The following commands have been verified to work correctly on cavium Thunderx2 
after this patch is applied.

papi_mem_info
ctests/memory
validation_tests/papi_l1_dcm
validation_tests/papi_l2_dcm
validation_tests/papi_l2_dcr
validation_tests/papi_l2_dcw

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
