### PR TITLE
counter_analysis_toolkit: Automatically detect platform in Makefile

### DIFF
--- a/src/counter_analysis_toolkit/Makefile
+++ b/src/counter_analysis_toolkit/Makefile
@@ -16,7 +16,7 @@ ifeq ($(USEMPI),true)
 endif
 
 ## Try to auto-detect architecture if it is not set.
-ifeq ($(origin ARCH), undefined)
+ifndef ARCH
     UNAME_M:=$(shell uname -m)
 
     ARCH=POWER

--- a/src/counter_analysis_toolkit/Makefile
+++ b/src/counter_analysis_toolkit/Makefile
@@ -1,4 +1,3 @@
-ARCH?=X86
 PAPIDIR?=${PAPI_DIR}
 USEMPI?=false
 LDFLAGS=-L$(PAPIDIR)/lib -lpapi -lm -lpthread -ldl -lrt
@@ -14,6 +13,21 @@ CC=gcc
 ifeq ($(USEMPI),true)
     CC=mpicc
     CFLAGS+=-DUSE_MPI
+endif
+
+## Try to auto-detect architecture if it is not set.
+ifeq ($(origin ARCH), undefined)
+    UNAME_M:=$(shell uname -m)
+
+    ARCH=POWER
+    ifeq ($(UNAME_M),x86_64)
+        ARCH=X86
+    endif
+    ifeq ($(UNAME_M),aarch64)
+        ARCH=ARM
+    endif
+
+    $(info    Detected ARCH=$(ARCH))
 endif
 
 ## Architecture determines vector instruction set.


### PR DESCRIPTION
## Pull Request Description

When compiling the Counter Analysis Toolkit (CAT) if the wrong architecture is selected for the ARCH variable, relatively confusing compilation errors can occur. For example, compiling on an ARM machine with the default `ARCH=X86` setting produces the following GCC error: `gcc: error: unrecognized command-line option ‘-mfma’`.

To prevent this from happening, make the CAT Makefile use 'uname -m' to detect if the architecture is arm or x86, and otherwise assume powerpc. If ARCH is already set, leave it alone. This change streamlines the workflow of using the CAT on new devices.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
