### PR TITLE
Update libpfm4 to Commit 332285

### DIFF
--- a/src/libpfm4/lib/pfmlib_common.c
+++ b/src/libpfm4/lib/pfmlib_common.c
@@ -1192,6 +1192,12 @@ pfmlib_init_env(void)
 	str = getenv("LIBPFM_DISABLED_PMUS");
 	if (str)
 		pfm_cfg.blacklist_pmus = str;
+
+	str = getenv("LIBPFM_PROC_CPUINFO");
+	if (str) {
+		printf("FOUND CPUINFO %s\n", str);
+		pfm_cfg.proc_cpuinfo = str;
+	}
 }
 
 static int

--- a/src/libpfm4/lib/pfmlib_common.c
+++ b/src/libpfm4/lib/pfmlib_common.c
@@ -1194,10 +1194,8 @@ pfmlib_init_env(void)
 		pfm_cfg.blacklist_pmus = str;
 
 	str = getenv("LIBPFM_PROC_CPUINFO");
-	if (str) {
-		printf("FOUND CPUINFO %s\n", str);
+	if (str)
 		pfm_cfg.proc_cpuinfo = str;
-	}
 }
 
 static int

--- a/src/libpfm4/lib/pfmlib_priv.h
+++ b/src/libpfm4/lib/pfmlib_priv.h
@@ -212,6 +212,7 @@ typedef struct {
 	int	inactive;
 	char	*forced_pmu;
 	char	*blacklist_pmus;
+	char	*proc_cpuinfo; /* override /proc/cpuinfo with this file */
 	FILE 	*fp;	/* verbose and debug file descriptor, default stderr or PFMLIB_DEBUG_STDOUT */
 } pfmlib_config_t;	
 


### PR DESCRIPTION
## Pull Request Description
Current with
commit 0118612a28d270e78d1f17c24e9db0935e332285
Author: Stephane Eranian <eranian@gmail.com>
Date:   Tue Sep 17 16:36:24 2024 -0700

    remove extraneous printf in pfmlib_init_env()

    Was introduced by mistake by commit:
    32b7c3d6ab6b ("add LIBPFM_PROC_CPUINFO variable for Linux")

    Signed-off-by: Stephane Eranian <eranian@gmail.com>

Current with
commit 3724e7ef87e71dd1de46ef4eb4ec2b1be4ea63e5
Author: Stephane Eranian <eranian@gmail.com>
Date:   Sun Sep 15 22:29:37 2024 -0700

    add LIBPFM_PROC_CPUINFO variable for Linux

    Allows overriding the filename used to parse the /proc/cpuinfo
    file. This can be used to detect certain CPU models, such
    as on ARM. Providing an override allows testing without the actual
    hardware.

    Signed-off-by: Stephane Eranian <eranian@gmail.com>

Note: Built PAPI on machines with Arm Neoverse V2 and Intel(R) Xeon(R) CPU E5-2698 v4 with both being successful. Ran papi_component_avail, papi_native_avail, and papi_command_line with all three utilities running succesfully on both of the aforementioned CPU's.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
