### PR TITLE
rocm: fix event count to include qualifiers

### DIFF
--- a/src/components/rocm/roc_dispatch.c
+++ b/src/components/rocm/roc_dispatch.c
@@ -70,6 +70,12 @@ rocd_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info)
 }
 
 int
+rocd_get_num_qualified_evts(int *count, uint64_t event_code)
+{
+    return rocp_get_num_qualified_evts(count, event_code);
+}
+
+int
 rocd_err_get_last(const char **error_str)
 {
     return rocc_err_get_last(error_str);

--- a/src/components/rocm/roc_dispatch.h
+++ b/src/components/rocm/roc_dispatch.h
@@ -26,6 +26,7 @@ int rocd_evt_code_to_descr(uint64_t event_code, char *descr, int len);
 int rocd_evt_name_to_code(const char *name, uint64_t *event_code);
 int rocd_evt_code_to_name(uint64_t event_code, char *name, int len);
 int rocd_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info);
+int rocd_get_num_qualified_evts(int *count, uint64_t event_code);
 
 /* error handling interfaces */
 int rocd_err_get_last(const char **error_str);

--- a/src/components/rocm/roc_profiler.c
+++ b/src/components/rocm/roc_profiler.c
@@ -385,6 +385,35 @@ rocp_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info)
     return papi_errno;
 }
 
+/* rocp_get_num_qualified_evts - get number of events with a common basename */
+int
+rocp_get_num_qualified_evts(int *count, uint64_t event_code) {
+
+    int papi_errno;
+    int insts;
+    int subcount = 0;
+
+    event_info_t inf;
+    papi_errno = evt_id_to_info(event_code, &inf);
+    if (papi_errno != PAPI_OK) {
+        return papi_errno;
+    }
+
+    /* If there are no instances, only count the basename.
+     * Otherwise, count each instance. */
+    insts = ntv_table_p->events[inf.nameid].instances;
+    if( insts < 1 ) {
+        ++subcount;
+    } else {
+        subcount += ntv_table_p->events[inf.nameid].instances;
+    }
+
+    /* Account for all devices. */
+    *count += subcount * (device_table_p->count);
+
+    return PAPI_OK;
+}
+
 /* rocp_ctx_open - open a profiling context for the requested events */
 int
 rocp_ctx_open(uint64_t *events_id, int num_events, rocp_ctx_t *rocp_ctx)

--- a/src/components/rocm/roc_profiler.h
+++ b/src/components/rocm/roc_profiler.h
@@ -22,6 +22,7 @@ int rocp_evt_code_to_descr(uint64_t event_code, char *descr, int len);
 int rocp_evt_name_to_code(const char *name, uint64_t *event_code);
 int rocp_evt_code_to_name(uint64_t event_code, char *name, int len);
 int rocp_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info);
+int rocp_get_num_qualified_evts(int *count, uint64_t event_code);
 
 /* profiling context handling interfaces */
 int rocp_ctx_open(uint64_t *events_id, int num_events, rocp_ctx_t *ctx);

--- a/src/components/rocm/rocm.c
+++ b/src/components/rocm/rocm.c
@@ -179,12 +179,19 @@ static int
 evt_get_count(int *count)
 {
     uint64_t event_code = 0;
+    int papi_errno;
 
     if (rocd_evt_enum(&event_code, PAPI_ENUM_FIRST) == PAPI_OK) {
-        ++(*count);
+        papi_errno = rocd_get_num_qualified_evts(count, event_code);
+        if (papi_errno != PAPI_OK) {
+            return papi_errno;
+        }
     }
     while (rocd_evt_enum(&event_code, PAPI_ENUM_EVENTS) == PAPI_OK) {
-        ++(*count);
+        papi_errno = rocd_get_num_qualified_evts(count, event_code);
+        if (papi_errno != PAPI_OK) {
+            return papi_errno;
+        }
     }
 
     return PAPI_OK;


### PR DESCRIPTION
## Pull Request Description

These changes address Issue #203.

The event count previously only counted basenames. This has been changed to include all qualified event names.

These changes have been tested on the Frontier supercomputer (AMD MI250X GPU architecture) with ROCm version 5.3.0.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
