### PR TITLE
cuda: fix typo in README

### DIFF
--- a/src/components/cuda/README.md
+++ b/src/components/cuda/README.md
@@ -72,7 +72,7 @@ This can be set using export; e.g.
 ## Known Limitations
 * In CUpti\_11, the number of possible events is vastly expanded; e.g. from
   some hundreds of events per device to over 110,000 events per device. this can
-  make the utility `papi/src/utils/papi_native_events` run for several minutes;
+  make the utility `papi/src/utils/papi_native_avail` run for several minutes;
   as much as 2 minutes per GPU. If the output is redirected to a file, this 
   may appear to "hang up". Give it time.
 


### PR DESCRIPTION
## Pull Request Description
Corrected the name of the 'papi_native_avail' utility.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
