### PR TITLE
Update Makefile - CUDA 12.2

### DIFF
--- a/src/components/cuda/tests/Makefile
+++ b/src/components/cuda/tests/Makefile
@@ -16,9 +16,9 @@ NVCC = $(PAPI_CUDA_ROOT)/bin/nvcc
 
 PAPI_FLAG = -DPAPI    # Comment this line for tests to run without PAPI profiling
 NVCFLAGS = -g -ccbin='$(CC)' $(PAPI_FLAG)
-CFLAGS += -g $(PAPI_FLAG)
+CFLAGS += -g $(PAPI_FLAG) -pthread
 INCLUDE += -I$(PAPI_CUDA_ROOT)/include
-CUDALIBS = -L$(PAPI_CUDA_ROOT)/lib64 -lcudart -lcuda
+CUDALIBS = -L$(PAPI_CUDA_ROOT)/lib64 -lcudart -lcuda -lstdc++
 PAPILIB += -L../../../libpfm4/lib -lpfm
 
 cuda_tests: $(TESTS) $(TESTS_NOCTX)


### PR DESCRIPTION
Adding these two extra options to compiler and linker will produce successful compilation for my machine with gcc 9.4.0 and CUDA 12.2. Compilation fails otherwise.

## Pull Request Description


## Author Checklist
- [1] Alfredo Metere, Samsung Semiconductor, Inc.
This fix addresses compilation failure of CUDA module tests on GCC v.9.4.0 and CUDA 12.2.
- changed two lines in the Makefile of CUDA module test.
The PR needs to pass all the tests
