### PR TITLE
Add support for AMD family 25 (19h) processors in the RAPL component.

### DIFF
--- a/src/components/rapl/linux-rapl.c
+++ b/src/components/rapl/linux-rapl.c
@@ -505,8 +505,8 @@ _rapl_init_component( int cidx )
 		msr_pkg_energy_status=MSR_AMD_PKG_ENERGY_STATUS;
 		msr_pp0_energy_status=MSR_AMD_PP0_ENERGY_STATUS;
 
-		if (hw_info->cpuid_family!=0x17) {
-			/* Not a family 17h machine */
+		if ((hw_info->cpuid_family!=0x17) && (hw_info->cpuid_family!=0x19)) {
+			/* Not a family 17h or 19h machine */
 			strCpy=strncpy(_rapl_vector.cmp_info.disabled_reason,
 				"CPU family not supported",PAPI_MAX_STR_LEN);
 			_rapl_vector.cmp_info.disabled_reason[PAPI_MAX_STR_LEN-1]=0;


### PR DESCRIPTION
## Pull Request Description
This PR will add support for AMD Family 25 (19h) in the RAPL component. As a result of this, Issue #141 will be resolved. See commit message or below for Zen 3/Zen 4 model's tested. 


# Zen 3 Microarchitecture

## Zen 3: OACISS - Gilgamesh
| System Name  | Family/Model/Stepping |  `papi_native_avail`  | `papi_component_avail` | `papi_command_line`  | RAPL tests |
| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: | :-------------:|
| Gilgamesh  | 25/1/1  | ✅   | ✅ | ✅  | ✅   |

## Zen 3: Oak Ridge - Frontier (Login Node)
| System Name  | Family/Model/Stepping |  `papi_native_avail`  | `papi_component_avail` | `papi_command_line`  | RAPL tests |
| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
| Frontier (Login Node)  | 25/1/1  | ✅   | ✅ | ✅   | ✅  |

## Zen 3: Oak Ridge - Frontier (Compute Node)
| System Name  | Family/Model/Stepping |  `papi_native_avail`  | `papi_component_avail` | `papi_command_line`  | RAPL tests |
| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
| Frontier (Compute Node)  | 25/48/1  | ✅   | ✅  | ✅   | ✅   |

## Zen 3: ICL - Dopamine
| System Name  | Family/Model/Stepping |  `papi_native_avail`  | `papi_component_avail` | `papi_command_line`  | RAPL tests |
| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
| Dopamine  | 25/1/1  | ✅  | ✅  | ✅   | ✅   |

# Zen 4 Microarchitecture

## Zen 4: OACISS - Gary
| System Name  | Family/Model/Stepping |  `papi_native_avail`  | `papi_component_avail` | `papi_command_line`  | RAPL tests |
| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
| Gary  | 25/17/1  | ✅   | ✅  | ✅   | ✅   |

## Zen 4: OACISS - Odyssey
| System Name  | Family/Model/Stepping |  `papi_native_avail`  | `papi_component_avail` | `papi_command_line`  | RAPL tests |
| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
| Odyssey  | 25/144/1  | ✅  | ✅ | ✅   | ✅   |

## Zen 4: OACISS - Roberta
| System Name  | Family/Model/Stepping |  `papi_native_avail`  | `papi_component_avail` | `papi_command_line`  | RAPL tests |
| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
| Roberta  | 25/17/1  | ✅   | ✅  | ✅  | ✅   |


## Zen 4: ICL - Serotonin
| System Name  | Family/Model/Stepping |  `papi_native_avail`  | `papi_component_avail` | `papi_command_line`  | RAPL tests |
| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
| Serotonin | 25/97/2  | ✅   | ✅  | ✅   | ✅   |

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
