### PR TITLE
Add Note in Doxygen Regarding Values Array in PAPI_accum() 

### DIFF
--- a/src/papi.c
+++ b/src/papi.c
@@ -3055,8 +3055,10 @@ PAPI_reset( int EventSet )
  *
  *  The counters continue counting after the read. 
  *
- *  Note the differences between PAPI_read() and PAPI_accum(), specifically
- *  that PAPI_accum() resets the values array to zero.
+ *  Note the differences between PAPI_read() and PAPI_accum(). Specifically,
+ *  PAPI_accum() adds the counter values to the values stored
+ *  in the array (the second parameter in PAPI_accum()) and then resets the counters
+ *  to zero.
  *
  *  PAPI_read() assumes an initialized PAPI library and a properly added 
  *  event set. 
@@ -3245,8 +3247,13 @@ PAPI_read_ts( int EventSet, long long *values, long long *cycles )
  *	These calls assume an initialized PAPI library and a properly added event set. 
  *	PAPI_accum adds the counters of the indicated event set into the array values. 
  *	The counters are zeroed and continue counting after the operation.
- *	Note the differences between PAPI_read and PAPI_accum, specifically 
- *	that PAPI_accum resets the values array to zero. 
+ *	Note the differences between PAPI_read() and PAPI_accum(). Specifically,
+ *	PAPI_accum() adds the counter values to the values stored in the array
+ *	(the second parameter in PAPI_accum()) and then resets the counters
+ *	to zero.
+ *
+ *	Note: The provided array (second parameter in PAPI_accum) must be initialized for PAPI_accum
+ *	because its values are read inside the function.
  *
  *	@param EventSet
  *		an integer handle for a PAPI Event Set 

--- a/src/papi.c
+++ b/src/papi.c
@@ -3056,8 +3056,8 @@ PAPI_reset( int EventSet )
  *  The counters continue counting after the read. 
  *
  *  Note the differences between PAPI_read() and PAPI_accum(). Specifically,
- *  PAPI_accum() adds the counter values to the values stored
- *  in the array (the second parameter in PAPI_accum()) and then resets the counters
+ *  PAPI_accum() adds the values of the counters to the values stored in the 
+ *  array (the second parameter in PAPI_accum()) and then resets the counters
  *  to zero.
  *
  *  PAPI_read() assumes an initialized PAPI library and a properly added 
@@ -3248,8 +3248,8 @@ PAPI_read_ts( int EventSet, long long *values, long long *cycles )
  *	PAPI_accum adds the counters of the indicated event set into the array values. 
  *	The counters are zeroed and continue counting after the operation.
  *	Note the differences between PAPI_read() and PAPI_accum(). Specifically,
- *	PAPI_accum() adds the counter values to the values stored in the array
- *	(the second parameter in PAPI_accum()) and then resets the counters
+ *	PAPI_accum() adds the values of the counters to the values stored in the
+ *	array (the second parameter in PAPI_accum()) and then resets the counters
  *	to zero.
  *
  *	Note: The provided array (second parameter in PAPI_accum) must be initialized for PAPI_accum


### PR DESCRIPTION
## Pull Request Description
Unlike for `PAPI_read()` and `PAPI_stop()` where the `values` array is only initialized (written) in these functions. `PAPI_accum()` must have the `values` array initialized, because its values are read in.

Due to not being able to check to see if the `values` array is initialized, we will document in the Doxygen that the `values` array must be initialized.

Programmer's Manual User Perspective (Doxygen):
![Screenshot 2024-06-27 at 2 37 00 PM](https://github.com/icl-utk-edu/papi/assets/88156797/8221e481-dfdd-4257-8343-b1e732d98a26)




## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
