### PR TITLE
rocm: add reason for disabled component

### DIFF
--- a/src/components/rocm/roc_common.c
+++ b/src/components/rocm/roc_common.c
@@ -35,6 +35,11 @@ rocc_init(void)
 
     hsa_status_t status = hsa_init_p();
     if (status != HSA_STATUS_SUCCESS) {
+        int errMsgLen = snprintf(error_string, PAPI_MAX_STR_LEN, "%s",
+            "Call to hsa_init() failed. This could be due to ROCm devices failing to be detected.");
+        if( errMsgLen < 0 || errMsgLen >= PAPI_MAX_STR_LEN ) {
+            SUBDBG("error_string was truncated.\n");
+        }
         papi_errno = PAPI_EMISC;
         goto fn_fail;
     }

--- a/src/components/rocm/rocm.c
+++ b/src/components/rocm/rocm.c
@@ -221,16 +221,22 @@ rocm_init_private(void)
     papi_errno = evt_get_count(&count);
     _rocm_vector.cmp_info.num_native_events = count;
     _rocm_vector.cmp_info.num_cntrs = count;
+    _rocm_vector.cmp_info.initialized = 1;
+    int strLen = snprintf(_rocm_vector.cmp_info.disabled_reason, PAPI_MAX_STR_LEN, "%s", "");
+    if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+        SUBDBG("Failed to fully write disabled_reason.\n");
+    }
+
+    goto fn_exit;
+
+  fn_fail:
+    _rocm_vector.cmp_info.initialized = 0;
 
   fn_exit:
-    _rocm_vector.cmp_info.initialized = 1;
     _rocm_vector.cmp_info.disabled = papi_errno;
-    strcpy(_rocm_vector.cmp_info.disabled_reason, "");
     SUBDBG("EXIT: %s\n", PAPI_strerror(papi_errno));
     _papi_hwi_unlock(COMPONENT_LOCK);
     return papi_errno;
-  fn_fail:
-    goto fn_exit;
 }
 
 int


### PR DESCRIPTION
## Pull Request Description
Previously, in the absence of a ROCm device, the rocm component did not set the string containing the reason that the component was disabled. This corresponds to Issue https://github.com/icl-utk-edu/papi/issues/220.

These changes have been tested with ROCm 6.3.1 on Frontier and ROCm 6.3.2 on a system with no ROCm devices.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
