### PR TITLE
perf_event: Eliminate paranoia error for check_exclude_guest()

### DIFF
--- a/src/components/perf_event/perf_event.c
+++ b/src/components/perf_event/perf_event.c
@@ -285,6 +285,7 @@ check_exclude_guest( void )
 	/* First check that we can open a plain instructions event */
 	memset(&attr, 0 , sizeof(attr));
 	attr.config = PERF_COUNT_HW_INSTRUCTIONS;
+	attr.exclude_kernel=1;
 
 	ev_fd = sys_perf_event_open( &attr, 0, -1, -1, 0 );
 	if ( ev_fd == -1 ) {
@@ -296,6 +297,7 @@ check_exclude_guest( void )
 	/* Now try again with excude_guest */
 	memset(&attr, 0 , sizeof(attr));
 	attr.config = PERF_COUNT_HW_INSTRUCTIONS;
+	attr.exclude_kernel=1;
 	attr.exclude_guest=1;
 
 	ev_fd = sys_perf_event_open( &attr, 0, -1, -1, 0 );


### PR DESCRIPTION
## Pull Request Description

On systems with the kernel setting `perf_event_paranoid`>=2, userspace calls to `perf_event_open()` must set `attr.exclude_kernel=1`. Set `exclude_kernel=1` in `check_exclude_guest()` to allow the function to execute successfully on systems with `perf_event_paranoid`>=2;

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
