### PR TITLE
Bug fix to correct behavior of --mem command line option for papi_avail.c

### DIFF
--- a/src/utils/papi_avail.c
+++ b/src/utils/papi_avail.c
@@ -357,7 +357,7 @@ main( int argc, char **argv )
       else if ( strstr( argv[args], "--l3" ) )
 	 filter |= PAPI_PRESET_BIT_L3;
       else if ( strstr( argv[args], "--mem" ) )
-	 filter |= PAPI_PRESET_BIT_BR;
+	 filter |= PAPI_PRESET_BIT_MEM;
       else if ( strstr( argv[args], "--msc" ) )
 	 filter |= PAPI_PRESET_BIT_MSC;
       else if ( strstr( argv[args], "--tlb" ) )


### PR DESCRIPTION
## Pull Request Description
Within `papi_avail.c` there is currently a small bug that occurs when passing `--mem` as the command line option. For example if you run `./papi_avail --mem` the output currently is: 

```bash
Available PAPI preset and user defined events plus hardware information.
--------------------------------------------------------------------------------
PAPI version             : 7.1.0.0
Operating system         : Linux 6.1.62-1.el9.elrepo.x86_64
Vendor string and code   : AuthenticAMD (2, 0x2)
Model string and code    : AMD EPYC 7742 64-Core Processor (49, 0x31)
CPU revision             : 0.000000
CPUID                    : Family/Model/Stepping 23/49/0, 0x17/0x31/0x00
CPU Max MHz              : 2250
CPU Min MHz              : 1500
Total cores              : 256
SMT threads per core     : 2
Cores per socket         : 64
Sockets                  : 2
Cores per NUMA region    : 32
NUMA regions             : 8
Running in a VM          : no
Number Hardware Counters : 5
Max Multiplex Counters   : 384
Fast counter read (rdpmc): yes
--------------------------------------------------------------------------------

================================================================================
  PAPI Preset Events
================================================================================
    Name        Code    Avail Deriv Description (Note)
PAPI_BRU_IDL 0x80000010  No    No   Cycles branch units are idle
PAPI_BTAC_M  0x8000001b  No    No   Branch target address cache misses
PAPI_BR_UCN  0x8000002a  No    No   Unconditional branch instructions
PAPI_BR_CN   0x8000002b  No    No   Conditional branch instructions
PAPI_BR_TKN  0x8000002c  Yes   No   Conditional branch instructions taken
PAPI_BR_NTK  0x8000002d  No    No   Conditional branch instructions not taken
PAPI_BR_MSP  0x8000002e  Yes   No   Conditional branch instructions mispredicted
PAPI_BR_PRC  0x8000002f  No    No   Conditional branch instructions correctly predicted
PAPI_BR_INS  0x80000037  Yes   No   Branch instructions
--------------------------------------------------------------------------------
Of 9 possible events, 3 are available, of which 0 are derived.
```
Which would be incorrect behavior since it returns PAPI preset events that are related to branches. 

To correct this behavior, the below code has been modified within `papi_avail.c`:
```c
else if ( strstr( argv[args], "--mem" ) )
    filter |= PAPI_PRESET_BIT_BR;
```
to

```c
else if ( strstr( argv[args], "--mem" ) )
    filter |= PAPI_PRESET_BIT_MEM;
```
With the updated code for `papi_avail.c` if you run `./papi_avail --mem` the output is now:

```bash
Available PAPI preset and user defined events plus hardware information.
--------------------------------------------------------------------------------
PAPI version             : 7.1.0.0
Operating system         : Linux 6.1.62-1.el9.elrepo.x86_64
Vendor string and code   : AuthenticAMD (2, 0x2)
Model string and code    : AMD EPYC 7742 64-Core Processor (49, 0x31)
CPU revision             : 0.000000
CPUID                    : Family/Model/Stepping 23/49/0, 0x17/0x31/0x00
CPU Max MHz              : 2250
CPU Min MHz              : 1500
Total cores              : 256
SMT threads per core     : 2
Cores per socket         : 64
Sockets                  : 2
Cores per NUMA region    : 32
NUMA regions             : 8
Running in a VM          : no
Number Hardware Counters : 5
Max Multiplex Counters   : 384
Fast counter read (rdpmc): yes
--------------------------------------------------------------------------------

================================================================================
  PAPI Preset Events
================================================================================
    Name        Code    Avail Deriv Description (Note)
PAPI_LSU_IDL 0x80000013  No    No   Cycles load/store units are idle
PAPI_CSR_FAL 0x8000001f  No    No   Failed store conditional instructions
PAPI_CSR_SUC 0x80000020  No    No   Successful store conditional instructions
PAPI_CSR_TOT 0x80000021  No    No   Total store conditional instructions
PAPI_MEM_SCY 0x80000022  No    No   Cycles Stalled Waiting for memory accesses
PAPI_MEM_RCY 0x80000023  No    No   Cycles Stalled Waiting for memory Reads
PAPI_MEM_WCY 0x80000024  No    No   Cycles Stalled Waiting for memory writes
PAPI_LD_INS  0x80000035  No    No   Load instructions
PAPI_SR_INS  0x80000036  No    No   Store instructions
PAPI_LST_INS 0x8000003c  No    No   Load/store instructions completed
--------------------------------------------------------------------------------
Of 10 possible events, 0 are available, of which 0 are derived.
```

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
