### PR TITLE
Update libpfm4 to commit 8b5634

### DIFF
--- a/src/libpfm4/lib/events/intel_adl_grt_events.h
+++ b/src/libpfm4/lib/events/intel_adl_grt_events.h
@@ -876,7 +876,7 @@ static const intel_x86_entry_t intel_adl_grt_pe[]={
   },
   { .name   = "INST_RETIRED",
     .desc   = "Counts the total number of instructions retired. (Fixed event)",
-    .code   = 0x0000,
+    .code   = 0x00c0,
     .modmsk = INTEL_V2_ATTRS,
     .cntmsk = 0x1ull,
     .ngrp   = 1,


### PR DESCRIPTION
## Pull Request Description
Current with
commit 4bdeb7e067363013257460bdb6c3dbae778b5634
Author: Stephane Eranian <eranian@gmail.com>
Date:   Fri Jun 14 22:14:05 2024 -0700

    Fix encoding of inst_retired.* on Alderlake E-core

    Was returning event code 0x0 for both .any and .any_p umasks.
    any_p refers to the generic counter encoding which uses event
    code 0xc0.

    Signed-off-by: Stephane Eranian <eranian@gmail.com>

Note: Unable to test due to the PAPI team not having access to a machine with Alderlake as of now.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
