### PR TITLE
 run_tests.sh: Full Test only active components

### DIFF
--- a/src/run_tests.sh
+++ b/src/run_tests.sh
@@ -42,10 +42,21 @@ VTESTS=`find validation_tests/* -prune -perm -u+x -type f ! -name "*.[c|h]"`;
 #CTESTS=`find ctests -maxdepth 1 -perm -u+x -type f`;
 CTESTS=`find ctests/* -prune -perm -u+x -type f ! -name "*.[c|h]"`;
 FTESTS=`find ftests -perm -u+x -type f ! -name "*.[c|h|F]"`;
-COMPTESTS=`find components/*/tests -perm -u+x -type f ! \( -name "*.[c|h]" -o -name "*.cu" -o -name "*.so" \)`;
-#EXCLUDE=`grep --regexp=^# --invert-match run_tests_exclude.txt`
-EXCLUDE=`grep -v -e '^#\|^$' run_tests_exclude.txt`
 
+
+
+# List of active components
+ACTIVE_COMPONENTS_PATTERN=$(utils/papi_component_avail | awk '/Active components:/{flag=1; next} flag' | grep "Name:" | sed 's/Name: //' | awk '{print $1}' | paste -sd'|' -)
+
+# Find the test files, filtering for only the active components
+COMPTESTS=$(find components/*/tests -perm -u+x -type f ! \( -name "*.[c|h]" -o -name "*.cu" -o -name "*.so" \) | grep -E "components/($ACTIVE_COMPONENTS_PATTERN)/")
+
+# Find the test files, filtering for inactive components
+INACTIVE_COMPTESTS=$(find components/*/tests -perm -u+x -type f ! \( -name "*.[c|h]" -o -name "*.cu" -o -name "*.so" \) | grep -vE "components/($ACTIVE_COMPONENTS_PATTERN)/")
+
+#EXCLUDE=`grep --regexp=^# --invert-match run_tests_exclude.txt`
+EXCLUDE_TXT=`grep -v -e '^#\|^$' run_tests_exclude.txt`
+EXCLUDE="$EXCLUDE_TXT $INACTIVE_COMPTESTS";
 
 ALLTESTS="$VTESTS $CTESTS $FTESTS $COMPTESTS";
 


### PR DESCRIPTION
## Pull Request Description
Full Test only active components. In the run_tests.sh script, when checking for components tests filter for active/inactive components.

When the only active components are `perf_event, perf_event_uncore, and sysdetect`.

Command line:
`make fulltest`


```
The following test cases will be run:

validation_tests/cycles_validation validation_tests/flops_validation validation_tests/fp_validation_hl validation_tests/papi_br_cn validation_tests/papi_br_ins validation_tests/papi_br_msp validation_tests/papi_br_ntk validation_tests/papi_br_prc validation_tests/papi_br_tkn validation_tests/papi_br_ucn validation_tests/papi_dp_ops validation_tests/papi_fp_ops validation_tests/papi_hw_int validation_tests/papi_l1_dca validation_tests/papi_l1_dcm validation_tests/papi_l2_dca validation_tests/papi_l2_dcm validation_tests/papi_l2_dcr validation_tests/papi_l2_dcw validation_tests/papi_ld_ins validation_tests/papi_ref_cyc validation_tests/papi_sp_ops validation_tests/papi_sr_ins validation_tests/papi_tot_cyc validation_tests/papi_tot_ins ctests/all_events ctests/all_native_events ctests/attach2 ctests/attach3 ctests/attach_cpu ctests/attach_cpu_sys_validate ctests/attach_cpu_validate ctests/attach_validate ctests/branches ctests/byte_profile ctests/calibrate ctests/case1 ctests/case2 ctests/child_overflow ctests/clockres_pthreads ctests/cmpinfo ctests/code2name ctests/data_range ctests/derived ctests/describe ctests/destroy ctests/disable_component ctests/dmem_info ctests/earprofile ctests/eventname ctests/exec ctests/exec2 ctests/exec_overflow ctests/exeinfo ctests/failed_events ctests/first ctests/fork ctests/fork2 ctests/fork_overflow ctests/forkexec ctests/forkexec2 ctests/forkexec3 ctests/forkexec4 ctests/get_event_component ctests/hwinfo ctests/inherit ctests/johnmay2 ctests/krentel_pthreads ctests/kufrin ctests/locks_pthreads ctests/low-level ctests/max_multiplex ctests/memory ctests/mendes-alt ctests/multiattach ctests/multiattach2 ctests/multiplex1 ctests/multiplex1_pthreads ctests/multiplex2 ctests/multiplex3_pthreads ctests/omp_hl ctests/overflow ctests/overflow2 ctests/overflow3_pthreads ctests/overflow_allcounters ctests/overflow_force_software ctests/overflow_index ctests/overflow_one_and_read ctests/overflow_pthreads ctests/overflow_single_event ctests/overflow_twoevents ctests/p4_lst_ins ctests/profile ctests/profile_force_software ctests/profile_pthreads ctests/profile_twoevents ctests/pthread_hl ctests/pthrtough ctests/realtime ctests/remove_events ctests/reset ctests/reset_multiplex ctests/sdsc-mpx ctests/sdsc2-mpx ctests/sdsc2-mpx-noreset ctests/sdsc4-mpx ctests/second ctests/serial_hl ctests/serial_hl_ll_comb ctests/shlib ctests/sprofile ctests/system_child_overflow ctests/system_overflow ctests/tenth ctests/thrspecific ctests/version ctests/virttime ctests/zero ctests/zero_attach ctests/zero_flip ctests/zero_fork ctests/zero_named ctests/zero_omp ctests/zero_pthreads ctests/zero_shmem ctests/zero_smp ftests/case2 ftests/fmultiplex2 ftests/strtest ftests/johnmay2 ftests/fdmemtest ftests/eventname ftests/case1 ftests/fmultiplex1 ftests/zeronamed ftests/openmp ftests/second ftests/fmatrixlowpapi ftests/avail ftests/accum ftests/description ftests/clockres ftests/cost ftests/first ftests/tenth ftests/serial_hl ftests/zero components/perf_event/tests/perf_event_system_wide components/perf_event/tests/perf_event_user_kernel components/perf_event/tests/broken_events components/perf_event/tests/perf_event_offcore_response components/perf_event/tests/nmi_watchdog components/perf_event_uncore/tests/perf_event_uncore_multiple components/perf_event_uncore/tests/perf_event_uncore_cbox components/perf_event_uncore/tests/perf_event_uncore components/perf_event_uncore/tests/perf_event_uncore_attach components/perf_event_uncore/tests/perf_event_amd_northbridge components/sysdetect/tests/query_device_simple components/sysdetect/tests/query_device_simple_f


The following test cases will NOT be run:
ftests/Makefile.recipies ftests/Makefile ftests/Makefile.target.in ctests/Makefile.recipies ctests/Makefile ctests/Makefile.target.in ctests/Make-export components/infiniband/tests/Makefile components/cuda/tests/Makefile components/Makefile_comp_tests components/net/tests/Makefile components/lustre/tests/Makefile components/perf_event/tests/Makefile components/nvml/tests/Makefile components/perf_event_uncore/tests/Makefile components/rapl/tests/Makefile components/bcs/tests/Makefile components/sde/tests/Makefile components/sde/tests/README.txt components/intel_gpu/tests/readme.txt testlib/Makefile testlib/Makefile.target.in validation_tests/memleak_check ctests/cpi.pbs ctests/burn ctests/attach_target ctests/pthrtough2 ctests/timer_overflow ctests/omptough ctests/serial_hl_ll_comb2 ctests/mpi_hl ctests/mpi_omp_hl components/appio/tests/iozone/Gnuplot.txt components/appio/tests/iozone/Generate_Graphs components/appio/tests/iozone/report.pl components/appio/tests/iozone/iozone_visualizer.pl components/appio/tests/iozone/gengnuplot.sh components/appio/tests/iozone/gnu3d.dem components/cuda/tests/HelloWorld components/cuda/tests/test_multi_read_and_reset components/cuda/tests/pthreads_noCuCtx components/cuda/tests/cudaOpenMP_noCuCtx components/cuda/tests/pthreads components/cuda/tests/HelloWorld_noCuCtx components/cuda/tests/simpleMultiGPU_noCuCtx components/cuda/tests/concurrent_profiling components/cuda/tests/concurrent_profiling_noCuCtx components/cuda/tests/test_2thr_1gpu_not_allowed components/cuda/tests/cudaOpenMP components/cuda/tests/test_multipass_event_fail components/cuda/tests/simpleMultiGPU components/rocm/tests/hl_intercept_single_thread_monitoring components/rocm/tests/hl_sample_single_kernel_monitoring components/rocm/tests/hl_intercept_multi_thread_monitoring components/rocm/tests/hl_sample_single_thread_monitoring components/rocm/tests/hl_intercept_single_kernel_monitoring components/rocm/tests/intercept_single_kernel_monitoring components/rocm/tests/intercept_multi_kernel_monitoring components/rocm/tests/sample_multi_thread_monitoring components/rocm/tests/sample_single_kernel_monitoring components/rocm/tests/sample_multi_kernel_monitoring components/rocm/tests/intercept_multi_thread_monitoring components/rocm/tests/intercept_single_thread_monitoring components/rocm/tests/sample_overflow_monitoring components/rocm/tests/sample_single_thread_monitoring
```


##Issue
#221 

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
