### PR TITLE
Removing conditional check for -arch=native flag.

### DIFF
--- a/src/components/cuda/tests/Makefile
+++ b/src/components/cuda/tests/Makefile
@@ -15,7 +15,7 @@ TESTS_NOCTX = concurrent_profiling_noCuCtx pthreads_noCuCtx \
 NVCC = $(PAPI_CUDA_ROOT)/bin/nvcc
 
 PAPI_FLAG = -DPAPI    # Comment this line for tests to run without PAPI profiling
-NVCFLAGS += -g -ccbin='$(CC)' $(PAPI_FLAG)
+NVCFLAGS = -g -ccbin='$(CC)' $(PAPI_FLAG)
 CFLAGS += -g $(PAPI_FLAG)
 INCLUDE += -I$(PAPI_CUDA_ROOT)/include
 CUDALIBS = -L$(PAPI_CUDA_ROOT)/lib64 -lcudart -lcuda

--- a/src/components/cuda/tests/Makefile
+++ b/src/components/cuda/tests/Makefile
@@ -13,12 +13,6 @@ TESTS_NOCTX = concurrent_profiling_noCuCtx pthreads_noCuCtx \
 			  simpleMultiGPU_noCuCtx
 
 NVCC = $(PAPI_CUDA_ROOT)/bin/nvcc
-NVCC_VERSION := $(shell $(NVCC) --version | grep -oP '(?<=release )\d+\.\d+')
-ifeq ($(shell echo "$(NVCC_VERSION) >= 11.6" | bc), 1)
-    NVCFLAGS := -arch=native
-else
-    NVCFLAGS :=
-endif
 
 PAPI_FLAG = -DPAPI    # Comment this line for tests to run without PAPI profiling
 NVCFLAGS += -g -ccbin='$(CC)' $(PAPI_FLAG)


### PR DESCRIPTION
## Pull Request Description
This PR removes the conditional block which determined if the `-arch=native` flag was used. There is no apparent difference to setting this flag or not.  See below for test output after removal of the conditional block.

#### Test running `simpleMultiGPU` in Cuda Component
Command line:
```
./simpleMultiGPU cuda:::dram__bytes.avg
```

Output:
```
Starting simpleMultiGPU
PAPI version: 7.1.0
CUDA-capable device count: 8
CUDA Device 0: Tesla V100-SXM2-32GB : computeCapability 7.0 runtimeVersion 12.1 driverVersion 12.5
CUDA Device 1: Tesla V100-SXM2-32GB : computeCapability 7.0 runtimeVersion 12.1 driverVersion 12.5
CUDA Device 2: Tesla V100-SXM2-32GB : computeCapability 7.0 runtimeVersion 12.1 driverVersion 12.5
CUDA Device 3: Tesla V100-SXM2-32GB : computeCapability 7.0 runtimeVersion 12.1 driverVersion 12.5
CUDA Device 4: Tesla V100-SXM2-32GB : computeCapability 7.0 runtimeVersion 12.1 driverVersion 12.5
CUDA Device 5: Tesla V100-SXM2-32GB : computeCapability 7.0 runtimeVersion 12.1 driverVersion 12.5
CUDA Device 6: Tesla V100-SXM2-32GB : computeCapability 7.0 runtimeVersion 12.1 driverVersion 12.5
CUDA Device 7: Tesla V100-SXM2-32GB : computeCapability 7.0 runtimeVersion 12.1 driverVersion 12.5
Generating input data...
Setup PAPI counters internally (PAPI)
Found CUDA Component at id 2
Add event success: 'cuda:::dram__bytes.avg:device=0' GPU 0
Add event success: 'cuda:::dram__bytes.avg:device=1' GPU 1
Add event success: 'cuda:::dram__bytes.avg:device=2' GPU 2
Add event success: 'cuda:::dram__bytes.avg:device=3' GPU 3
Add event success: 'cuda:::dram__bytes.avg:device=4' GPU 4
Add event success: 'cuda:::dram__bytes.avg:device=5' GPU 5
Add event success: 'cuda:::dram__bytes.avg:device=6' GPU 6
Add event success: 'cuda:::dram__bytes.avg:device=7' GPU 7
Computing with 8 GPUs...
Process GPU results on 8 GPUs...
PAPI counterValue        26491 		 --> cuda:::dram__bytes.avg:device=0 
PAPI counterValue        24344 		 --> cuda:::dram__bytes.avg:device=1 
PAPI counterValue        24144 		 --> cuda:::dram__bytes.avg:device=2 
PAPI counterValue        23583 		 --> cuda:::dram__bytes.avg:device=3 
PAPI counterValue        22175 		 --> cuda:::dram__bytes.avg:device=4 
PAPI counterValue        22783 		 --> cuda:::dram__bytes.avg:device=5 
PAPI counterValue        21681 		 --> cuda:::dram__bytes.avg:device=6 
PAPI counterValue        21450 		 --> cuda:::dram__bytes.avg:device=7 
  GPU Processing time: 3.043000 (ms)
Computing the same result with Host CPU...
  CPU Processing time: 4.527000 (ms) (speedup 1.49X)
Comparing GPU and Host CPU results...
  GPU sum: 777239.750000
  CPU sum: 777239.896331
  Relative difference: 1.882697E-07 
PASSED


```


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
