### PR TITLE
Update Makefile.in to have PAPI version 7.2.0.0b1.

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -1,7 +1,7 @@
 PAPIVER=7
-PAPIREV=1
+PAPIREV=2
 PAPIAGE=0
-PAPIINC=0
+PAPIINC=0b1
 PREFIX    = @prefix@
 prefix    = $(PREFIX)
 exec_prefix = $(EPREFIX)


### PR DESCRIPTION
## Pull Request Description
In `Makefile.in` the PAPI version was still set to 7.1.0.0, which meant the library file names at the location `papi-install/lib` would read `libpapi.so.7.1` and `libpapi.so.7.1.0.0`.  This PR updates `Makefile.in` to account for the current version of PAPI: 7.2.0.0b1. 

Updating `Makefile.in` with the current version of PAPI will see the library file names updated to:
```
libpapi.so.7.2
libpapi.so.7.2.0.0b1
```

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
