### PR TITLE
Correcting documentation in PAPI_add_named_event

### DIFF
--- a/src/papi.c
+++ b/src/papi.c
@@ -2366,8 +2366,8 @@ PAPI_remove_event( int EventSet, int EventCode )
  *
  *	@param EventSet
  *		An integer handle for a PAPI Event Set as created by PAPI_create_eventset.
- *	@param EventCode 
- *		A defined event such as PAPI_TOT_INS. 
+ *	@param EventName
+ *		A string containing the event name as listed in papi_avail or papi_native_avail.
  *
  *	@retval Positive-Integer
  *		The number of consecutive elements that succeeded before the error. 


### PR DESCRIPTION
## Pull Request Description
This PR updates the `PAPI_add_named_event` documentation. Specifically updating the list of params.

As stands the documentation is the following:
``` 
@params EventCode
    A defined event such as PAPI_TOT_INS.
```
The update would see the above changed to:
```
@params EventName
    A string containing the event name as listed in papi_avail or papi_native_avail.
```

Merging this PR will close Issue #2.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
