### PR TITLE
For papi_component_avail Count Only Base Event Names

### DIFF
--- a/src/components/rocm/roc_dispatch.c
+++ b/src/components/rocm/roc_dispatch.c
@@ -70,12 +70,6 @@ rocd_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info)
 }
 
 int
-rocd_get_num_qualified_evts(int *count, uint64_t event_code)
-{
-    return rocp_get_num_qualified_evts(count, event_code);
-}
-
-int
 rocd_err_get_last(const char **error_str)
 {
     return rocc_err_get_last(error_str);

--- a/src/components/rocm/roc_dispatch.h
+++ b/src/components/rocm/roc_dispatch.h
@@ -26,7 +26,6 @@ int rocd_evt_code_to_descr(uint64_t event_code, char *descr, int len);
 int rocd_evt_name_to_code(const char *name, uint64_t *event_code);
 int rocd_evt_code_to_name(uint64_t event_code, char *name, int len);
 int rocd_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info);
-int rocd_get_num_qualified_evts(int *count, uint64_t event_code);
 
 /* error handling interfaces */
 int rocd_err_get_last(const char **error_str);

--- a/src/components/rocm/roc_profiler.c
+++ b/src/components/rocm/roc_profiler.c
@@ -385,35 +385,6 @@ rocp_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info)
     return papi_errno;
 }
 
-/* rocp_get_num_qualified_evts - get number of events with a common basename */
-int
-rocp_get_num_qualified_evts(int *count, uint64_t event_code) {
-
-    int papi_errno;
-    int insts;
-    int subcount = 0;
-
-    event_info_t inf;
-    papi_errno = evt_id_to_info(event_code, &inf);
-    if (papi_errno != PAPI_OK) {
-        return papi_errno;
-    }
-
-    /* If there are no instances, only count the basename.
-     * Otherwise, count each instance. */
-    insts = ntv_table_p->events[inf.nameid].instances;
-    if( insts < 1 ) {
-        ++subcount;
-    } else {
-        subcount += ntv_table_p->events[inf.nameid].instances;
-    }
-
-    /* Account for all devices. */
-    *count += subcount * (device_table_p->count);
-
-    return PAPI_OK;
-}
-
 /* rocp_ctx_open - open a profiling context for the requested events */
 int
 rocp_ctx_open(uint64_t *events_id, int num_events, rocp_ctx_t *rocp_ctx)

--- a/src/components/rocm/roc_profiler.h
+++ b/src/components/rocm/roc_profiler.h
@@ -22,7 +22,6 @@ int rocp_evt_code_to_descr(uint64_t event_code, char *descr, int len);
 int rocp_evt_name_to_code(const char *name, uint64_t *event_code);
 int rocp_evt_code_to_name(uint64_t event_code, char *name, int len);
 int rocp_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info);
-int rocp_get_num_qualified_evts(int *count, uint64_t event_code);
 
 /* profiling context handling interfaces */
 int rocp_ctx_open(uint64_t *events_id, int num_events, rocp_ctx_t *ctx);

--- a/src/components/rocm/rocm.c
+++ b/src/components/rocm/rocm.c
@@ -179,19 +179,12 @@ static int
 evt_get_count(int *count)
 {
     uint64_t event_code = 0;
-    int papi_errno;
 
     if (rocd_evt_enum(&event_code, PAPI_ENUM_FIRST) == PAPI_OK) {
-        papi_errno = rocd_get_num_qualified_evts(count, event_code);
-        if (papi_errno != PAPI_OK) {
-            return papi_errno;
-        }
+        ++(*count);
     }
     while (rocd_evt_enum(&event_code, PAPI_ENUM_EVENTS) == PAPI_OK) {
-        papi_errno = rocd_get_num_qualified_evts(count, event_code);
-        if (papi_errno != PAPI_OK) {
-            return papi_errno;
-        }
+        ++(*count);
     }
 
     return PAPI_OK;


### PR DESCRIPTION
## Pull Request Description
This PR makes it such that only the base event names for a component will be count in output from `papi_component_avail` and `papi_native_avail`. Therefore, PR #204 is reverted to the original way the counting was done for `papi_component_avail`.

As of the PICL meeting on August 1st, 2024 it was discussed to only count base event names due to the complexity of getting the correct count. Reasons for this decision are:

1. A component such as `perf_event` could have an event with multiple combinations of qualifiers; therefore, getting the correct total event count would be difficult. 
2. As stands, we can accurately count base event names for both `papi_component_avail` and `papi_native_avail`. With the output matching between the two. 

## Output for `./papi_component_avail` on Frontier
```
[trebu@login04.frontier bin]$ srun --account=CSC617 --time=1 --nodes=1 --gpus=4 ./papi_component_avail
srun: job 2172859 queued and waiting for resources
srun: job 2172859 has been allocated resources
Available components and hardware information.
--------------------------------------------------------------------------------
PAPI version             : 7.1.0.0
Operating system         : Linux 5.14.21-150400.24.111_12.0.91-cray_shasta_c
Vendor string and code   : AuthenticAMD (2, 0x2)
Model string and code    : AMD EPYC 7A53 64-Core Processor (48, 0x30)
CPU revision             : 1.000000
CPUID                    : Family/Model/Stepping 25/48/1, 0x19/0x30/0x01
CPU Max MHz              : 2000
CPU Min MHz              : 1500
Total cores              : 128
SMT threads per core     : 2
Cores per socket         : 64
Sockets                  : 1
Cores per NUMA region    : 32
NUMA regions             : 4
Running in a VM          : no
Number Hardware Counters : 5
Max Multiplex Counters   : 384
Fast counter read (rdpmc): yes
--------------------------------------------------------------------------------

Compiled-in components:
Name:   perf_event              Linux perf_event CPU counters
Name:   perf_event_uncore       Linux perf_event CPU uncore and northbridge
   \-> Disabled: Insufficient permissions for uncore access.  Set /proc/sys/kernel/perf_event_paranoid to 0 or run as root.
Name:   rocm                    GPU events and metrics via AMD ROCm-PL API
Name:   sysdetect               System info detection component

Active components:
Name:   perf_event              Linux perf_event CPU counters
                                Native: 145, Preset: 27, Counters: 5
                                PMUs supported: perf, perf_raw, amd64_fam19h_zen3

Name:   rocm                    GPU events and metrics via AMD ROCm-PL API
                                Native: 397, Preset: 0, Counters: 397

Name:   sysdetect               System info detection component
                                Native: 0, Preset: 0, Counters: 0


--------------------------------------------------------------------------------
```
## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
