### PR TITLE
Fixed issue with building CUDA tests when linked with shared PAPI lib

### DIFF
--- a/src/components/cuda/tests/Makefile
+++ b/src/components/cuda/tests/Makefile
@@ -22,6 +22,7 @@ endif
 
 PAPI_FLAG = -DPAPI    # Comment this line for tests to run without PAPI profiling
 NVCFLAGS += -g -ccbin='$(CC)' $(PAPI_FLAG)
+CFLAGS += -g $(PAPI_FLAG)
 INCLUDE += -I$(PAPI_CUDA_ROOT)/include
 CUDALIBS = -L$(PAPI_CUDA_ROOT)/lib64 -lcudart -lcuda
 PAPILIB += -L../../../libpfm4/lib -lpfm
@@ -35,49 +36,43 @@ cuda_tests: $(TESTS) $(TESTS_NOCTX)
 	$(NVCC) $(INCLUDE) $(NVCFLAGS) -E -c -o $@ $<
 
 test_multi_read_and_reset: test_multi_read_and_reset.o $(UTILOBJS)
-	$(NVCC) $(NVCFLAGS) -o test_multi_read_and_reset test_multi_read_and_reset.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o test_multi_read_and_reset test_multi_read_and_reset.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
 concurrent_profiling: concurrent_profiling.o $(UTILOBJS)
-	$(NVCC) $(NVCFLAGS) -o concurrent_profiling concurrent_profiling.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
+	$(CXX) $(CFLAGS) -o concurrent_profiling concurrent_profiling.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
 concurrent_profiling_noCuCtx: concurrent_profiling_noCuCtx.o $(UTILOBJS)
-	$(NVCC) $(NVCFLAGS) -o concurrent_profiling_noCuCtx concurrent_profiling_noCuCtx.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
+	$(CXX) $(CFLAGS) -o concurrent_profiling_noCuCtx concurrent_profiling_noCuCtx.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
 pthreads: pthreads.o
-	$(NVCC) $(NVCFLAGS) -o pthreads pthreads.o -lpthread $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o pthreads pthreads.o -lpthread $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
 pthreads_noCuCtx: pthreads_noCuCtx.o
-	$(NVCC) $(NVCFLAGS) -o pthreads_noCuCtx pthreads_noCuCtx.o -lpthread $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o pthreads_noCuCtx pthreads_noCuCtx.o -lpthread $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
 cudaOpenMP: cudaOpenMP.o
-	$(NVCC) $(NVCFLAGS) -o cudaOpenMP cudaOpenMP.o -lgomp $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
-
-cudaOpenMP.o: cudaOpenMP.cu
-	$(NVCC) $(INCLUDE) $(NVCFLAGS) -c cudaOpenMP.cu -Xcompiler -fopenmp
+	$(CC) $(CFLAGS) -o cudaOpenMP cudaOpenMP.o -lgomp -fopenmp $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
 cudaOpenMP_noCuCtx: cudaOpenMP_noCuCtx.o
-	$(NVCC) $(NVCFLAGS) -o cudaOpenMP_noCuCtx cudaOpenMP_noCuCtx.o -lgomp $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
-
-cudaOpenMP_noCuCtx.o: cudaOpenMP_noCuCtx.cu
-	$(NVCC) $(INCLUDE) $(NVCFLAGS) -c cudaOpenMP_noCuCtx.cu -Xcompiler -fopenmp
+	$(CC) $(CFLAGS) -o cudaOpenMP_noCuCtx cudaOpenMP_noCuCtx.o -lgomp -fopenmp $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
 test_multipass_event_fail: test_multipass_event_fail.o $(UTILOBJS)
-	$(NVCC) $(NVCFLAGS) -o test_multipass_event_fail test_multipass_event_fail.o $(INCLUDE) $(UTILOBJS) $(PAPILIB) $(LDFLAGS) $(CUDALIBS)
+	$(CC) $(CFLAGS) -o test_multipass_event_fail test_multipass_event_fail.o $(INCLUDE) $(UTILOBJS) $(PAPILIB) $(LDFLAGS) $(CUDALIBS)
 
 test_2thr_1gpu_not_allowed: test_2thr_1gpu_not_allowed.o
-	$(NVCC) $(NVCFLAGS) -o test_2thr_1gpu_not_allowed test_2thr_1gpu_not_allowed.o -lpthread $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o test_2thr_1gpu_not_allowed test_2thr_1gpu_not_allowed.o -lpthread $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
 HelloWorld: HelloWorld.o $(UTILOBJS)
-	$(NVCC) $(NVCFLAGS) -o HelloWorld HelloWorld.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o HelloWorld HelloWorld.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
 HelloWorld_noCuCtx: HelloWorld_noCuCtx.o $(UTILOBJS)
-	$(NVCC) $(NVCFLAGS) -o HelloWorld_noCuCtx HelloWorld_noCuCtx.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o HelloWorld_noCuCtx HelloWorld_noCuCtx.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
-simpleMultiGPU: simpleMultiGPU.cu $(UTILOBJS)
-	$(NVCC) $(NVCFLAGS) $(INCLUDE) -o $@ $+ $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
+simpleMultiGPU: simpleMultiGPU.o $(UTILOBJS)
+	$(CC) $(CFLAGS) -o simpleMultiGPU simpleMultiGPU.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
-simpleMultiGPU_noCuCtx: simpleMultiGPU_noCuCtx.cu $(UTILOBJS)
-	$(NVCC) $(NVCFLAGS) $(INCLUDE) -g -o $@ $+ $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
+simpleMultiGPU_noCuCtx: simpleMultiGPU_noCuCtx.o $(UTILOBJS)
+	$(CC) $(CFLAGS) -o simpleMultiGPU_noCuCtx simpleMultiGPU_noCuCtx.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
 clean:
 	rm -f *.o $(TESTS) $(TESTS_NOCTX)


### PR DESCRIPTION
If CUDA tests are linked with the PAPI shared library (`.so`) (configure option `--with-shlib-tools`), the tests don't build because `nvcc` doesn't accept the `-Wl,-rpath` linker option.

To fix this issue, instead of linking with `nvcc`, we can link with the PAPI-chosen C compiler via the `CC` macro (or `CXX` macro for tests with C++ code).

Additionally, this PR cleans up other issues with tests (e.g., `cudaOpenMP.cu` and `cudaOpenMP_noCuCtx.cu`) by removing redundant explicit compilations, as the Makefile already includes a compilation rule. 

(Fixes #205, second part)

## Pull Request Description


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
