### PR TITLE
Temporary fix for cuda version in CI

### DIFF
--- a/.github/workflows/spack.sh
+++ b/.github/workflows/spack.sh
@@ -14,7 +14,7 @@ export HOME=`pwd`
 git clone https://github.com/spack/spack spack || true
 source spack/share/spack/setup-env.sh
 
-SPEC="papi@master +lmsensors +powercap +sde +infiniband +rapl +cuda %$COMPILER"
+SPEC="papi@master +lmsensors +powercap +sde +infiniband +rapl +cuda %$COMPILER ^cuda@12.5.1"
 echo SPEC=$SPEC
 
 module load $COMPILER


### PR DESCRIPTION
## Pull Request Description

This temporarily fixes the version on cuda using the spack installation test to version 12.5.1 which is the currently highest version that works with papi.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
