### PR TITLE
SDE_LIB: Build libsde.so.1.0 with the CFLAGS and LDFLAGS passed in

### DIFF
--- a/src/sde_lib/Makefile
+++ b/src/sde_lib/Makefile
@@ -1,7 +1,7 @@
 CC ?= gcc
 SDE_INC = -I. -I..
 SDE_LD = -ldl -pthread
-CFLAGS = -Wextra -Wall -O2
+CFLAGS += -Wextra -Wall -O2
 
 %_d.o: %.c
 		$(CC) -c -Bdynamic -fPIC -shared -fvisibility=hidden $(CFLAGS) $(SDE_INC) $< -o $@
@@ -14,7 +14,7 @@ SOBJS=$(patsubst %.c,%_s.o,$(wildcard *.c))
 all: dynamic static
 
 dynamic: $(DOBJS)
-	$(CC) -Bdynamic -fPIC -shared -Wl,-soname -Wl,libsde.so -fvisibility=hidden $(CFLAGS) $(DOBJS) -lrt -ldl -pthread -o libsde.so.1.0
+	$(CC) $(LDFLAGS) -Bdynamic -fPIC -shared -Wl,-soname -Wl,libsde.so -fvisibility=hidden $(CFLAGS) $(DOBJS) -lrt -ldl -pthread -o libsde.so.1.0
 	rm -f *_d.o
 
 static: $(SOBJS)


### PR DESCRIPTION
A recent annocheck of the papi RPMS showed that libsde.so.1.0 was not built with the expected flags passed into the RPM build.  Minor changes were made to src/sde_lib/Makefile to use the CFLAGS and LDFLAGS passed in.

## Pull Request Description

This is a revision of pull request #182 based on the discussion.


## Author Checklist
- [ x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ x] **Tests**
The PR needs to pass all the tests
