### PR TITLE
Update Allowed Modifiers for PAPI_enum_event 

### DIFF
--- a/src/papi.c
+++ b/src/papi.c
@@ -1664,34 +1664,6 @@ PAPI_event_name_to_code( const char *in, int *out )
  *	The following values are implemented for preset events
  *	<ul>
  *         <li> PAPI_PRESET_ENUM_AVAIL -- enumerate only available presets
- *         <li> PAPI_PRESET_ENUM_MSC   -- Miscellaneous preset events
- *         <li> PAPI_PRESET_ENUM_INS   -- Instruction related preset events
- *         <li> PAPI_PRESET_ENUM_IDL   -- Stalled or Idle preset events
- *         <li> PAPI_PRESET_ENUM_BR    -- Branch related preset events
- *         <li> PAPI_PRESET_ENUM_CND   -- Conditional preset events
- *         <li> PAPI_PRESET_ENUM_MEM   -- Memory related preset events
- *         <li> PAPI_PRESET_ENUM_CACH  -- Cache related preset events
- *         <li> PAPI_PRESET_ENUM_L1    -- L1 cache related preset events
- *         <li> PAPI_PRESET_ENUM_L2    -- L2 cache related preset events
- *         <li> PAPI_PRESET_ENUM_L3    -- L3 cache related preset events
- *         <li> PAPI_PRESET_ENUM_TLB   -- Translation Lookaside Buffer events
- *         <li> PAPI_PRESET_ENUM_FP    -- Floating Point related preset events
- *	</ul>
- *
- *	@par ITANIUM Modifiers
- *	The following values are implemented for modifier on Itanium: 
- *	<ul>
- *	   <li> PAPI_NTV_ENUM_IARR - Enumerate IAR (instruction address ranging) events 
- *	   <li> PAPI_NTV_ENUM_DARR - Enumerate DAR (data address ranging) events 
- *	   <li> PAPI_NTV_ENUM_OPCM - Enumerate OPC (opcode matching) events 
- *	   <li> PAPI_NTV_ENUM_IEAR - Enumerate IEAR (instr event address register) events 
- *	   <li> PAPI_NTV_ENUM_DEAR - Enumerate DEAR (data event address register) events
- *	</ul>
- *
- *	@par POWER Modifiers
- *	The following values are implemented for POWER
- *	<ul>
- *	   <li> PAPI_NTV_ENUM_GROUPS - Enumerate groups to which an event belongs
  *	</ul>
  *
  *	@see PAPI @n
@@ -1717,6 +1689,17 @@ PAPI_enum_event( int *EventCode, int modifier )
 
 	/* Do we handle presets in componets other than CPU? */
 	/* if (( IS_PRESET(i) ) && cidx > 0 )) return PAPI_ENOCMP; */
+
+    /* check to see if a valid modifier is provided */
+    if (modifier != PAPI_ENUM_EVENTS &&
+        modifier != PAPI_ENUM_FIRST &&
+        modifier != PAPI_ENUM_ALL &&
+        modifier != PAPI_PRESET_ENUM_AVAIL && 
+        modifier != PAPI_NTV_ENUM_UMASKS && 
+        modifier != PAPI_NTV_ENUM_UMASK_COMBOS)
+        {
+            return PAPI_EINVAL;
+        }
 		
 	if ( IS_PRESET(i) ) {
 		if ( modifier == PAPI_ENUM_FIRST ) {


### PR DESCRIPTION
## Pull Request Description
Pull requests updates `PAPI_enum_event(int * EventCode, int  modifer)` to: 

1. Update documentation to show modifiers that are allowed to be passed by a user
2. Add conditional check to make sure a valid modifier is provided

No internal code utilizes the ITANIUM/Power modifiers. Checked with Github's search functionality.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
