### PR TITLE
high-level: Explicitly use python3

### DIFF
--- a/src/high-level/scripts/papi_hl_output_writer.py
+++ b/src/high-level/scripts/papi_hl_output_writer.py
@@ -1,10 +1,10 @@
+#!/usr/bin/env python3
 ## 
 # @file papi_hl_output_writer.py
 # @brief Converts HL output to be more comprehensible. 
 # Output is enhanced by creating derived metrics like IPC,
 # MFlop/s, and MFlips/s. As well as real and processor time.
 
-#!/usr/bin/python
 from __future__ import division
 from collections import OrderedDict
 


### PR DESCRIPTION
Python3 has been released for over 15 years.  Fedora, Debian, and other distributions state that python scripts should avoid using unversioned python intepreter:

https://fedoraproject.org/wiki/FinalizingFedoraSwitchtoPython3 https://www.debian.org/doc/packaging-manuals/python-policy/

The RPM build process will flag unversioned python interpreter use as an error and the build will fail.  Making the papi_hl_output_writer.py explicitly use /usr/bin/python3.

## Pull Request Description


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
