### PR TITLE
presets: remove PAPI_FP_OPS from POWER9 & POWER10

### DIFF
--- a/src/papi_events.csv
+++ b/src/papi_events.csv
@@ -1844,7 +1844,10 @@ PRESET,PAPI_FMA_INS,NOT_DERIVED,PM_FMA_CMPL
 PRESET,PAPI_TOT_IIS,NOT_DERIVED,PM_INST_DISP
 PRESET,PAPI_TOT_INS,NOT_DERIVED,PM_INST_CMPL
 PRESET,PAPI_INT_INS,NOT_DERIVED,PM_FXU_FIN
-PRESET,PAPI_FP_OPS,NOT_DERIVED,PM_FLOP_CMPL
+# Note: PAPI_FP_OPS is not available on this architecture. The following combination is
+# equivalent to all FLOPs; however, these events cannot be added to the same event set.
+# If a user chooses, they can utilize the multiplexing feature with these events.
+# 8 * PM_8FLOP_CMPL + 4 * PM_4FLOP_CMPL + 2 * PM_2FLOP_CMPL + 1 * PM_1FLOP_CMPL
 PRESET,PAPI_FP_INS,NOT_DERIVED,PM_FLOP_CMPL
 PRESET,PAPI_DP_OPS,NOT_DERIVED,PM_DP_QP_FLOP_CMPL
 PRESET,PAPI_SP_OPS,NOT_DERIVED,PM_SP_FLOP_CMPL
@@ -1892,7 +1895,10 @@ PRESET,PAPI_FMA_INS,NOT_DERIVED,PM_FMA_CMPL
 PRESET,PAPI_TOT_IIS,NOT_DERIVED,PM_INST_DISP
 PRESET,PAPI_TOT_INS,NOT_DERIVED,PM_INST_CMPL
 PRESET,PAPI_INT_INS,NOT_DERIVED,PM_FXU_ISSUE
-PRESET,PAPI_FP_OPS,NOT_DERIVED,PM_FLOP_CMPL
+# Note: PAPI_FP_OPS is not available on this architecture. The following combination is
+# equivalent to all FLOPs; however, these events cannot be added to the same event set.
+# If a user chooses, they can utilize the multiplexing feature with these events.
+# 8 * PM_8FLOP_CMPL + 4 * PM_4FLOP_CMPL + 2 * PM_2FLOP_CMPL + 1 * PM_1FLOP_CMPL
 PRESET,PAPI_FP_INS,NOT_DERIVED,PM_FLOP_CMPL
 PRESET,PAPI_DP_OPS,NOT_DERIVED,PM_DPP_FLOP_CMPL
 PRESET,PAPI_SP_OPS,NOT_DERIVED,PM_SP_FLOP_CMPL


### PR DESCRIPTION
## Pull Request Description

The previous definition counted floating-point instructions instead of operations. Added note to papi_events.csv that explains how to scale and combine native events to measure all FLOPs with multiplexing.

These changes have been tested on the IBM POWER9 and POWER10 architectures.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
