### PR TITLE
Update ROCm Component Disabled Reason if Initialized

### DIFF
--- a/src/components/rocm/rocm.c
+++ b/src/components/rocm/rocm.c
@@ -225,6 +225,7 @@ rocm_init_private(void)
   fn_exit:
     _rocm_vector.cmp_info.initialized = 1;
     _rocm_vector.cmp_info.disabled = papi_errno;
+    strcpy(_rocm_vector.cmp_info.disabled_reason, "");
     SUBDBG("EXIT: %s\n", PAPI_strerror(papi_errno));
     _papi_hwi_unlock(COMPONENT_LOCK);
     return papi_errno;


### PR DESCRIPTION
## Pull Request Description
This PR updates the disabled reason in the ROCm component to be an empty string if the component has properly been initialized. Previously, the string for disabled reason would show: `Not initialized. Access component events to initialize it.` regardless of being initialized or not. 

### Sample Output of Behavior in Master if Initialized
```
Disabled Reason: Not initialized. Access component events to initialize it.
```


### Sample Output of Behavior in PR if Initialized
```
Disabled Reason: 
```



## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
