### PR TITLE
rapl: Added RAPL component support for Intel RaptorLake.

### DIFF
--- a/src/components/rapl/linux-rapl.c
+++ b/src/components/rapl/linux-rapl.c
@@ -403,7 +403,7 @@ _rapl_init_component( int cidx )
 
 		/* Desktop / Laptops */
 
-      case 183:   /* RaptorLake */
+		case 183:   /* RaptorLake-S/HX B0 */
 		case 42:	/* SandyBridge */
 		case 58:	/* IvyBridge */
 			package_avail=1;

--- a/src/components/rapl/linux-rapl.c
+++ b/src/components/rapl/linux-rapl.c
@@ -406,8 +406,8 @@ _rapl_init_component( int cidx )
 		case 42:	/* SandyBridge */
 		case 58:	/* IvyBridge */
 		case 183:	/* RaptorLake-S/HX */
-      case 186:	/* RaptorLake */
-      case 191:	/* RaptorLake */
+		case 186:	/* RaptorLake */
+		case 191:	/* RaptorLake */
 			package_avail=1;
 			pp0_avail=1;
 			pp1_avail=1;

--- a/src/components/rapl/linux-rapl.c
+++ b/src/components/rapl/linux-rapl.c
@@ -403,9 +403,11 @@ _rapl_init_component( int cidx )
 
 		/* Desktop / Laptops */
 
-		case 183:   /* RaptorLake-S/HX B0 */
 		case 42:	/* SandyBridge */
 		case 58:	/* IvyBridge */
+		case 183:	/* RaptorLake-S/HX */
+      case 186:	/* RaptorLake */
+      case 191:	/* RaptorLake */
 			package_avail=1;
 			pp0_avail=1;
 			pp1_avail=1;

--- a/src/components/rapl/linux-rapl.c
+++ b/src/components/rapl/linux-rapl.c
@@ -403,6 +403,7 @@ _rapl_init_component( int cidx )
 
 		/* Desktop / Laptops */
 
+      case 183:   /* RaptorLake */
 		case 42:	/* SandyBridge */
 		case 58:	/* IvyBridge */
 			package_avail=1;


### PR DESCRIPTION
## Pull Request Description

This PR adds support for the `rapl` component on Intel's RaptorLake architecture. Adding this was extremely simple as RaptorLake has the same RAPL setup as SandyBridge and IvyBridge.

Tested systems:

| **System Name** | **Family/Model/Stepping** | `papi_native_avail` | `papi_component_avail` | `papi_command_line` | **RAPL tests** |
|-------------|-----------------------|-------------------|----------------------|-------------------|------------|
| Raptor Lake-S/HX B0  | 0x6/0xb7/0x1 |<ul><li> [x] </li></ul>|<ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |<ul><li> [x] </li></ul>|


## Author Checklist
- [X] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [X] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [X] **Tests**
The PR needs to pass all the tests
