### PR TITLE
cuda/test/Makefile: Remove unecessary linking for cuda 

### DIFF
--- a/src/components/cuda/tests/Makefile
+++ b/src/components/cuda/tests/Makefile
@@ -22,7 +22,6 @@ endif
 CFLAGS += -g $(PAPI_FLAG)
 INCLUDE += -I$(PAPI_CUDA_ROOT)/include
 CUDALIBS = -L$(PAPI_CUDA_ROOT)/lib64 -lcudart -lcuda
-PAPILIB += -L../../../libpfm4/lib -lpfm
 
 cuda_tests: $(TESTS) $(TESTS_NOCTX)
 


### PR DESCRIPTION
## Pull Request Description
The Makefile for CUDA component tests includes the line PAPILIB += -L../../../libpfm4/lib -lpfm for linking, but this linkage is unnecessary and causes errors when the perf_event and perf_event_uncore components are disabled because libpfm4 is not built.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
