### PR TITLE
Updating format of export LD_LIBRARY_PATH= in Cuda component README

### DIFF
--- a/src/components/cuda/README.md
+++ b/src/components/cuda/README.md
@@ -67,7 +67,7 @@ standard `PAPI_CUDA_ROOT` subdirectories, you must add the correct paths,
 e.g. `/usr/lib64` or `/usr/lib` to `LD_LIBRARY_PATH`, separated by colons `:`.
 This can be set using export; e.g. 
 
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PAPI_CUDA_ROOT/lib64
+    export LD_LIBRARY_PATH=$PAPI_CUDA_ROOT/lib64:$LD_LIBRARY_PATH
 
 ## Known Limitations
 * In CUpti\_11, the number of possible events is vastly expanded; e.g. from
@@ -101,7 +101,7 @@ usually `/usr/lib64`, `/lib64`, `/usr/lib` and `/lib`.
 The system will also search the directories listed in `LD_LIBRARY_PATH`,
 separated by colons `:`. This can be set using export; e.g. 
 
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/WhereLib1CanBeFound:/WhereLib2CanBeFound
+    export LD_LIBRARY_PATH=/WhereLib1CanBeFound:/WhereLib2CanBeFound:$LD_LIBRARY_PATH
 
 * If CUDA libraries are installed on your system, such that the OS can find `nvcc`, the header files, and the shared libraries, then `PAPI_CUDA_ROOT` and `LD_LIBRARY_PATH` may not be necessary.
 


### PR DESCRIPTION
## Pull Request Description
Updates the Cuda component README to prepend necessary libraries to `LD_LIBRARY_PATH` instead of appending.

From:
```
export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PAPI_CUDA_ROOT/lib64
```
To:
```
export LD_LIBRARY_PATH=$PAPI_CUDA_ROOT/lib64:$LD_LIBRARY_PATH
```

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
