### PR TITLE
intel_gpu: move destruction functions

### DIFF
--- a/src/components/intel_gpu/internal/src/GPUMetricHandler.cpp
+++ b/src/components/intel_gpu/internal/src/GPUMetricHandler.cpp
@@ -1230,18 +1230,6 @@ int GPUMetricHandler::EnableTimeBasedStream(uint32_t timePeriod, uint32_t numRep
 	} else {
 		DebugPrintError("EnableTimeBasedStream: failed on device [%p], status 0x%x\n", 
 						m_device, status);
-		if (m_metricStreamer) {
-			status = zetMetricStreamerCloseFunc(m_metricStreamer);
-			m_metricStreamer = nullptr;
-		}
-		if (m_event) {
-			status = zeEventDestroyFunc(m_event);
-			m_event = nullptr;
-		}
-		if (m_eventPool) {
-			status = zeEventPoolDestroyFunc(m_eventPool);
-			m_eventPool = nullptr;
-		}
 		status = zetContextActivateMetricGroupsFunc(m_context, m_device, 0, nullptr);
 		m_status = COLLECTION_INIT;
 		ret = 1;
@@ -1331,22 +1319,6 @@ int GPUMetricHandler::EnableEventBasedQuery()
 		ret  = 0;
 	} else {
 		DebugPrintError("EnableEventBasedQuery: failed with status 0x%x, abort.\n", status);
-		if (m_tracer) {
-			status = zetTracerExpDestroyFunc(m_tracer);
-			m_tracer = nullptr;
-		}
-		if (m_event) {
-			status = zeEventDestroyFunc(m_event);
-			m_event = nullptr;
-		}
-		if (m_eventPool) {
-			status = zeEventPoolDestroyFunc(m_eventPool);
-			m_eventPool = nullptr;
-		}
-		if (m_queryPool) {
-			status = zetMetricQueryPoolDestroyFunc(m_queryPool);
-			m_queryPool = nullptr;
-		}
 		status = zetContextActivateMetricGroupsFunc(m_context, m_device, 0, nullptr);
 		m_status = COLLECTION_INIT;
 		ret  = retError;
@@ -1374,31 +1346,6 @@ GPUMetricHandler::DisableMetricGroup()
 	   return;
 	}
 	m_status = COLLECTION_DISABLED;
-
-	if (m_groupType == ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_TIME_BASED) {
-		if (m_metricStreamer) {
-			zetMetricStreamerCloseFunc(m_metricStreamer);
-			m_metricStreamer = nullptr;
-		}
-	}
-	if (m_groupType == ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_EVENT_BASED) {
-		if (m_tracer) {
-			zetTracerExpDestroyFunc(m_tracer);
-			m_tracer = nullptr;
-		}
-		if (m_queryPool) {
-			zetMetricQueryPoolDestroyFunc(m_queryPool);
-			m_queryPool = nullptr;
-		}
-	}
-	if (m_event) {
-		zeEventDestroyFunc(m_event);
-		m_event = nullptr;
-	}
-	if (m_eventPool) {
-		zeEventPoolDestroyFunc(m_eventPool);
-		m_eventPool = nullptr;
-	}
 	zetContextActivateMetricGroupsFunc(m_context,  m_device, 0, nullptr);
 	m_lock.unlock();
 	return;

--- a/src/components/intel_gpu/linux_intel_gpu_metrics.c
+++ b/src/components/intel_gpu/linux_intel_gpu_metrics.c
@@ -284,11 +284,27 @@ intel_gpu_update_control_state( hwd_control_state_t *ctl,
 	(void)ctl;
 
 	// use local maintained context,
-	if (!count ||!native)  {
+	MetricContext *mContext = (MetricContext *)ctx;
+
+    /* This check accounts for calls to PAPI_destroy_eventset(). */
+	if ( !count )  {
+	    for (uint32_t i=0; i<mContext->num_devices; i++) {
+		    uint32_t dev_idx = mContext->active_devices[i];
+		    if (dev_idx >= num_active_devices) {
+			    return PAPI_ENOMEM;
+		    }
+		    DeviceContext *dev = &active_devices[dev_idx];
+		    DEVICE_HANDLE handle = dev->handle;
+            if( !handle ) {
+		        GPUFreeDevice(handle);
+            }
+	    }
 		return PAPI_OK;
 	}
 
-	MetricContext *mContext = (MetricContext *)ctx;
+	if ( !native ) {
+		return PAPI_OK;
+	}
 
 #if defined(_DEBUG)
 	for (int i=0; i<count; i++) {


### PR DESCRIPTION
## Pull Request Description
Implements PAPI_destroy_eventset() functionality for the intel_gpu component.
The functions used to free data structures used in the Level Zero API should only be called when an eventset is being destroyed; whereas, they were erroneously being called upon PAPI_stop().

This Pull Request addresses Issue #227.

These changes have been tested on the Intel Ponte Vecchio architecture.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
