### PR TITLE
Configure | run_test.sh : Disable perf_event and perf_event_uncore

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -796,10 +796,12 @@ with_pfm_root
 with_pfm_prefix
 with_pfm_incdir
 with_pfm_libdir
+enable_cpu
+enable_perf_event
+enable_perf_event_uncore
 with_perf_events
 enable_perfevent_rdpmc
 with_pe_incdir
-enable_perf_event_uncore
 with_sysdetect
 with_components
 enable_fortran
@@ -1436,11 +1438,13 @@ Optional Features:
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --enable-warnings       Enable build with -Wall -Wextra (default: disabled)
+  --disable-cpu           Disable cpu component
+  --disable-perf-event    Disable perf_event component
+  --disable-perf-event-uncore
+                          Disable perf_event_uncore component
   --enable-perfevent-rdpmc
                           Enable userspace rdpmc instruction on perf_event,
                           default: yes
-  --disable-perf-event-uncore
-                          Disable perf_event uncore component
   --disable-fortran       Whether to disable fortran bindings
 
 Optional Packages:
@@ -4459,7 +4463,8 @@ rm -f core conftest.err conftest.$ac_objext \
 $as_echo "found" >&6; }
                         LRT="-lrt -lpthread"
                 else
-			as_fn_error $? "cannot find timer_create and timer_*ettime symbols neither in the base system libraries nor in -lrt, nor in -lrt -lpthread" "$LINENO" 5
+			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
+$as_echo "not found" >&6; }
 		fi
 	fi
 fi
@@ -5944,12 +5949,96 @@ fi
 #          Linux perf_event/perf_counter
 ##################################################
 
+perf_events=yes
+force_perf_events=no
+perf_events_uncore=yes
+
 if test "x$mic" = "xno"; then
        perf_events=no
 fi
 
-force_perf_events=no
-disable_uncore=yes
+awk '
+/^# validation_tests:[[:space:]]+\$\(LIBS\)[[:space:]]+testlib$/ { sub(/^# /, ""); print; next }
+/^# \t\$\(SETPATH\)[[:space:]]+\$\(MAKE\)[[:space:]]+-C[[:space:]]+validation_tests$/ { sub(/^# /, ""); print; next }
+# ctests lines
+/^# ctests:[[:space:]]+\$\(LIBS\)[[:space:]]+testlib[[:space:]]+validation_tests$/ { sub(/^# /, ""); print; next }
+/^# \t\$\(SETPATH\)[[:space:]]+\$\(MAKE\)[[:space:]]+-C[[:space:]]+ctests$/ { sub(/^# /, ""); print; next }
+# ftests lines
+/^# ftests:[[:space:]]+\$\(LIBS\)[[:space:]]+testlib$/ { sub(/^# /, ""); print; next }
+/^# \t\$\(SETPATH\)[[:space:]]+\$\(MAKE\)[[:space:]]+-C[[:space:]]+ftests$/ { sub(/^# /, ""); print; next }
+{ print }
+' "Makefile.inc" > "t_Makefile.inc"
+mv "t_Makefile.inc" "Makefile.inc"
+
+# Check whether --enable-cpu was given.
+if test "${enable_cpu+set}" = set; then :
+  enableval=$enable_cpu;
+fi
+
+
+if test "x$enable_cpu" = "xno"; then :
+
+	perf_events=no
+  force_perf_events=no
+  perf_events_uncore=no
+
+  FILE_PATH="Makefile.inc"
+  TEMP_FILE="temp_$FILE_PATH"
+
+  # Comment out lines to disable ctest ftest vtest
+  awk '
+    /^validation_tests:[:space:]+\$\(LIBS\)[:space:]+testlib$/ { print "# " $0; next }
+    /^\t\$\(SETPATH\)[:space:]+\$\(MAKE\)[:space:]+-C[:space:]+validation_tests$/ { print "# " $0; next }
+    /^ctests:[:space:]+\$\(LIBS\)[:space:]+testlib[:space:]+validation_tests$/ { print "# " $0; next }
+    /^\t\$\(SETPATH\)[:space:]+\$\(MAKE\)[:space:]+-C[:space:]+ctests$/ { print "# " $0; next }
+    /^ftests:[:space:]+\$\(LIBS\)[:space:]+testlib$/ { print "# " $0; next }
+    /^\t\$\(SETPATH\)[:space:]+\$\(MAKE\)[:space:]+-C[:space:]+ftests$/ { print "# " $0; next }
+    { print }
+    '  "$FILE_PATH" > "$TEMP_FILE"
+  mv "$TEMP_FILE" "$FILE_PATH"
+
+fi
+
+# Check whether --enable-perf_event was given.
+if test "${enable_perf_event+set}" = set; then :
+  enableval=$enable_perf_event;
+fi
+
+
+if test "x$enable_perf_event" = "xno"; then :
+
+	perf_events=no
+  force_perf_events=no
+
+  FILE_PATH="Makefile.inc"
+  TEMP_FILE="temp_$FILE_PATH"
+
+  awk '
+    /^validation_tests:[:space:]+\$\(LIBS\)[:space:]+testlib$/ { print "# " $0; next }
+    /^\t\$\(SETPATH\)[:space:]+\$\(MAKE\)[:space:]+-C[:space:]+validation_tests$/ { print "# " $0; next }
+    /^ctests:[:space:]+\$\(LIBS\)[:space:]+testlib[:space:]+validation_tests$/ { print "# " $0; next }
+    /^\t\$\(SETPATH\)[:space:]+\$\(MAKE\)[:space:]+-C[:space:]+ctests$/ { print "# " $0; next }
+    /^ftests:[:space:]+\$\(LIBS\)[:space:]+testlib$/ { print "# " $0; next }
+    /^\t\$\(SETPATH\)[:space:]+\$\(MAKE\)[:space:]+-C[:space:]+ftests$/ { print "# " $0; next }
+    { print }
+    '  "$FILE_PATH" > "$TEMP_FILE"
+  mv "$TEMP_FILE" "$FILE_PATH"
+
+fi
+
+# Check whether --enable-perf_event_uncore was given.
+if test "${enable_perf_event_uncore+set}" = set; then :
+  enableval=$enable_perf_event_uncore;
+fi
+
+
+if test "x$enable_perf_event_uncore" = "xno"; then :
+
+	perf_events_uncore=no
+
+
+fi
+
 
 
 # Check whether --with-perf_events was given.
@@ -5989,18 +6078,6 @@ else
 fi
 
 
-# Check whether --enable-perf_event_uncore was given.
-if test "${enable_perf_event_uncore+set}" = set; then :
-  enableval=$enable_perf_event_uncore;
-fi
-
-
-if test "x$enable_perf_event_uncore" != "xno"; then :
-
-	disable_uncore=no
-
-fi
-
 # Check for perf_event.h
   if test "$force_perf_events" = "yes"; then
 	perf_events="yes"
@@ -6024,7 +6101,7 @@ $as_echo "$ac_cv_file__proc_sys_kernel_perf_event_paranoid" >&6; }
 if test "x$ac_cv_file__proc_sys_kernel_perf_event_paranoid" = xyes; then :
 
 	  have_paranoid=yes
-	  as_ac_File=`$as_echo "ac_cv_file_$pe_incdir/perf_event.h" | $as_tr_sh`
+    as_ac_File=`$as_echo "ac_cv_file_$pe_incdir/perf_event.h" | $as_tr_sh`
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $pe_incdir/perf_event.h" >&5
 $as_echo_n "checking for $pe_incdir/perf_event.h... " >&6; }
 if eval \${$as_ac_File+:} false; then :
@@ -6042,7 +6119,11 @@ eval ac_res=\$$as_ac_File
 	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
 $as_echo "$ac_res" >&6; }
 if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
-  perf_events="yes"
+
+      if test "$perf_events" != "no"; then
+        perf_events="yes"
+      fi
+
 fi
 
 
@@ -6607,8 +6688,15 @@ elif test "$MAKEVER" = "linux-generic"; then
 elif test "$MAKEVER" = "linux-pe"; then
     FILENAME=Rules.pfm4_pe
     CPUCOMPONENT_NAME=perf_event
-    components="perf_event"
-    if test "$disable_uncore" = "no"; then
+    if test "$perf_events" = "no"; then
+        components="$components"
+    else
+        components="$components perf_event"
+    fi
+
+    if test "$perf_events_uncore" = "no"; then
+       components="$components"
+    else
        components="$components perf_event_uncore"
     fi
 
@@ -6739,6 +6827,7 @@ else
   with_sysdetect=yes
 fi
 
+# Enable sysdetect unless the user has explicitly told us not to.
 if test "$with_sysdetect" = "yes"; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
@@ -6758,8 +6847,14 @@ echo "" >> components_config.h
 
 # Check whether --with-components was given.
 if test "${with_components+set}" = set; then :
-  withval=$with_components; components="$components $withval"
+  withval=$with_components;
+        if test -n "${with_components//[[:space:]]/}"; then
+            components="$components $withval"
+        fi
+
+
 fi
+
 
 
 # This is an ugly hack to keep building on configurations covered by any-null in the past.
@@ -6776,7 +6871,7 @@ if test "$VECTOR" = "_papi_dummy_vector"; then
 		.num_native_events = 0,
 		.num_preset_events = 0,
 		.num_cntrs = 0,
-		.name = \"Your system is unsupported! \",
+		.name = \"No Components Configured. \",
 		.short_name = \"UNSUPPORTED!\"
 	},
 	.dispatch_timer = NULL,
@@ -6817,7 +6912,9 @@ fi
 
 # Enable sysdetect unless the user has explicitly told us not to.
 if test "$with_sysdetect" = "yes"; then
-  components="$components sysdetect"
+  if test "$perf_events" != "no"; then
+    components="$components sysdetect"
+    fi
 fi
 
 PAPI_NUM_COMP=0

--- a/src/configure.in
+++ b/src/configure.in
@@ -232,7 +232,7 @@ else
                         AC_MSG_RESULT([found])
                         LRT="-lrt -lpthread"
                 else
-			AC_MSG_ERROR([cannot find timer_create and timer_*ettime symbols neither in the base system libraries nor in -lrt, nor in -lrt -lpthread])
+			AC_MSG_RESULT([not found])
 		fi
 	fi
 fi
@@ -1172,12 +1172,84 @@ fi
 #          Linux perf_event/perf_counter
 ##################################################
 
+perf_events=yes
+force_perf_events=no
+perf_events_uncore=yes
+
 if test "x$mic" = "xno"; then
        perf_events=no
 fi
 
-force_perf_events=no
-disable_uncore=yes
+awk '
+/^# validation_tests:[[:space:]]+\$\(LIBS\)[[:space:]]+testlib$/ { sub(/^# /, ""); print; next }
+/^# \t\$\(SETPATH\)[[:space:]]+\$\(MAKE\)[[:space:]]+-C[[:space:]]+validation_tests$/ { sub(/^# /, ""); print; next }
+# ctests lines
+/^# ctests:[[:space:]]+\$\(LIBS\)[[:space:]]+testlib[[:space:]]+validation_tests$/ { sub(/^# /, ""); print; next }
+/^# \t\$\(SETPATH\)[[:space:]]+\$\(MAKE\)[[:space:]]+-C[[:space:]]+ctests$/ { sub(/^# /, ""); print; next }
+# ftests lines
+/^# ftests:[[:space:]]+\$\(LIBS\)[[:space:]]+testlib$/ { sub(/^# /, ""); print; next }
+/^# \t\$\(SETPATH\)[[:space:]]+\$\(MAKE\)[[:space:]]+-C[[:space:]]+ftests$/ { sub(/^# /, ""); print; next }
+{ print }
+' "Makefile.inc" > "t_Makefile.inc"
+mv "t_Makefile.inc" "Makefile.inc"
+
+AC_ARG_ENABLE(cpu,
+              [AS_HELP_STRING([--disable-cpu],
+              [Disable cpu component])])
+
+AS_IF([test "x$enable_cpu" = "xno"],[
+	perf_events=no
+  force_perf_events=no
+  perf_events_uncore=no
+
+  FILE_PATH="Makefile.inc"
+  TEMP_FILE="temp_$FILE_PATH"
+   
+  # Comment out lines to disable ctest ftest vtest
+  awk '
+    /^validation_tests:[[:space:]]+\$\(LIBS\)[[:space:]]+testlib$/ { print "# " $0; next } 
+    /^\t\$\(SETPATH\)[[:space:]]+\$\(MAKE\)[[:space:]]+-C[[:space:]]+validation_tests$/ { print "# " $0; next }
+    /^ctests:[[:space:]]+\$\(LIBS\)[[:space:]]+testlib[[:space:]]+validation_tests$/ { print "# " $0; next }
+    /^\t\$\(SETPATH\)[[:space:]]+\$\(MAKE\)[[:space:]]+-C[[:space:]]+ctests$/ { print "# " $0; next }
+    /^ftests:[[:space:]]+\$\(LIBS\)[[:space:]]+testlib$/ { print "# " $0; next }
+    /^\t\$\(SETPATH\)[[:space:]]+\$\(MAKE\)[[:space:]]+-C[[:space:]]+ftests$/ { print "# " $0; next }
+    { print }
+    '  "$FILE_PATH" > "$TEMP_FILE"
+  mv "$TEMP_FILE" "$FILE_PATH" 
+])
+
+AC_ARG_ENABLE(perf_event,
+              [AS_HELP_STRING([--disable-perf-event],
+              [Disable perf_event component])])
+
+AS_IF([test "x$enable_perf_event" = "xno"],[
+	perf_events=no
+  force_perf_events=no
+
+  FILE_PATH="Makefile.inc"
+  TEMP_FILE="temp_$FILE_PATH"
+   
+  awk '
+    /^validation_tests:[[:space:]]+\$\(LIBS\)[[:space:]]+testlib$/ { print "# " $0; next } 
+    /^\t\$\(SETPATH\)[[:space:]]+\$\(MAKE\)[[:space:]]+-C[[:space:]]+validation_tests$/ { print "# " $0; next }
+    /^ctests:[[:space:]]+\$\(LIBS\)[[:space:]]+testlib[[:space:]]+validation_tests$/ { print "# " $0; next }
+    /^\t\$\(SETPATH\)[[:space:]]+\$\(MAKE\)[[:space:]]+-C[[:space:]]+ctests$/ { print "# " $0; next }
+    /^ftests:[[:space:]]+\$\(LIBS\)[[:space:]]+testlib$/ { print "# " $0; next }
+    /^\t\$\(SETPATH\)[[:space:]]+\$\(MAKE\)[[:space:]]+-C[[:space:]]+ftests$/ { print "# " $0; next }
+    { print }
+    '  "$FILE_PATH" > "$TEMP_FILE"
+  mv "$TEMP_FILE" "$FILE_PATH" 
+])
+
+AC_ARG_ENABLE(perf_event_uncore,
+              [AS_HELP_STRING([--disable-perf-event-uncore],
+              [Disable perf_event_uncore component])])
+
+AS_IF([test "x$enable_perf_event_uncore" = "xno"],[
+	perf_events_uncore=no
+
+])
+
 
 AC_ARG_WITH(perf_events,
             [AS_HELP_STRING([--with-perf-events],
@@ -1210,14 +1282,6 @@ AC_ARG_WITH(pe_incdir,
               user_specified_interface=pe],
             [pe_incdir=$pfm_incdir/perfmon])
 
-AC_ARG_ENABLE(perf_event_uncore,
-              [AS_HELP_STRING([--disable-perf-event-uncore],
-              [Disable perf_event uncore component])])
-
-AS_IF([test "x$enable_perf_event_uncore" != "xno"],[
-	disable_uncore=no
-])
-
 # Check for perf_event.h
   if test "$force_perf_events" = "yes"; then
 	perf_events="yes"
@@ -1225,7 +1289,11 @@ AS_IF([test "x$enable_perf_event_uncore" != "xno"],[
   if test "$cross_compiling" = "no"; then 
 	AC_CHECK_FILE(/proc/sys/kernel/perf_event_paranoid,[
 	  have_paranoid=yes
-	  AC_CHECK_FILE($pe_incdir/perf_event.h,perf_events="yes")
+    AC_CHECK_FILE([$pe_incdir/perf_event.h], [
+      if test "$perf_events" != "no"; then
+        perf_events="yes"
+      fi
+      ])
     ])
   fi
   if test "$perf_events" = "yes"; then
@@ -1620,8 +1688,15 @@ elif test "$MAKEVER" = "linux-generic"; then
 elif test "$MAKEVER" = "linux-pe"; then
     FILENAME=Rules.pfm4_pe
     CPUCOMPONENT_NAME=perf_event 
-    components="perf_event"
-    if test "$disable_uncore" = "no"; then
+    if test "$perf_events" = "no"; then
+        components="$components"
+    else
+        components="$components perf_event"
+    fi
+    
+    if test "$perf_events_uncore" = "no"; then
+       components="$components"
+    else
        components="$components perf_event_uncore"
     fi
 
@@ -1748,6 +1823,7 @@ AC_ARG_WITH(sysdetect,
                             [Build the sysdetect component (default: yes)])],
             [],
             [with_sysdetect=yes])
+# Enable sysdetect unless the user has explicitly told us not to.
 if test "$with_sysdetect" = "yes"; then
   AC_MSG_RESULT(yes)
 else
@@ -1761,10 +1837,16 @@ echo "#ifndef COMPONENTS_CONFIG_H" >> components_config.h
 echo "#define COMPONENTS_CONFIG_H" >> components_config.h
 echo "" >> components_config.h
 
-AC_ARG_WITH(components,
-        	  [AS_HELP_STRING([--with-components=<"component1 component2">],
-            [Specify which components to build])],
-        	[components="$components $withval"]) 
+AC_ARG_WITH([components],
+    [AS_HELP_STRING([--with-components=<"component1 component2">],
+    [Specify which components to build])],
+    [
+        if test -n "m4_quote(${with_components//[[[:space:]]]/})"; then
+            components="$components $withval"
+        fi
+    ]
+)
+
 
 # This is an ugly hack to keep building on configurations covered by any-null in the past.
 if test "$VECTOR" = "_papi_dummy_vector"; then
@@ -1780,7 +1862,7 @@ if test "$VECTOR" = "_papi_dummy_vector"; then
 		.num_native_events = 0, 
 		.num_preset_events = 0, 
 		.num_cntrs = 0,
-		.name = \"Your system is unsupported! \",
+		.name = \"No Components Configured. \",
 		.short_name = \"UNSUPPORTED!\" 
 	},
 	.dispatch_timer = NULL,
@@ -1818,10 +1900,12 @@ if test "$VECTOR" = "_papi_dummy_vector"; then
 elif test "x$VECTOR" != "x"; then
    echo "extern papi_vector_t ${VECTOR};" >> components_config.h
 fi
-    
+
 # Enable sysdetect unless the user has explicitly told us not to.
 if test "$with_sysdetect" = "yes"; then
-  components="$components sysdetect"
+  if test "$perf_events" != "no"; then
+    components="$components sysdetect"
+    fi
 fi
 
 PAPI_NUM_COMP=0

--- a/src/darwin-common.c
+++ b/src/darwin-common.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <sys/utsname.h>
+#include <sys/sysctl.h>
 
 #include <time.h>
 #include <sys/time.h>

--- a/src/darwin-common.h
+++ b/src/darwin-common.h
@@ -1,5 +1,6 @@
 #ifndef _DARWIN_COMMON_H
 #define _DARWIN_COMMON_H
+#include <pthread.h>
 
 #define min(x, y) ({				\
 	typeof(x) _min1 = (x);			\
@@ -10,7 +11,10 @@
 static inline pid_t
 mygettid( void )
 {
-  return pthread_self();
+    pthread_t ptid = pthread_self();
+    pid_t thread_id = 0;
+    memcpy(&thread_id, &ptid, sizeof(pid_t) < sizeof(pthread_t) ? sizeof(pid_t) : sizeof(pthread_t));
+    return thread_id;
 }
 
 long long _darwin_get_real_cycles( void );

--- a/src/darwin-memory.c
+++ b/src/darwin-memory.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <errno.h>
+#include <sys/sysctl.h>
 
 #include "papi.h"
 #include "papi_internal.h"

--- a/src/run_tests.sh
+++ b/src/run_tests.sh
@@ -38,12 +38,17 @@ if [ "x$VALGRIND" != "x" ]; then
   VALGRIND="valgrind --leak-check=full";
 fi
 
-VTESTS=`find validation_tests/* -prune -perm -u+x -type f ! -name "*.[c|h]"`;
-#CTESTS=`find ctests -maxdepth 1 -perm -u+x -type f`;
-CTESTS=`find ctests/* -prune -perm -u+x -type f ! -name "*.[c|h]"`;
-FTESTS=`find ftests -perm -u+x -type f ! -name "*.[c|h|F]"`;
+# Check for active 'perf_event' component
+PERF_EVENT_ACTIVE=$(utils/papi_component_avail | awk '/Active components:/{flag=1; next} flag' | grep -q "perf_event" && echo "true" || echo "false")
 
-
+if [ "$PERF_EVENT_ACTIVE" == "true" ]; then
+    VTESTS=`find validation_tests/* -prune -perm -u+x -type f ! -name "*.[c|h]"`;
+    CTESTS=`find ctests/* -prune -perm -u+x -type f ! -name "*.[c|h]"`;
+    #CTESTS=`find ctests -maxdepth 1 -perm -u+x -type f`;
+    FTESTS=`find ftests -perm -u+x -type f ! -name "*.[c|h|F]"`;
+else
+  EXCLUDE="$EXCLUDE $VTESTS $CTESTS $FTESTS";
+fi
 
 # List of active components
 ACTIVE_COMPONENTS_PATTERN=$(utils/papi_component_avail | awk '/Active components:/{flag=1; next} flag' | grep "Name:" | sed 's/Name: //' | awk '{print $1}' | paste -sd'|' -)
@@ -124,92 +129,96 @@ else
 fi
 export LIBPATH
 
-echo ""
-echo "Running Event Validation Tests";
-echo ""
 
-for i in $VTESTS;
-do
-  for xtest in $EXCLUDE;
+if [ "$PERF_EVENT_ACTIVE" == "true" ]; then
+  
+  echo ""
+  echo "Running Event Validation Tests";
+  echo ""
+  
+  for i in $VTESTS;
   do
-    if [ "$i" = "$xtest" ]; then
-      MATCH=1
-      break
+    for xtest in $EXCLUDE;
+    do
+      if [ "$i" = "$xtest" ]; then
+        MATCH=1
+        break
+      fi;
+    done
+    if [ $MATCH -ne 1 ]; then
+      if [ -x $i ]; then
+        RAN="$i $RAN"
+        printf "Running %-50s %s" $i:
+        $VALGRIND ./$i $TESTS_QUIET
+        
+        #delete output folder for high-level tests
+        case "$i" in
+          *"_hl"*) rm -r papi_hl_output ;;
+        esac
+  
+      fi;
     fi;
+    MATCH=0
   done
-  if [ $MATCH -ne 1 ]; then
-    if [ -x $i ]; then
-      RAN="$i $RAN"
-      printf "Running %-50s %s" $i:
-      $VALGRIND ./$i $TESTS_QUIET
-      
-      #delete output folder for high-level tests
-      case "$i" in
-        *"_hl"*) rm -r papi_hl_output ;;
-      esac
-
-    fi;
-  fi;
-  MATCH=0
-done
-
-echo ""
-echo "Running C Tests";
-echo ""
-
-for i in $CTESTS;
-do
-  for xtest in $EXCLUDE;
+  
+  echo ""
+  echo "Running C Tests";
+  echo ""
+  
+  for i in $CTESTS;
   do
-    if [ "$i" = "$xtest" ]; then
-      MATCH=1
-      break
+    for xtest in $EXCLUDE;
+    do
+      if [ "$i" = "$xtest" ]; then
+        MATCH=1
+        break
+      fi;
+    done
+    if [ $MATCH -ne 1 ]; then
+      if [ -x $i ]; then
+        RAN="$i $RAN"
+        printf "Running %-50s %s" $i:
+        $VALGRIND ./$i $TESTS_QUIET
+  
+        #delete output folder for high-level tests
+        case "$i" in
+          *"_hl"*) rm -r papi_hl_output ;;
+        esac
+  
+      fi;
     fi;
+    MATCH=0
   done
-  if [ $MATCH -ne 1 ]; then
-    if [ -x $i ]; then
-      RAN="$i $RAN"
-      printf "Running %-50s %s" $i:
-      $VALGRIND ./$i $TESTS_QUIET
-
-      #delete output folder for high-level tests
-      case "$i" in
-        *"_hl"*) rm -r papi_hl_output ;;
-      esac
-
-    fi;
-  fi;
-  MATCH=0
-done
-
-echo ""
-echo "Running Fortran Tests";
-echo ""
-
-for i in $FTESTS;
-do
-  for xtest in $EXCLUDE;
+  
+  echo ""
+  echo "Running Fortran Tests";
+  echo ""
+  
+  for i in $FTESTS;
   do
-    if [ "$i" = "$xtest" ]; then
-      MATCH=1
-      break
+    for xtest in $EXCLUDE;
+    do
+      if [ "$i" = "$xtest" ]; then
+        MATCH=1
+        break
+      fi;
+    done
+    if [ $MATCH -ne 1 ]; then
+      if [ -x $i ]; then
+        RAN="$i $RAN"
+        printf "Running $i:\n"
+        $VALGRIND ./$i $TESTS_QUIET
+  
+        #delete output folder for high-level tests
+        case "$i" in
+          *"_hl"*) rm -r papi_hl_output ;;
+        esac
+  
+      fi;
     fi;
+    MATCH=0
   done
-  if [ $MATCH -ne 1 ]; then
-    if [ -x $i ]; then
-      RAN="$i $RAN"
-      printf "Running $i:\n"
-      $VALGRIND ./$i $TESTS_QUIET
-
-      #delete output folder for high-level tests
-      case "$i" in
-        *"_hl"*) rm -r papi_hl_output ;;
-      esac
-
-    fi;
-  fi;
-  MATCH=0
-done
+fi
 
 echo "";
 echo "Running Component Tests";

--- a/src/threads.c
+++ b/src/threads.c
@@ -602,7 +602,15 @@ _papi_hwi_gather_all_thrspec_data( int tag, PAPI_all_thr_spec_t * where )
 
 }
 
-#if defined(__NR_gettid) && !defined(HAVE_GETTID)
+#if defined(__APPLE__)
+  #include <pthread.h>
+  unsigned long _papi_gettid(void)
+  {
+    uint64_t tid;
+    pthread_threadid_np(NULL, &tid);  // macOS-specific thread ID function
+    return (unsigned long)tid;
+  }
+#elif defined(__NR_gettid) && !defined(HAVE_GETTID)
   #include <syscall.h>
   #include <unistd.h>
   unsigned long _papi_gettid(void)

--- a/src/utils/papi_multiplex_cost.c
+++ b/src/utils/papi_multiplex_cost.c
@@ -251,13 +251,15 @@ main( int argc, char **argv )
 	}
 
 	info = PAPI_get_component_info(0);
+ 
+  if (info != NULL ) {
 	options.kernel_mpx &= info->kernel_multiplex;
-
-	if ( options.kernel_mpx && !info->kernel_multiplex ) {
-		fprintf(stderr,"Error! Kernel multiplexing is "
-				"not supported on this platform, bailing!\n");
-		exit(1);
-	}
+  	if ( options.kernel_mpx && !info->kernel_multiplex ) {
+  		fprintf(stderr,"Error! Kernel multiplexing is "
+  				"not supported on this platform, bailing!\n");
+  		exit(1);
+  	}
+  }
 
 	retval = PAPI_create_eventset( &SoftwareMPX );
 	if (retval != PAPI_OK) {
@@ -273,7 +275,7 @@ main( int argc, char **argv )
 
 	retval = PAPI_assign_eventset_component( KernelMPX, 0 );
 	if (retval != PAPI_OK ) {
-		fprintf(stderr,"PAPI_assign_eventset_component");
+		fprintf(stderr,"PAPI_assign_eventset_component\n");
 		exit(retval);
 	}
 
@@ -285,7 +287,7 @@ main( int argc, char **argv )
 
 	retval = PAPI_assign_eventset_component( SoftwareMPX, 0 );
 	if (retval != PAPI_OK ) {
-		fprintf(stderr,"PAPI_assign_eventset_component");
+		fprintf(stderr,"PAPI_assign_eventset_component\n");
 		exit(retval);
 	}
 


### PR DESCRIPTION
## Pull Request Description
  --disable-perf-event-uncore Disable perf_event_uncore component
  --disable-perf-event    Disable perf_event component(disabling perf_event will disable perf_event_uncore as well)
  --disable-cpu           Disable perf_event and perf_event_uncore component 

## `configure/configure.in`
- Added `--disable-cpu`, `--disable-perf-event`, `--disable-perf-event-uncore`.
- Disabled `sysdetect` if perf-event is disabled
- Changed `AC_MSG_ERROR` → `AC_MSG_RESULT`.
- added `awk` statements to comment `ctest/ftest/vtest` in `Makefile.inc`.
- Reinstates them if disabling CPU is not specified.
- Changed a condition for enabling perf_events on for "if eval test \"x\$"$as_ac_File"\" = x"yes"; then :"


## `Run_tests.sh`
- Checks for `perf_event`.
- If not enabled, ctests ftests vtests do not run.

## `Darwin-common.h`
- Retrieve the current thread's ID using `pthread_self()`, but instead of returning the `pthread_t` value directly, it copies the memory of the `pthread_t` into a `pid_t` variable and returns it.
- Added missing library: `#include <pthread.h>`.

## `Darwin-common.c` & `darwin-memory.c`
- Added missing library: `#include <sys/sysctl.h>`.

## `threads.c`
- macOS-specific thread ID function.

## `Print_header.c` 
- Checks if `perf_event` is missing and returns "NA" if it isn’t present.
- Displays: `Number of Hardware Counters : PAPI error -1: Invalid argument`.
  - This only happens for ROCm.
  - Says "NA" for ROCm.
  - Else: displays 0 or the number of hardware counters of other devices.
  - If there are no components enabled, options is null. This results in the last print statement to segfault, so now it checks if the options variable is NULL.
  - When there are 0 components. Max Multiplex Counters   : PAPI error -4: Not supported by component

## CUDA Support
- Nvidia stopped supporting cuda for macos



## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
