### PR TITLE
2024.09.18 intel_gpu bug fixes

### DIFF
--- a/src/components/intel_gpu/internal/inc/GPUMetricInterface.h
+++ b/src/components/intel_gpu/internal/inc/GPUMetricInterface.h
@@ -135,7 +135,7 @@ typedef struct MetricNode_S {
  * metric code:  group(8) + metrics(8)
  */
 #define METRIC_BITS		  8
-#define METRIC_GROUP_MASK	0xff00
+#define METRIC_GROUP_MASK	0xfff00
 #define METRIC_MASK		  0x00ff
 
 #define CreateGroupCode(mGroupId)		 (((mGroupId+1)<<METRIC_BITS) & METRIC_GROUP_MASK)

--- a/src/components/intel_gpu/internal/src/GPUMetricHandler.cpp
+++ b/src/components/intel_gpu/internal/src/GPUMetricHandler.cpp
@@ -1230,18 +1230,6 @@ int GPUMetricHandler::EnableTimeBasedStream(uint32_t timePeriod, uint32_t numRep
 	} else {
 		DebugPrintError("EnableTimeBasedStream: failed on device [%p], status 0x%x\n", 
 						m_device, status);
-		if (m_metricStreamer) {
-			status = zetMetricStreamerCloseFunc(m_metricStreamer);
-			m_metricStreamer = nullptr;
-		}
-		if (m_event) {
-			status = zeEventDestroyFunc(m_event);
-			m_event = nullptr;
-		}
-		if (m_eventPool) {
-			status = zeEventPoolDestroyFunc(m_eventPool);
-			m_eventPool = nullptr;
-		}
 		status = zetContextActivateMetricGroupsFunc(m_context, m_device, 0, nullptr);
 		m_status = COLLECTION_INIT;
 		ret = 1;
@@ -1331,22 +1319,6 @@ int GPUMetricHandler::EnableEventBasedQuery()
 		ret  = 0;
 	} else {
 		DebugPrintError("EnableEventBasedQuery: failed with status 0x%x, abort.\n", status);
-		if (m_tracer) {
-			status = zetTracerExpDestroyFunc(m_tracer);
-			m_tracer = nullptr;
-		}
-		if (m_event) {
-			status = zeEventDestroyFunc(m_event);
-			m_event = nullptr;
-		}
-		if (m_eventPool) {
-			status = zeEventPoolDestroyFunc(m_eventPool);
-			m_eventPool = nullptr;
-		}
-		if (m_queryPool) {
-			status = zetMetricQueryPoolDestroyFunc(m_queryPool);
-			m_queryPool = nullptr;
-		}
 		status = zetContextActivateMetricGroupsFunc(m_context, m_device, 0, nullptr);
 		m_status = COLLECTION_INIT;
 		ret  = retError;
@@ -1375,30 +1347,6 @@ GPUMetricHandler::DisableMetricGroup()
 	}
 	m_status = COLLECTION_DISABLED;
 
-	if (m_groupType == ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_TIME_BASED) {
-		if (m_metricStreamer) {
-			zetMetricStreamerCloseFunc(m_metricStreamer);
-			m_metricStreamer = nullptr;
-		}
-	}
-	if (m_groupType == ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_EVENT_BASED) {
-		if (m_tracer) {
-			zetTracerExpDestroyFunc(m_tracer);
-			m_tracer = nullptr;
-		}
-		if (m_queryPool) {
-			zetMetricQueryPoolDestroyFunc(m_queryPool);
-			m_queryPool = nullptr;
-		}
-	}
-	if (m_event) {
-		zeEventDestroyFunc(m_event);
-		m_event = nullptr;
-	}
-	if (m_eventPool) {
-		zeEventPoolDestroyFunc(m_eventPool);
-		m_eventPool = nullptr;
-	}
 	zetContextActivateMetricGroupsFunc(m_context,  m_device, 0, nullptr);
 	m_lock.unlock();
 	return;

--- a/src/components/intel_gpu/linux_intel_gpu_metrics.c
+++ b/src/components/intel_gpu/linux_intel_gpu_metrics.c
@@ -121,13 +121,6 @@ addMetricToDevice(uint32_t code, int rootDev) {
 	uint32_t i=0;
 	for (i=0; i<num_active_devices; i++)  {
 		if  (active_devices[i].device_code == devcode) {
-			if (active_devices[i].mgroup_code != group) {
-				// conflict with existing metric group
-				GPUDEBUG("intel_gpu: metrics from more than one group cannot be collected "
-						" in the same device at the same time. "
-						" Failed with return code 0x%x \n", PAPI_ENOSUPP);
-		   		return -1;
-			}
 			break;
 		}
 	}

--- a/src/components/intel_gpu/linux_intel_gpu_metrics.c
+++ b/src/components/intel_gpu/linux_intel_gpu_metrics.c
@@ -150,6 +150,22 @@ addMetricToDevice(uint32_t code, int rootDev) {
 	return i;
 }
 
+/*!
+ * @brief  Reset metric counts to zero.
+ */
+void
+metricReset( MetricContext *mContext )
+{
+    for (uint32_t i=0; i<num_avail_devices; i++) {
+        uint32_t dev_idx = mContext->active_devices[i];
+        if  (dev_idx < num_active_devices) {
+            DeviceContext *dev = &active_devices[dev_idx];
+            GPUSetMetricControl(dev->handle, METRIC_RESET);
+        }
+    }
+}
+
+
 
 /************************* PAPI Functions **********************************/
 
@@ -277,11 +293,39 @@ intel_gpu_update_control_state( hwd_control_state_t *ctl,
 	(void)ctl;
 
 	// use local maintained context,
-	if (!count ||!native)  {
-		return PAPI_OK;
+	MetricContext *mContext = (MetricContext *)ctx;
+
+    /* This check accounts for calls to PAPI_cleanup_eventset(). */
+	if ( !count )  {
+	    metricReset(mContext);
+        /* Free devices. */
+        for (uint32_t i=0; i<mContext->num_devices; i++) {
+            uint32_t dev_idx = mContext->active_devices[i];
+            if (dev_idx >= num_active_devices) {
+                return PAPI_ENOMEM;
+            }
+            DeviceContext *dev = &active_devices[dev_idx];
+            DEVICE_HANDLE handle = dev->handle;
+            if( !handle ) {
+                GPUFreeDevice(handle);
+            }
+            mContext->active_devices[i] = 0;
+        }
+        mContext->num_devices = 0;
+        /* Free metric slots. */
+        for (uint32_t midx=0; midx<mContext->num_metrics; midx++) {
+            mContext->metric_idx[midx] = 0;
+            mContext->metric_values[midx] = 0;
+            mContext->dev_ctx_idx[midx] = 0;
+            mContext->subdev_idx[midx] = 0;
+        }
+        mContext->num_metrics = 0;
+        return PAPI_OK;
 	}
 
-	MetricContext *mContext = (MetricContext *)ctx;
+	if ( !native ) {
+		return PAPI_OK;
+	}
 
 #if defined(_DEBUG)
 	for (int i=0; i<count; i++) {
@@ -354,6 +398,9 @@ intel_gpu_start( hwd_context_t * ctx, hwd_control_state_t * ctl )
 	MetricContext *mContext = (MetricContext *)ctx;
 
 	int	 ret	= PAPI_OK;
+
+    metricReset(mContext);
+
 	if (mContext->num_metrics == 0) {
 		GPUDEBUG("intel_gpu_start : No metric selected, abort.\n");
 		return PAPI_EINVAL;
@@ -521,13 +568,8 @@ intel_gpu_reset( hwd_context_t *ctx, hwd_control_state_t *ctl)
 	GPUDEBUG("Entering intel_gpu_reset\n");
 	MetricContext *mContext = (MetricContext *)ctx;
 
-	for (uint32_t i=0; i<num_avail_devices; i++) {
-		uint32_t dev_idx = mContext->active_devices[i];
-		if  (dev_idx < num_active_devices) {
-			DeviceContext *dev = &active_devices[dev_idx];
-			GPUSetMetricControl(dev->handle, METRIC_RESET);
-		}
-	}
+	metricReset(mContext);
+
 	return PAPI_OK;
 }
 


### PR DESCRIPTION
## Pull Request Description
This PR addresses bugs that were present in the intel_gpu component, namely:
- Fix mapping between the metric code and metric group ID.
- Remove check preventing metrics from separate groups from being added to separate event sets.
- Implement PAPI_cleanup_eventset() functionality.

This Pull Request addresses Issue #227.

These changes have been tested using an OpenCL matrix addition kernel on the Intel Ponte Vecchio architecture.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
