### PR TITLE
Updating Cuda Tests Makefile with -pthread

### DIFF
--- a/src/components/cuda/tests/Makefile
+++ b/src/components/cuda/tests/Makefile
@@ -36,16 +36,16 @@ test_multi_read_and_reset: test_multi_read_and_reset.o $(UTILOBJS)
 	$(CXX) $(CFLAGS) -o test_multi_read_and_reset test_multi_read_and_reset.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
 concurrent_profiling: concurrent_profiling.o $(UTILOBJS)
-	$(CXX) $(CFLAGS) -o concurrent_profiling concurrent_profiling.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
+	$(CXX) $(CFLAGS) -pthread -o concurrent_profiling concurrent_profiling.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
 concurrent_profiling_noCuCtx: concurrent_profiling_noCuCtx.o $(UTILOBJS)
-	$(CXX) $(CFLAGS) -o concurrent_profiling_noCuCtx concurrent_profiling_noCuCtx.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
+	$(CXX) $(CFLAGS) -pthread -o concurrent_profiling_noCuCtx concurrent_profiling_noCuCtx.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
 pthreads: pthreads.o
-	$(CXX) $(CFLAGS) -o pthreads pthreads.o -lpthread $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
+	$(CXX) $(CFLAGS) -pthread -o pthreads pthreads.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
 pthreads_noCuCtx: pthreads_noCuCtx.o
-	$(CXX) $(CFLAGS) -o pthreads_noCuCtx pthreads_noCuCtx.o -lpthread $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
+	$(CXX) $(CFLAGS) -pthread -o pthreads_noCuCtx pthreads_noCuCtx.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
 cudaOpenMP: cudaOpenMP.o
 	$(CXX) $(CFLAGS) -o cudaOpenMP cudaOpenMP.o -lgomp -fopenmp $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
@@ -57,7 +57,7 @@ test_multipass_event_fail: test_multipass_event_fail.o $(UTILOBJS)
 	$(CXX) $(CFLAGS) -o test_multipass_event_fail test_multipass_event_fail.o $(INCLUDE) $(UTILOBJS) $(PAPILIB) $(LDFLAGS) $(CUDALIBS)
 
 test_2thr_1gpu_not_allowed: test_2thr_1gpu_not_allowed.o
-	$(CXX) $(CFLAGS) -o test_2thr_1gpu_not_allowed test_2thr_1gpu_not_allowed.o -lpthread $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
+	$(CXX) $(CFLAGS) -pthread -o test_2thr_1gpu_not_allowed test_2thr_1gpu_not_allowed.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
 HelloWorld: HelloWorld.o $(UTILOBJS)
 	$(CXX) $(CFLAGS) -o HelloWorld HelloWorld.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)


### PR DESCRIPTION
## Pull Request Description
In GLIBC version 2.34, libpthread as a separate library has been removed. Most components that used to be in a separate shared object have been placed into the main libc object, `libc.so.6`. Due to this, the `-lpthread` flag is not needed in GLIBC >= 2.34. See the following [webpage ](https://developers.redhat.com/articles/2021/12/17/why-glibc-234-removed-libpthread#) for more discussion on this topic. 

Even with versions of GLIBC >= 2.34 or GLIBC < 2.34, we still should place the `-pthread` flag when needed. `-pthread` encompasses `-lpthread`, but it also defines extra macros. From the man pages for gcc the following is stated for the `-pthread` flag: You should use this option consistently for both compilation and linking.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
