### PR TITLE
Cuda component fixes

### DIFF
--- a/src/components/cuda/linux-cuda.c
+++ b/src/components/cuda/linux-cuda.c
@@ -155,7 +155,7 @@ static int cuda_init_private(void)
     papi_errno = cuptid_init();
     if (papi_errno != PAPI_OK) {
         cuptid_disabled_reason_get(&disabled_reason);
-        sprintf(_cuda_vector.cmp_info.disabled_reason, disabled_reason);
+        sprintf(_cuda_vector.cmp_info.disabled_reason, "%s", disabled_reason);
         _cuda_vector.cmp_info.disabled = papi_errno;
         goto fn_exit;
     }

--- a/src/components/cuda/tests/Makefile
+++ b/src/components/cuda/tests/Makefile
@@ -13,7 +13,7 @@ TESTS_NOCTX = concurrent_profiling_noCuCtx pthreads_noCuCtx \
 			  simpleMultiGPU_noCuCtx
 
 NVCC = $(PAPI_CUDA_ROOT)/bin/nvcc
-NVCC_VERSION := $(shell nvcc --version | grep -oP '(?<=release )\d+\.\d+')
+NVCC_VERSION := $(shell $(NVCC) --version | grep -oP '(?<=release )\d+\.\d+')
 ifeq ($(shell echo "$(NVCC_VERSION) >= 11.6" | bc), 1)
     NVCFLAGS := -arch=native
 else


### PR DESCRIPTION
## Pull Request Description

When working through and trying to build locally build a PAPI RPM with the cuda component enabled, I found a couple minor issues in the cuda component that prevented it from being built:

1. An sprintf without a format string 
2. Assumption that nvcc would be on the default path

When runing "run_tests.sh" the ctests/all_native_events: took a number of hours to complete, but the tests eventually completed.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
