### PR TITLE
sysdetect: Fix infinite loop for heterogeneous processors 

### DIFF
--- a/src/components/sysdetect/cpu_utils.c
+++ b/src/components/sysdetect/cpu_utils.c
@@ -98,7 +98,7 @@ cpu_get_cache_info( CPU_attr_e attr, int level, _sysdetect_cache_level_info_t *c
 
     *value = 0;
 
-    if (level >= PAPI_MAX_MEM_HIERARCHY_LEVELS)
+    if (level > PAPI_MAX_MEM_HIERARCHY_LEVELS)
         return CPU_ERROR;
 
     switch(attr) {

--- a/src/components/sysdetect/linux_cpu_utils.c
+++ b/src/components/sysdetect/linux_cpu_utils.c
@@ -765,6 +765,11 @@ get_thread_affinity( int thread, int *val )
         return CPU_SUCCESS;
     }
 
+    if (!path_exist(_PATH_SYS_SYSTEM "/cpu/cpu%d", thread)) {
+        *val = 0;
+        return CPU_SUCCESS;
+    }
+
     int i = 0;
     while (!path_exist(_PATH_SYS_SYSTEM "/cpu/cpu%d/node%d", thread, i)) {
         ++i;


### PR DESCRIPTION
## Pull Request Description

This PR fixes #256 by allowing the problem function to exit. However, this PR does not add support for heterogeneous CPU detection to `sysdetect` and is more of a quick fix to ensure `./utils/papi_hardware_avail` and the `sysdetect` tests fail. Additionally, while working on this I noticed that on Intel Raptorlake `cpu_get_cache_info()` fails to get information for the 4th cache level because the check to ensure no writes are made off the end of the cache level array is too strict. This PR allows the entire array to be used.


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
