### PR TITLE
run_tests.sh: change libpfm-3.y to libpfm4

### DIFF
--- a/src/run_tests.sh
+++ b/src/run_tests.sh
@@ -112,15 +112,15 @@ echo "Running Tests";
 echo ""
 
 if [ "$LD_LIBRARY_PATH" = "" ]; then
-  LD_LIBRARY_PATH=.:./libpfm-3.y/lib
+  LD_LIBRARY_PATH=.:./libpfm4/lib
 else
-  LD_LIBRARY_PATH=.:./libpfm-3.y/lib:"$LD_LIBRARY_PATH"
+  LD_LIBRARY_PATH=.:./libpfm4/lib:"$LD_LIBRARY_PATH"
 fi
 export LD_LIBRARY_PATH
 if [ "$LIBPATH" = "" ]; then
-  LIBPATH=.:./libpfm-3.y/lib
+  LIBPATH=.:./libpfm4/lib
 else
-  LIBPATH=.:./libpfm-3.y/lib:"$LIBPATH"
+  LIBPATH=.:./libpfm4/lib:"$LIBPATH"
 fi
 export LIBPATH
 


### PR DESCRIPTION
## Pull Request Description
Change paths from libpfm-3.y to libpfm4 so that the tests link to libpfm.so.4

This Pull Request addresses Issue #240.

These changes have been tested on the NVIDIA Grace-Hopper architecture.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
