### PR TITLE
Update all_native_events.c and get_event_component.c to allow users to optionally disable Cuda native events

### DIFF
--- a/src/ctests/all_native_events.c
+++ b/src/ctests/all_native_events.c
@@ -1,6 +1,7 @@
 /*
  * File:    all_native_events.c
  * Author:  Haihang You <you@cs.utk.edu>
+ * Author:  Treece Burgess tburgess@icl.utk.edu (updated in November 2024 to add a flag to enable or disable Cuda events.)
  */
 
 /* This test tries to add all native events from all components */
@@ -22,169 +23,198 @@
 static int
 check_event( int event_code, char *name, int quiet )
 {
-	int retval;
-	long long values;
-	int EventSet = PAPI_NULL;
+    int retval;
+    long long values;
+    int EventSet = PAPI_NULL;
 
-	/* Possibly there was an older issue with the	*/
-	/* REPLAY_EVENT:BR_MSP on Pentium4 ???		*/
+    /* Possibly there was an older issue with the	*/
+    /* REPLAY_EVENT:BR_MSP on Pentium4 ???		*/
 
-	/* Create an eventset */
-	retval = PAPI_create_eventset( &EventSet );
-	if ( retval != PAPI_OK ) {
-	   test_fail( __FILE__, __LINE__, "PAPI_create_eventset", retval );
-	}
+    /* Create an eventset */
+    retval = PAPI_create_eventset( &EventSet );
+    if ( retval != PAPI_OK ) {
+        test_fail( __FILE__, __LINE__, "PAPI_create_eventset", retval );
+    }
 
-	/* Add the event */
-	retval = PAPI_add_event( EventSet, event_code );
-	if ( retval != PAPI_OK ) {
-		if (!quiet) printf( "Error adding %s %d\n", name, retval );
-		return retval;
-	}
+    /* Add the event */
+    retval = PAPI_add_event( EventSet, event_code );
+    if ( retval != PAPI_OK ) {
+        if (!quiet) printf( "Error adding %s %d\n", name, retval );
+            return retval;
+    }
 
-	/* Start the event */
-	retval = PAPI_start( EventSet );
-	if ( retval != PAPI_OK ) {
-		PAPI_perror( "PAPI_start" );
-	} else {
-		retval = PAPI_stop( EventSet, &values );
-		if ( retval != PAPI_OK ) {
-			PAPI_perror( "PAPI_stop" );
-			return retval;
-		} else {
-			if (!quiet) printf( "Added and Stopped %s successfully.\n", name );
-		}
-	}
+    /* Start the event */
+    retval = PAPI_start( EventSet );
+    if ( retval != PAPI_OK ) {
+        PAPI_perror( "PAPI_start" );
+    } else {
+        retval = PAPI_stop( EventSet, &values );
+        if ( retval != PAPI_OK ) {
+            PAPI_perror( "PAPI_stop" );
+            return retval;
+        } else {
+            if (!quiet) printf( "Added and Stopped %s successfully.\n", name );
+        }
+     }
 
-	/* Cleanup the eventset */
-	retval=PAPI_cleanup_eventset( EventSet );
-	if (retval != PAPI_OK ) {
-		test_fail( __FILE__, __LINE__, "PAPI_cleanup_eventset", retval);
-	}
+     /* Cleanup the eventset */
+     retval=PAPI_cleanup_eventset( EventSet );
+     if (retval != PAPI_OK ) {
+         test_fail( __FILE__, __LINE__, "PAPI_cleanup_eventset", retval);
+     }
 
-	/* Destroy the eventset */
-	retval=PAPI_destroy_eventset( &EventSet );
-	if (retval != PAPI_OK ) {
-		test_fail( __FILE__, __LINE__, "PAPI_destroy_eventset", retval);
-	}
+     /* Destroy the eventset */
+     retval=PAPI_destroy_eventset( &EventSet );
+     if (retval != PAPI_OK ) {
+         test_fail( __FILE__, __LINE__, "PAPI_destroy_eventset", retval);
+     }
 
-	return PAPI_OK;
+     return PAPI_OK;
+}
+
+static void
+print_help(char **argv)
+{
+    printf( "This is the all_native_events program.\n" );
+    printf( "For all components compiled in, it attempts to: add the component events, start, and stop.\n" );
+    printf( "Usage: %s [options]\n", argv[0] );
+    printf( "General command options:\n" );
+    printf( "\t-h, --help                           Print the help message.\n" );
+    printf( "\t--disable-cuda-events=<yes,no>       Optionally disable processing the Cuda native events. Default is no.\n" );
+    printf( "\n" );
 }
 
 int
 main( int argc, char **argv )
 {
 
-	int i, k, add_count = 0, err_count = 0;
-	int retval;
-	PAPI_event_info_t info, info1;
-	const PAPI_hw_info_t *hwinfo = NULL;
-	const PAPI_component_info_t* cmpinfo;
-	int event_code;
-	int numcmp, cid;
-	int quiet;
+    int i, k, add_count = 0, err_count = 0;
+    int retval;
+    PAPI_event_info_t info, info1;
+    const PAPI_hw_info_t *hwinfo = NULL;
+    const PAPI_component_info_t* cmpinfo;
+    char disableCudaEvts[PAPI_MIN_STR_LEN] = "no";
+    int event_code;
+    int numcmp, cid;
+    int quiet;
 
-	/* Set quiet variable */
-	quiet=tests_quiet( argc, argv );
+    /* Set quiet variable */
+    quiet=tests_quiet( argc, argv );
 
-	/* Init PAPI library */
-	retval = PAPI_library_init( PAPI_VER_CURRENT );
-	if ( retval != PAPI_VER_CURRENT ) {
-		test_fail( __FILE__, __LINE__, "PAPI_library_init", retval );
-	}
+    /* parse command line flags */
+    for (i = 0; i < argc; i++) {
+        if (strncmp(argv[i], "--disable-cuda-events=", 22) == 0) {
+            strncpy(disableCudaEvts, argv[i] + 22, PAPI_MIN_STR_LEN);
+        }
 
-	if (!quiet) {
-		printf("Test case ALL_NATIVE_EVENTS: Available "
-				"native events and hardware "
-				"information.\n");
-	}
+        if (strncmp(argv[i], "--help", 6) == 0 ||
+            strncmp(argv[i], "-h", 2) == 0) {
+            print_help(argv);
+            exit(-1);
+        }
+    }
 
-	hwinfo=PAPI_get_hardware_info();
-	if ( hwinfo == NULL ) {
-		test_fail( __FILE__, __LINE__, "PAPI_get_hardware_info", 2 );
-	}
+    /* Init PAPI library */
+    retval = PAPI_library_init( PAPI_VER_CURRENT );
+    if ( retval != PAPI_VER_CURRENT ) {
+        test_fail( __FILE__, __LINE__, "PAPI_library_init", retval );
+    }
 
-	numcmp = PAPI_num_components(  );
+    if (!quiet) {
+        printf("Test case ALL_NATIVE_EVENTS: Available "
+               "native events and hardware "
+               "information.\n");
+    }
+
+    hwinfo=PAPI_get_hardware_info();
+    if ( hwinfo == NULL ) {
+        test_fail( __FILE__, __LINE__, "PAPI_get_hardware_info", 2 );
+    }
+
+    numcmp = PAPI_num_components(  );
 
     int rocm_id = PAPI_get_component_index("rocm");
-
-	/* Loop through all components */
-	for( cid = 0; cid < numcmp; cid++ ) {
-
+    int cuda_id = PAPI_get_component_index("cuda");
+    /* Loop through all components */
+    for( cid = 0; cid < numcmp; cid++ ) {
         if (cid == rocm_id) {
             /* skip rocm component due to a bug in rocprofiler that
              * crashes PAPI if multiple GPUs are present */
             continue;
         }
 
-		cmpinfo = PAPI_get_component_info( cid );
-		if (cmpinfo  == NULL) {
-			test_fail( __FILE__, __LINE__, "PAPI_get_component_info", 2 );
-		}
+        /* optionally skip the Cuda native events, default is no  */
+        if (strcmp(disableCudaEvts, "yes") == 0 && cid == cuda_id) {
+            continue;
+        }
 
-		/* Skip disabled components */
-		if (cmpinfo->disabled != PAPI_OK && cmpinfo->disabled != PAPI_EDELAY_INIT) {
-			if (!quiet) {
-				printf( "Name:   %-23s %s\n",
-					cmpinfo->name ,cmpinfo->description);
-				printf("   \\-> Disabled: %s\n",
-					cmpinfo->disabled_reason);
-			}
-			continue;
-		}
+        cmpinfo = PAPI_get_component_info( cid );
+        if (cmpinfo  == NULL) {
+            test_fail( __FILE__, __LINE__, "PAPI_get_component_info", 2 );
+        }
 
-		/* For platform independence, always ASK FOR the first event */
-		/* Don't just assume it'll be the first numeric value */
-		i = 0 | PAPI_NATIVE_MASK;
-		retval = PAPI_enum_cmp_event( &i, PAPI_ENUM_FIRST, cid );
+        /* Skip disabled components */
+        if (cmpinfo->disabled != PAPI_OK && cmpinfo->disabled != PAPI_EDELAY_INIT) {
+            if (!quiet) {
+                printf( "Name:   %-23s %s\n",
+                    cmpinfo->name ,cmpinfo->description);
+                printf("   \\-> Disabled: %s\n",
+                    cmpinfo->disabled_reason);
+            }
+            continue;
+        }
 
-		do {
-			retval = PAPI_get_event_info( i, &info );
-			event_code = ( int ) info.event_code;
-			if ( check_event( event_code, info.symbol, quiet ) == PAPI_OK) {
-				add_count++;
-			}
-			else {
-				err_count++;
-			}
+        /* For platform independence, always ASK FOR the first event */
+        /* Don't just assume it'll be the first numeric value */
+        i = 0 | PAPI_NATIVE_MASK;
+        retval = PAPI_enum_cmp_event( &i, PAPI_ENUM_FIRST, cid );
 
-			/* We used to skip OFFCORE and UNCORE events  */
-			/* Why? */
+        do {
+            retval = PAPI_get_event_info( i, &info );
+            event_code = ( int ) info.event_code;
+            if ( check_event( event_code, info.symbol, quiet ) == PAPI_OK) {
+                add_count++;
+            }
+            else {
+                err_count++;
+            }
 
-			/* Enumerate all umasks */
-	  k = i;
-	  if ( PAPI_enum_cmp_event(&k, PAPI_NTV_ENUM_UMASKS, cid )==PAPI_OK ) {
-	     do {
-		retval = PAPI_get_event_info( k, &info1 );
-		event_code = ( int ) info1.event_code;
-		if ( check_event( event_code, info1.symbol, quiet ) == PAPI_OK ) {
-		   add_count++;
-		}
-		else {
-		   err_count++;
-		}
-	     } while ( PAPI_enum_cmp_event( &k, PAPI_NTV_ENUM_UMASKS, cid ) == PAPI_OK );
-	  }
+            /* We used to skip OFFCORE and UNCORE events  */
+            /* Why? */
 
-       } while ( PAPI_enum_cmp_event( &i, PAPI_ENUM_EVENTS, cid ) == PAPI_OK );
+            /* Enumerate all umasks */
+            k = i;
+            if ( PAPI_enum_cmp_event(&k, PAPI_NTV_ENUM_UMASKS, cid )==PAPI_OK ) {
+                do {
+                    retval = PAPI_get_event_info( k, &info1 );
+                    event_code = ( int ) info1.event_code;
+                    if ( check_event( event_code, info1.symbol, quiet ) == PAPI_OK ) {
+                        add_count++;
+                    }
+                    else {
+                        err_count++;
+                    }
+                } while ( PAPI_enum_cmp_event( &k, PAPI_NTV_ENUM_UMASKS, cid ) == PAPI_OK );
+            }
+        } while ( PAPI_enum_cmp_event( &i, PAPI_ENUM_EVENTS, cid ) == PAPI_OK );
 
     }
 
-	if (!quiet) {
-		printf( "\n\nSuccessfully found and added %d events "
-			"(in %d eventsets).\n",
-			add_count , add_count);
-	}
+    if (!quiet) {
+        printf( "\n\nSuccessfully found and added %d events "
+            "(in %d eventsets).\n",
+            add_count , add_count);
+    }
 
-	if ( err_count ) {
-		if (!quiet) printf( "Failed to add %d events.\n", err_count );
-	}
+    if ( err_count ) {
+        if (!quiet) printf( "Failed to add %d events.\n", err_count );
+    }
 
-	if ( add_count <= 0 ) {
-		test_fail( __FILE__, __LINE__, "No events added", 1 );
-	}
+    if ( add_count <= 0 ) {
+        test_fail( __FILE__, __LINE__, "No events added", 1 );
+    }
 
-	test_pass( __FILE__ );
+    test_pass( __FILE__ );
 
-	return 0;
+    return 0;
 }

--- a/src/ctests/get_event_component.c
+++ b/src/ctests/get_event_component.c
@@ -1,17 +1,31 @@
 /*
  * File:    get_event_component.c
- * Author:  Vince Weaver
- *	        vweaver1@eecs.utk.edu
+ * Author:  Vince Weaver vweaver1@eecs.utk.edu
+ * Author:  Treece Burgess tburgess@icl.utk.edu (updated in November 2024 to add a flag to enable or disable Cuda events.)
  */
 
 /*
   This test makes sure PAPI_get_event_component() works
 */
-
+#include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "papi.h"
 #include "papi_test.h"
+
+static void
+print_help(char **argv)
+{
+    printf( "This is the get_event_component program.\n" );
+    printf( "For all components compiled in, it uses the function\n" );
+    printf( "PAPI_get_event_component to get the appropriate component index for a native event.\n");
+    printf( "Usage: %s [options]\n", argv[0] );
+    printf( "General command options:\n" );
+    printf( "\t-h, --help                           Print the help message.\n" );
+    printf( "\t--disable-cuda-events=<yes,no>       Optionally disable processing the Cuda native events. Default is no.\n" );
+    printf( "\n" );
+}
 
 int
 main( int argc, char **argv )
@@ -22,14 +36,28 @@ main( int argc, char **argv )
     PAPI_event_info_t info;
     int numcmp, cid, our_cid;
     const PAPI_component_info_t* cmpinfo;
+    char disableCudaEvts[PAPI_MIN_STR_LEN] = "no";
 
     /* Set TESTS_QUIET variable */
     tests_quiet( argc, argv );
 
+    /* parse command line flags */
+    for (i = 0; i < argc; i++) {
+        if (strncmp(argv[i], "--disable-cuda-events=", 22) == 0) {
+            strncpy(disableCudaEvts, argv[i] + 22, PAPI_MIN_STR_LEN);
+        }
+
+        if (strncmp(argv[i], "--help", 6) == 0 ||
+            strncmp(argv[i], "-h", 2) == 0) {
+            print_help(argv);
+            exit(-1);
+        }
+    }
+
     /* Init PAPI library */
     retval = PAPI_library_init( PAPI_VER_CURRENT );
     if ( retval != PAPI_VER_CURRENT ) {
-       test_fail( __FILE__, __LINE__, "PAPI_library_init", retval );
+        test_fail( __FILE__, __LINE__, "PAPI_library_init", retval );
     }
 
     numcmp = PAPI_num_components(  );
@@ -40,48 +68,56 @@ main( int argc, char **argv )
     {
         cmpinfo = PAPI_get_component_info( cid );
 
-         if (cmpinfo  == NULL)
-         {
+        if (cmpinfo  == NULL)
+        {
             test_fail( __FILE__, __LINE__, "PAPI_get_component_info", 2 );
-         }
+        }
 
-         if (cmpinfo->disabled != PAPI_OK && cmpinfo->disabled != PAPI_EDELAY_INIT && !TESTS_QUIET) {
-           printf( "Name:   %-23s %s\n", cmpinfo->name ,cmpinfo->description);
-           printf("   \\-> Disabled: %s\n",cmpinfo->disabled_reason);
-           continue;
-         }
+        /* optionally skip the Cuda native events, default is no  */
+        if (strcmp(cmpinfo->name, "cuda") == 0 &&
+            strcmp(disableCudaEvts, "yes") == 0)
+        {
+            continue;
+        }
 
 
-       i = 0 | PAPI_NATIVE_MASK;
-       retval = PAPI_enum_cmp_event( &i, PAPI_ENUM_FIRST, cid );
-       if (retval!=PAPI_OK) continue;
+        if (cmpinfo->disabled != PAPI_OK && cmpinfo->disabled != PAPI_EDELAY_INIT && !TESTS_QUIET) {
+            printf( "Name:   %-23s %s\n", cmpinfo->name ,cmpinfo->description);
+            printf("   \\-> Disabled: %s\n",cmpinfo->disabled_reason);
+            continue;
+        }
 
-       do {
-	   if (PAPI_get_event_info( i, &info ) != PAPI_OK) {
-	       if (!TESTS_QUIET) {
-		   printf("Getting information about event: %#x failed\n", i);
-	       }
-	       continue;
-	   }
-	  our_cid=PAPI_get_event_component(i);
 
-	  if (our_cid!=cid) {
-	     if (!TESTS_QUIET) {
-	        printf("%d %d %s\n",cid,our_cid,info.symbol);
-	     }
-             test_fail( __FILE__, __LINE__, "component mismatch", 1 );
-	  }
+        i = 0 | PAPI_NATIVE_MASK;
+        retval = PAPI_enum_cmp_event( &i, PAPI_ENUM_FIRST, cid );
+        if (retval!=PAPI_OK) continue;
 
-	  if (!TESTS_QUIET) {
-	    printf("%d %d %s\n",cid,our_cid,info.symbol);
-	  }
+        do {
+            if (PAPI_get_event_info( i, &info ) != PAPI_OK) {
+                if (!TESTS_QUIET) {
+                    printf("Getting information about event: %#x failed\n", i);
+                }
+                continue;
+            }
+            our_cid=PAPI_get_event_component(i);
+
+            if (our_cid!=cid) {
+                if (!TESTS_QUIET) {
+                    printf("%d %d %s\n",cid,our_cid,info.symbol);
+                }
+                test_fail( __FILE__, __LINE__, "component mismatch", 1 );
+            }
+
+            if (!TESTS_QUIET) {
+                printf("%d %d %s\n",cid,our_cid,info.symbol);
+            }
 
 	  
-       } while ( PAPI_enum_cmp_event( &i, PAPI_ENUM_EVENTS, cid ) == PAPI_OK );
+        } while ( PAPI_enum_cmp_event( &i, PAPI_ENUM_EVENTS, cid ) == PAPI_OK );
 
     }
 
-	test_pass( __FILE__ );
+    test_pass( __FILE__ );
 
-	return 0;
+    return 0;
 }


### PR DESCRIPTION
## Pull Request Description
This PR looks to add an optional flag to `all_native_events.c` and `get_event_component.c` titled `--disable-cuda-events` with options of `yes` and `no` (the default is no). The reason for this is due to the runtime length of `all_native_events.c` and `get_event_component.c`when the Cuda component has been compiled in.

Along with the `--disable-cuda-events` option, I have also added `-h` and `--help`. Example of `--help` and `-h` is below (shown is `all_native_events.c`, but similarly is `get_event_component.c`):
```
This is the all_native_events program.
For all components compiled in, it attempts to: add the component events, start, and stop.
Usage: ./all_native_events [options]
General command options:
	-h, --help                           Print the help message.
	--disable-cuda-events=<yes,no>       Optionally disable processing the Cuda native events. Default is no.

```


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
