### PR TITLE
Better support for multiple eventsets and multiple devices.

### DIFF
--- a/src/components/rocp_sdk/sdk_class.hpp
+++ b/src/components/rocp_sdk/sdk_class.hpp
@@ -68,6 +68,10 @@ do {                                             \
 #define RPSDK_MODE_CALLBACK_DISPATCH (0)
 #define RPSDK_MODE_AGENT_PROFILE     (1)
 
+#define RPSDK_AES_STOPPED (0x0)
+#define RPSDK_AES_OPEN    (0x1)
+#define RPSDK_AES_RUNNING (0x2)
+
 typedef struct {
     char name[PAPI_MAX_STR_LEN];
     char descr[PAPI_2MAX_STR_LEN];
@@ -79,7 +83,7 @@ typedef struct {
 } ntv_event_table_t;
 
 struct vendord_ctx {
-//    int state;
+    int state;
     int *event_ids;
     long long *counters;
     int num_events;

--- a/src/components/rocp_sdk/tests/Makefile
+++ b/src/components/rocp_sdk/tests/Makefile
@@ -12,16 +12,16 @@ template_tests: $(TESTS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(OPTFLAGS) -c -o $@ $<
 
 kernel.o: kernel.cpp
-	$(PAPI_ROCM_ROOT)/bin/amdclang++ -D__HIP_ROCclr__=1 -O2 -g -DNDEBUG -std=gnu++17 --offload-arch=gfx90a --offload-arch=gfx90a -W -Wall -Wextra -Wshadow -o kernel.o -x hip -c kernel.cpp
+	$(PAPI_ROCP_SDK_ROOT)/bin/amdclang++ -D__HIP_ROCclr__=1 -O2 -g -DNDEBUG -std=gnu++17 --offload-arch=gfx90a --offload-arch=gfx90a -W -Wall -Wextra -Wshadow -o kernel.o -x hip -c kernel.cpp
 
 simple: simple.o kernel.o
-	$(PAPI_ROCM_ROOT)/bin/amdclang++ -O2 -g -DNDEBUG --offload-arch=gfx90a --offload-arch=gfx90a --hip-link --rtlib=compiler-rt -unwindlib=libgcc simple.o kernel.o -o simple $(PAPI_ROCM_ROOT)/lib/libamdhip64.so.6 $(LDFLAGS)
+	$(PAPI_ROCP_SDK_ROOT)/bin/amdclang++ -O2 -g -DNDEBUG --offload-arch=gfx90a --offload-arch=gfx90a --hip-link --rtlib=compiler-rt -unwindlib=libgcc simple.o kernel.o -o simple $(PAPI_ROCP_SDK_ROOT)/lib/libamdhip64.so.6 $(LDFLAGS)
 
 advanced: advanced.o kernel.o
-	$(PAPI_ROCM_ROOT)/bin/amdclang++ -O2 -g -DNDEBUG --offload-arch=gfx90a --offload-arch=gfx90a --hip-link --rtlib=compiler-rt -unwindlib=libgcc advanced.o kernel.o -o advanced $(PAPI_ROCM_ROOT)/lib/libamdhip64.so.6 $(LDFLAGS)
+	$(PAPI_ROCP_SDK_ROOT)/bin/amdclang++ -O2 -g -DNDEBUG --offload-arch=gfx90a --offload-arch=gfx90a --hip-link --rtlib=compiler-rt -unwindlib=libgcc advanced.o kernel.o -o advanced $(PAPI_ROCP_SDK_ROOT)/lib/libamdhip64.so.6 $(LDFLAGS)
 
 two_eventsets: two_eventsets.o kernel.o
-	$(PAPI_ROCM_ROOT)/bin/amdclang++ -O2 -g -DNDEBUG --offload-arch=gfx90a --offload-arch=gfx90a --hip-link --rtlib=compiler-rt -unwindlib=libgcc two_eventsets.o kernel.o -o two_eventsets $(PAPI_ROCM_ROOT)/lib/libamdhip64.so.6 $(LDFLAGS)
+	$(PAPI_ROCP_SDK_ROOT)/bin/amdclang++ -O2 -g -DNDEBUG --offload-arch=gfx90a --offload-arch=gfx90a --hip-link --rtlib=compiler-rt -unwindlib=libgcc two_eventsets.o kernel.o -o two_eventsets $(PAPI_ROCP_SDK_ROOT)/lib/libamdhip64.so.6 $(LDFLAGS)
 
 
 clean:

--- a/src/components/rocp_sdk/tests/kernel.cpp
+++ b/src/components/rocp_sdk/tests/kernel.cpp
@@ -49,5 +49,5 @@ void launch_kernel(int device_id) {
 
     HIP_CALL(hipDeviceSynchronize());
 
-    std::cerr << " =====> Run completed\n";
+//    std::cerr << " =====> Run completed\n";
 }

--- a/src/components/rocp_sdk/tests/two_eventsets.c
+++ b/src/components/rocp_sdk/tests/two_eventsets.c
@@ -1,0 +1,193 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <papi.h>
+#include <papi_test.h>
+
+extern void launch_kernel(int device_id);
+
+int main(int argc, char *argv[])
+{
+    int papi_errno;
+#define NUM_EVENTS (5)
+    long long counters1[NUM_EVENTS] = { 0 };
+    long long counters2[NUM_EVENTS] = { 0 };
+    int eventset1 = PAPI_NULL;
+    int eventset2 = PAPI_NULL;
+    int exp1[NUM_EVENTS] = {1, 120000, 900, 500000, 1};
+    int exp2[NUM_EVENTS] = {120000, 1, 900, 1, 500000};
+    int exp3[NUM_EVENTS] = {1, 120000, 1, 1, 1};
+
+    const char *events1[NUM_EVENTS] = {
+                  "rocp_sdk:::SQ_CYCLES:device=0",
+                  "rocp_sdk:::SQ_CYCLES:device=1",
+                  "rocp_sdk:::SQ_BUSY_CYCLES:device=1",
+                  "rocp_sdk:::TCC_CYCLE:device=1",
+                  "rocp_sdk:::SQ_WAVES:device=1"
+    };
+
+    const char *events2[NUM_EVENTS] = {
+                  "rocp_sdk:::SQ_CYCLES:device=1",
+                  "rocp_sdk:::SQ_CYCLES:device=0",
+                  "rocp_sdk:::SQ_BUSY_CYCLES:device=1",
+                  "rocp_sdk:::SQ_WAVES:device=0",
+                  "rocp_sdk:::TCC_CYCLE:device=1"
+    };
+
+    papi_errno = PAPI_library_init(PAPI_VER_CURRENT);
+    if (papi_errno != PAPI_VER_CURRENT) {
+        test_fail(__FILE__, __LINE__, "PAPI_library_init", papi_errno);
+    }
+
+    papi_errno = PAPI_create_eventset(&eventset1);
+    if (papi_errno != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_create_eventset", papi_errno);
+    }
+
+    for (int i = 0; i < NUM_EVENTS; ++i) {
+        papi_errno = PAPI_add_named_event(eventset1, events1[i]);
+        if (papi_errno != PAPI_OK) {
+            test_fail(__FILE__, __LINE__, "PAPI_add_named_event", papi_errno);
+        }
+    }
+
+    papi_errno = PAPI_create_eventset(&eventset2);
+    if (papi_errno != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_create_eventset", papi_errno);
+    }
+
+    for (int i = 0; i < NUM_EVENTS; ++i) {
+        papi_errno = PAPI_add_named_event(eventset2, events2[i]);
+        if (papi_errno != PAPI_OK) {
+            test_fail(__FILE__, __LINE__, "PAPI_add_named_event", papi_errno);
+        }
+    }
+
+    printf("==================== FIRST EVENTSET - DEVICE 1 ====================\n");
+
+    papi_errno = PAPI_start(eventset1);
+    if (papi_errno != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_start", papi_errno);
+    }
+    for(int rep=0; rep<=3; ++rep){
+
+        launch_kernel(1);
+
+        usleep(1000);
+
+        papi_errno = PAPI_read(eventset1, counters1);
+        if (papi_errno != PAPI_OK) {
+            test_fail(__FILE__, __LINE__, "PAPI_read", papi_errno);
+        }
+        printf("---------------------  PAPI_read()\n");
+
+        for (int i = 0; i < NUM_EVENTS; ++i) {
+            printf("%s: %lld (%.2lf)\n", events1[i], counters1[i], 1.0*counters1[i]/((1.0+rep)*exp1[i]));
+        }
+    }
+
+    papi_errno = PAPI_stop(eventset1, counters1);
+    if (papi_errno != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_stop", papi_errno);
+    }
+
+    printf("---------------------  PAPI_stop()\n");
+
+    for (int i = 0; i < NUM_EVENTS; ++i) {
+        printf("%s: %lld (%.2lf)\n", events1[i], counters1[i], 1.0*counters1[i]/((1.0+3)*exp1[i]));
+    }
+
+    printf("==================== SECOND EVENTSET - DEVICE 1 ====================\n");
+
+
+    papi_errno = PAPI_start(eventset2);
+    if (papi_errno != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_start", papi_errno);
+    }
+    for(int rep=0; rep<=3; ++rep){
+
+        launch_kernel(1);
+
+        usleep(1000);
+
+        papi_errno = PAPI_read(eventset2, counters2);
+        if (papi_errno != PAPI_OK) {
+            test_fail(__FILE__, __LINE__, "PAPI_read", papi_errno);
+        }
+        printf("---------------------  PAPI_read()\n");
+
+        for (int i = 0; i < NUM_EVENTS; ++i) {
+            printf("%s: %lld (%.2lf)\n", events2[i], counters2[i], 1.0*counters2[i]/((1.0+rep)*exp2[i]));
+        }
+    }
+
+    papi_errno = PAPI_stop(eventset2, counters2);
+    if (papi_errno != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_stop", papi_errno);
+    }
+
+    printf("---------------------  PAPI_stop()\n");
+
+    for (int i = 0; i < NUM_EVENTS; ++i) {
+        printf("%s: %lld (%.2lf)\n", events2[i], counters2[i], 1.0*counters2[i]/((1.0+3)*exp2[i]));
+    }
+
+    printf("==================== SECOND EVENTSET - DEVICE 0 ====================\n");
+
+    papi_errno = PAPI_start(eventset2);
+    if (papi_errno != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_start", papi_errno);
+    }
+    for(int rep=0; rep<=2; ++rep){
+
+        launch_kernel(0);
+
+        usleep(1000);
+
+        papi_errno = PAPI_read(eventset2, counters2);
+        if (papi_errno != PAPI_OK) {
+            test_fail(__FILE__, __LINE__, "PAPI_read", papi_errno);
+        }
+        printf("---------------------  PAPI_read()\n");
+
+        for (int i = 0; i < NUM_EVENTS; ++i) {
+            printf("%s: %lld (%.2lf)\n", events2[i], counters2[i], 1.0*counters2[i]/((1.0+rep)*exp3[i]));
+        }
+    }
+
+    papi_errno = PAPI_stop(eventset2, counters2);
+    if (papi_errno != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_stop", papi_errno);
+    }
+
+    printf("---------------------  PAPI_stop()\n");
+
+    for (int i = 0; i < NUM_EVENTS; ++i) {
+        printf("%s: %lld (%.2lf)\n", events2[i], counters2[i], 1.0*counters2[i]/((1.0+2)*exp3[i]));
+    }
+
+    /* * * Cleanup * * */
+
+    papi_errno = PAPI_cleanup_eventset(eventset1);
+    if (papi_errno != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_cleanup_eventset", papi_errno);
+    }
+
+    papi_errno = PAPI_destroy_eventset(&eventset1);
+    if (papi_errno != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_destroy_eventset", papi_errno);
+    }
+
+    papi_errno = PAPI_cleanup_eventset(eventset2);
+    if (papi_errno != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_cleanup_eventset", papi_errno);
+    }
+
+    papi_errno = PAPI_destroy_eventset(&eventset2);
+    if (papi_errno != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_destroy_eventset", papi_errno);
+    }
+
+    PAPI_shutdown();
+    test_pass(__FILE__);
+    return 0;
+}


### PR DESCRIPTION
Create the dispatch profile when the user calls PAPI_start(), not when the dispatch callback is invoked.
Create as many profiles as there are devices requested by the user events, and associate each profile with the corresponding agent.

## Pull Request Description


## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
