### PR TITLE
sysdetect: accounting for missing core ids.

### DIFF
--- a/src/components/sysdetect/cpu.c
+++ b/src/components/sysdetect/cpu.c
@@ -119,8 +119,10 @@ fill_cpu_info( _sysdetect_cpu_info_t *info )
     }
 
     for (a = 0; a < info->threads * info->cores * info->sockets; ++a) {
-        CPU_CALL(cpu_get_attribute_at(CPU_ATTR__HWTHREAD_NUMA_AFFINITY, a, &info->numa_affinity[a]),
-                 info->numa_affinity[a] = 0);
+        int status = cpu_get_attribute_at(CPU_ATTR__HWTHREAD_NUMA_AFFINITY, a, &info->numa_affinity[a]);
+        if( CPU_SUCCESS != status ){
+            SUBDBG("Warning: core ids might not be contiguous.\n");
+        }
     }
 
     info->cache_levels = level;

--- a/src/components/sysdetect/linux_cpu_utils.c
+++ b/src/components/sysdetect/linux_cpu_utils.c
@@ -765,6 +765,14 @@ get_thread_affinity( int thread, int *val )
         return CPU_SUCCESS;
     }
 
+    // If gaps exist in the core numbering, the caller of this
+    // fucntion will likely inquire about cpu-ids that do not
+    // exist in the system (i.e., the gaps).
+    if( !path_exist(_PATH_SYS_SYSTEM "/cpu/cpu%d", thread) ){
+        *val = -1;
+        return CPU_ERROR;
+    }
+
     int i = 0;
     while (!path_exist(_PATH_SYS_SYSTEM "/cpu/cpu%d/node%d", thread, i)) {
         ++i;

--- a/src/components/sysdetect/sysdetect.c
+++ b/src/components/sysdetect/sysdetect.c
@@ -454,7 +454,11 @@ get_num_threads_per_numa( _sysdetect_cpu_info_t *cpu_info )
 
     int threads = cpu_info->threads * cpu_info->cores * cpu_info->sockets;
     for (k = 0; k < threads; ++k) {
-        cpu_info->num_threads_per_numa[cpu_info->numa_affinity[k]]++;
+        int tmp = cpu_info->numa_affinity[k];
+        // If gaps exist in the core numbering, the numa_affinity entries
+        // for the skipped core ids will be negative.
+        if( tmp >= 0 )
+            cpu_info->num_threads_per_numa[cpu_info->numa_affinity[k]]++;
     }
 
     initialized = 1;

--- a/src/utils/papi_hardware_avail.c
+++ b/src/utils/papi_hardware_avail.c
@@ -202,7 +202,8 @@ main( int argc, char **argv )
                 unsigned int numa_threads[MAX_NUMA_NODES][MAX_CPU_THREADS];
                 for (j = 0; j < threads; ++j) {
                     PAPI_get_dev_attr(handle, j, PAPI_DEV_ATTR__CPU_UINT_THR_NUMA_AFFINITY, &affinity[j]);
-                    numa_threads[affinity[j]][numa_threads_count[affinity[j]]++] = j;
+                    if( affinity[j] >= 0 )
+                        numa_threads[affinity[j]][numa_threads_count[affinity[j]]++] = j;
                 }
 
                 for ( j = 0; j < numas; ++j ) {


### PR DESCRIPTION
## Pull Request Description

Some systems have non-contiguous numbering of cores, which affects the way we count the number of cores each numa node has.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
