### PR TITLE
Allow for a user to supply just the base cuda native event name

### DIFF
--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -2546,9 +2546,11 @@ static int evt_name_to_basename(const char *name, char *base, int len)
 static int evt_name_to_device(const char *name, int *device)
 {
     char *p = strstr(name, ":device=");
-    if (!p) {
-        return PAPI_ENOEVNT;
+    if (p) {
+        *device = (int) strtol(p + strlen(":device="), NULL, 10);
     }
-    *device = (int) strtol(p + strlen(":device="), NULL, 10);
+    else {
+        *device = 0;
+    }
     return PAPI_OK;
 }


### PR DESCRIPTION
## Pull Request Description
This pull request will allow a user to supply just the base Cuda native event name to a PAPI function call and we internally will handle it as if `:device=0` was supplied. Therefore, a user supplying just `cuda:::dram__bytes.avg` will not encounter the error `PAPI_ENOEVNT` anymore. 


## Demo of using just `cuda:::dram__bytes.avg`
Code:
```c
#include "papi.h"

#include <cuda.h>
#include <stdio.h>
#include <stdlib.h>

int main() {
    int retval, EventCode, EventSet = PAPI_NULL, Events, number = 1;
    char EventName[PAPI_MAX_STR_LEN];
    long long values[1]; 
    CUcontext pctx;

    CUresult status = cuInit(0);
    if (status != CUDA_SUCCESS) {
        printf("Failed to create context: %d\n", status);
    }   

    retval = PAPI_library_init(PAPI_VER_CURRENT);
    if (retval != PAPI_VER_CURRENT) {
        printf("Failed to initialize PAPI.\n");
        exit(1);
    } 

    retval = PAPI_create_eventset(&EventSet);
    if (retval != PAPI_OK) {
        printf("Failed to create an EventSet: %d\n", retval);
        return retval; 
    }   

    retval = PAPI_event_name_to_code("cuda:::dram__bytes.avg", &EventCode);
    if (retval != PAPI_OK) {
        printf("Failed to convert name to code: %d\n", retval);
        exit(1);
    }

    retval = PAPI_add_event(EventSet, EventCode);
    if (retval != PAPI_OK) {
        printf("Failed to add event: %d\n", retval);
        exit(1);
    }

    status = cuCtxCreate(&pctx, 0, 0);
    if (status != CUDA_SUCCESS) {
        printf("Failed to create context: %d\n", status);
    }

    retval = PAPI_start(EventSet);
    if (retval != PAPI_OK) {
        printf("Failed to start counting: %d\n", retval);
        exit(1);
    } 

    retval = PAPI_stop(EventSet, values);
    if (retval != PAPI_OK) {
        printf("Failed to stop counting: %d\n", retval);
        exit(1);
    } 

    retval = PAPI_list_events(EventSet, &Events, &number);
    if (retval != PAPI_OK) {
        printf("Failed to list events: %d\n", retval);
        exit(1);
    }   

    retval = PAPI_event_code_to_name(EventCode, EventName);
    if (retval != PAPI_OK) {
        printf("Failed to convert code to name: %d\n", retval);
        exit(1);
    }

    printf("Event Name: %s\nCounter Values: %d\n", EventName, values[0]);
 
    return PAPI_OK;
} 

```
Output:
```
Event Name: cuda:::dram__bytes.avg:device=0
Counter Values: 12
```

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
