### PR TITLE
Update libpfm4 to Commit e21e89

### DIFF
--- a/src/libpfm4/README
+++ b/src/libpfm4/README
@@ -78,7 +78,7 @@ The library supports many PMUs. The current version can handle:
 		ARMV7 Cortex A8
 		ARMV7 Cortex A9
 		ARMV7 Cortex A15
-		ARMV8 Cortex A57, A53
+		ARMV8 Cortex A57, A53, A72
 		Applied Micro X-Gene
 		Qualcomm Krait
 		Fujitsu A64FX

--- a/src/libpfm4/docs/Makefile
+++ b/src/libpfm4/docs/Makefile
@@ -146,6 +146,7 @@ ARCH_MAN += libpfm_arm_xgene.3 \
 	    libpfm_arm_ac7.3 \
 	    libpfm_arm_ac57.3 \
 	    libpfm_arm_ac53.3 \
+	    libpfm_arm_ac72.3 \
 	    libpfm_arm_ac15.3 \
 	    libpfm_arm_ac8.3 \
 	    libpfm_arm_ac9.3 \
@@ -160,6 +161,7 @@ ifeq ($(CONFIG_PFMLIB_ARCH_ARM64),y)
 ARCH_MAN += libpfm_arm_xgene.3 \
 	    libpfm_arm_ac57.3 \
 	    libpfm_arm_ac53.3 \
+	    libpfm_arm_ac72.3 \
 	    libpfm_arm_a64fx.3 \
 		libpfm_arm_neoverse_n1.3 \
 	    libpfm_arm_neoverse_n2.3 \

--- a/src/libpfm4/docs/man3/libpfm_arm_ac72.3
+++ b/src/libpfm4/docs/man3/libpfm_arm_ac72.3
@@ -1,0 +1,36 @@
+.TH LIBPFM 3  "September, 2024" "" "Linux Programmer's Manual"
+.SH NAME
+libpfm_arm_ac72 - support for Arm Cortex A72 PMU
+.SH SYNOPSIS
+.nf
+.B #include <perfmon/pfmlib.h>
+.sp
+.B PMU name: arm_ac72
+.B PMU desc: ARM Cortex A72
+.sp
+.SH DESCRIPTION
+The library supports the ARM Cortex A72 core PMU.
+
+This PMU supports 6 counters and privilege levels filtering.
+It can operate in both 32 and 64 bit modes.
+
+.SH MODIFIERS
+The following modifiers are supported on ARM Cortex A72:
+.TP
+.B u
+Measure at the user level. This corresponds to \fBPFM_PLM3\fR.
+This is a boolean modifier.
+.TP
+.B k
+Measure at the kernel level. This corresponds to \fBPFM_PLM0\fR.
+This is a boolean modifier.
+.TP
+.B hv
+Measure at the hypervisor level. This corresponds to \fBPFM_PLMH\fR.
+This is a boolean modifier.
+
+.SH AUTHORS
+.nf
+Stephane Eranian <eranian@gmail.com>
+.if
+.PP

--- a/src/libpfm4/include/perfmon/pfmlib.h
+++ b/src/libpfm4/include/perfmon/pfmlib.h
@@ -814,6 +814,8 @@ typedef enum {
 
 	PFM_PMU_AMD64_FAM1AH_ZEN5,      /* AMD64 Fam1Ah Zen5 */
 	PFM_PMU_AMD64_FAM1AH_ZEN5_L3,	/* AMD64 Fam1Ah Zen5 L3 */
+
+	PFM_PMU_ARM_CORTEX_A72,		/* ARM Cortex A72 (ARMv8) */
 	/* MUST ADD NEW PMU MODELS HERE */
 
 	PFM_PMU_MAX			/* end marker */

--- a/src/libpfm4/lib/events/intel_gnr_events.h
+++ b/src/libpfm4/lib/events/intel_gnr_events.h
@@ -709,7 +709,7 @@ static const intel_x86_umask_t intel_gnr_frontend_retired[]={
   },
   { .uname   = "LATE_SWPF",
     .udesc   = "I-Cache miss too close to Code Prefetch Instruction",
-    .ucode   = 0x0900ull,
+    .ucode   = 0x0a00ull,
     .uflags  = INTEL_X86_NCOMBO | INTEL_X86_PEBS,
   },
   { .uname   = "MISP_ANT",

--- a/src/libpfm4/lib/pfmlib_arm.c
+++ b/src/libpfm4/lib/pfmlib_arm.c
@@ -161,25 +161,22 @@ pfm_arm_detect(void *this)
 		ret = pfmlib_getcpuinfo_attr("CPU implementer", buffer, sizeof(buffer));
 		if (ret == -1)
 			return PFM_ERR_NOTSUPP;
+		pfm_arm_cfg.implementer = strtol(buffer, NULL, 16);
 	}
-
-        pfm_arm_cfg.implementer = strtol(buffer, NULL, 16);
    
 	if (pfm_arm_cfg.part == -1) {
 		ret = pfmlib_getcpuinfo_attr("CPU part", buffer, sizeof(buffer));
 		if (ret == -1)
 			return PFM_ERR_NOTSUPP;
+		pfm_arm_cfg.part = strtol(buffer, NULL, 16);
 	}
-
-	pfm_arm_cfg.part = strtol(buffer, NULL, 16);
 
 	if (pfm_arm_cfg.architecture == -1) {
 		ret = pfmlib_getcpuinfo_attr("CPU architecture", buffer, sizeof(buffer));
 		if (ret == -1)
 			return PFM_ERR_NOTSUPP;
+		pfm_arm_cfg.architecture = strtol(buffer, NULL, 16);
 	}
-
-	pfm_arm_cfg.architecture = strtol(buffer, NULL, 16);
    
 	return PFM_SUCCESS;
 }

--- a/src/libpfm4/lib/pfmlib_arm_armv8.c
+++ b/src/libpfm4/lib/pfmlib_arm_armv8.c
@@ -93,6 +93,22 @@ pfm_arm_detect_cortex_a57(void *this)
 }
 
 static int
+pfm_arm_detect_cortex_a72(void *this)
+{
+	int ret;
+
+	ret = pfm_arm_detect(this);
+	if (ret != PFM_SUCCESS)
+		return PFM_ERR_NOTSUPP;
+
+	if ((pfm_arm_cfg.implementer == 0x41) && /* ARM */
+		(pfm_arm_cfg.part == 0xd08)) { /* Cortex A57 */
+			return PFM_SUCCESS;
+	}
+	return PFM_ERR_NOTSUPP;
+}
+
+static int
 pfm_arm_detect_cortex_a53(void *this)
 {
 	int ret;
@@ -187,6 +203,32 @@ pfmlib_pmu_t arm_cortex_a57_support={
 	.pe			= arm_cortex_a57_pe,
 
 	.pmu_detect		= pfm_arm_detect_cortex_a57,
+	.max_encoding		= 1,
+	.num_cntrs		= 6,
+
+	.get_event_encoding[PFM_OS_NONE] = pfm_arm_get_encoding,
+	 PFMLIB_ENCODE_PERF(pfm_arm_get_perf_encoding),
+	.get_event_first	= pfm_arm_get_event_first,
+	.get_event_next		= pfm_arm_get_event_next,
+	.event_is_valid		= pfm_arm_event_is_valid,
+	.validate_table		= pfm_arm_validate_table,
+	.get_event_info		= pfm_arm_get_event_info,
+	.get_event_attr_info	= pfm_arm_get_event_attr_info,
+	 PFMLIB_VALID_PERF_PATTRS(pfm_arm_perf_validate_pattrs),
+	.get_event_nattrs	= pfm_arm_get_event_nattrs,
+};
+
+/* ARM Cortex A72 support */
+pfmlib_pmu_t arm_cortex_a72_support={
+	.desc			= "ARM Cortex A72",
+	.name			= "arm_ac72",
+	.pmu			= PFM_PMU_ARM_CORTEX_A72,
+	.pme_count		= LIBPFM_ARRAY_SIZE(arm_cortex_a57_pe), /* shared with a57 */
+	.type			= PFM_PMU_TYPE_CORE,
+	.supported_plm          = ARMV8_PLM,
+	.pe			= arm_cortex_a57_pe, /* shared with a57 */
+
+	.pmu_detect		= pfm_arm_detect_cortex_a72,
 	.max_encoding		= 1,
 	.num_cntrs		= 6,
 

--- a/src/libpfm4/lib/pfmlib_common.c
+++ b/src/libpfm4/lib/pfmlib_common.c
@@ -658,6 +658,7 @@ static pfmlib_pmu_t *pfmlib_pmus[]=
 	&arm_qcom_krait_support,
 	&arm_cortex_a57_support,
 	&arm_cortex_a53_support,
+	&arm_cortex_a72_support,
 	&arm_xgene_support,
 	&arm_thunderx2_support,
 	&arm_thunderx2_dmc0_support,
@@ -731,6 +732,7 @@ static pfmlib_pmu_t *pfmlib_pmus[]=
 #ifdef CONFIG_PFMLIB_ARCH_ARM64
 	&arm_cortex_a57_support,
 	&arm_cortex_a53_support,
+	&arm_cortex_a72_support,
 	&arm_xgene_support,
 	&arm_thunderx2_support,
 	&arm_thunderx2_dmc0_support,

--- a/src/libpfm4/lib/pfmlib_priv.h
+++ b/src/libpfm4/lib/pfmlib_priv.h
@@ -833,6 +833,7 @@ extern pfmlib_pmu_t arm_1176_support;
 extern pfmlib_pmu_t arm_qcom_krait_support;
 extern pfmlib_pmu_t arm_cortex_a57_support;
 extern pfmlib_pmu_t arm_cortex_a53_support;
+extern pfmlib_pmu_t arm_cortex_a72_support;
 extern pfmlib_pmu_t arm_xgene_support;
 extern pfmlib_pmu_t arm_n1_support;
 extern pfmlib_pmu_t arm_n2_support;

--- a/src/libpfm4/tests/validate_x86.c
+++ b/src/libpfm4/tests/validate_x86.c
@@ -9562,7 +9562,7 @@ static const test_event_t x86_test_events[]={
 	  .ret  = PFM_SUCCESS,
 	  .count = 2,
 	  .codes[0] = 0x5303c6,
-	  .codes[1] = 0x9,
+	  .codes[1] = 0xa,
 	  .fstr = "gnr::FRONTEND_RETIRED:LATE_SWPF:k=1:u=1:e=0:i=0:c=0:intx=0:intxcp=0:fe_thres=0",
 	},
 	{ SRC_LINE,


### PR DESCRIPTION
## Pull Request Description

Current with
commit 9c5c88e734e866f0801b80c527330ad6dbe21e89
Author: Stephane Eranian <eranian@gmail.com>
Date:   Tue Sep 10 23:58:35 2024 -0700

      add ARM Cortex A72 Core PMU support

      As a clone of Cortex A57.

      Signed-off-by: Stephane Eranian <eranian@gmail.com>

commit 6d276b48eba5ead4e3fd4b6eca359504f2b69b6c
Author: Ian Rogers <irogers@google.com>
Date:   Mon Sep 9 09:22:50 2024 -0700

    fix pfm_arm_detect() buffer initialization problem

    Commit 3abda5bc6c1a ("Optimize pfm_detect() for ARM processors")
    added an optimization to avoid parsing /proc/cpuinfo too many times.
    But it had a bug whereby it was reinitializing the pfm_arm_cfg.*
    fields multiple times and potentially from an uninitialized buffer.

    Signed-off-by: Ian Rogers <irogers@google.com>

commit fd3191c34ad87e22d3f3d31d2cf5c1050a9136ba
Author: Stephane Eranian <eranian@gmail.com>
Date:   Thu Sep 5 23:38:53 2024 -0700

     Fix FRONTEND_RETIRED.LATE_SWPF encoding on Intel GNR

     Fix was missing from commit d799b554647 ("update Intel GraniteRapids core PMU to 1.03")

     Signed-off-by: Stephane Eranian <eranian@gmail.com>

Note: As stands the PAPI team does not have access to a machine with either, Intel Granite Rapids or ARM Cortex A72 to test the updated changes mentioned above.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
