### PR TITLE
Updating Conditional Check to Avoid Accidentally Entering with --cache and --cnd for papi_avail.c

### DIFF
--- a/src/utils/papi_avail.c
+++ b/src/utils/papi_avail.c
@@ -326,7 +326,7 @@ main( int argc, char **argv )
 	 }
 	 name = argv[args + 1];
       }
-      else if ( strstr( argv[args], "-c" ) || strstr (argv[args], "--check") )
+      else if ( ( !strstr( argv[args], "--") && strstr( argv[args], "-c" ) ) || strstr(argv[args], "--check") )
       {
 	 print_avail_only = PAPI_PRESET_ENUM_AVAIL;
          check_counter = 1;


### PR DESCRIPTION
## Pull Request Description
This PR addresses updating a conditional check within `papi_avail.c` such that when passing either `--cache` or `--cnd` on the command line we do not accidentally enter. Which would result in output being incorrect. Please see Issue #183 for more details/output.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
