### PR TITLE
Adding tests for the lmsensors component

### DIFF
--- a/src/components/lmsensors/tests/Makefile
+++ b/src/components/lmsensors/tests/Makefile
@@ -1,0 +1,19 @@
+NAME=lmsensors
+include ../../Makefile_comp_tests.target
+
+TESTS = lmsensors_list_events \
+        lmsensors_read
+
+lmsensors_tests: $(TESTS)
+
+%.o:%.c
+	$(CC) $(CFLAGS) $(OPTFLAGS) $(INCLUDE) -c -o $@ $<
+
+lmsensors_list_events: lmsensors_list_events.o $(UTILOBJS) $(PAPILIB)
+	$(CC) $(CFLAGS) $(INCLUDE) -o $@ lmsensors_list_events.o $(UTILOBJS) $(PAPILIB) $(LDFLAGS)
+
+lmsensors_read: lmsensors_read.o $(UTILOBJS) $(PAPILIB)
+	$(CC) $(CFLAGS) $(INCLUDE) -o $@ lmsensors_read.o $(UTILOBJS) $(PAPILIB) $(LDFLAGS)
+
+clean:
+	rm -f $(TESTS) *.o

--- a/src/components/lmsensors/tests/lmsensors_list_events.c
+++ b/src/components/lmsensors/tests/lmsensors_list_events.c
@@ -1,0 +1,87 @@
+/****************************/
+/* THIS IS OPEN SOURCE CODE */
+/****************************/
+
+/**
+ * @author  Treece Burgess (tburgess@icl.utk.edu)
+ *
+ * Test case for the lmsensors component.
+ * For GitHub CI and terminal use.
+ *
+ * Tested on Leconte at ICL in winter 2024 with an 
+ * Intel(R) Xeon(R) CPU E5-2698.
+ *
+ * @brief
+ *   List the event code and event name for all 
+ *   available lmsensor events on the current 
+ *   machine.
+ */
+
+#include <stdio.h>
+
+#include "papi.h"
+#include "papi_test.h"
+
+int main(int argc, char **argv) 
+{
+    int retval, event_cnt = 0, EventCode, cidx;
+    char EventName[PAPI_2MAX_STR_LEN];
+
+    /* determine if we quiet output */
+    tests_quiet(argc, argv);
+
+    /* initialize the PAPI library */
+    retval = PAPI_library_init(PAPI_VER_CURRENT);
+    if (retval != PAPI_VER_CURRENT) {
+        test_fail(__FILE__, __LINE__, "PAPI_library_init", retval);
+    }
+
+    /* get the lmsensors component index */
+    cidx = PAPI_get_component_index("lmsensors");
+    if (cidx < 0) {
+        test_fail(__FILE__, __LINE__, "PAPI_get_component_index failed for lmsensors", cidx);
+    }
+
+    if (!TESTS_QUIET) { 
+        printf("Component index for lmsensors: %d\n", cidx);
+    }   
+
+    int modifier = PAPI_ENUM_FIRST;
+    EventCode = PAPI_NATIVE_MASK;
+    retval = PAPI_enum_cmp_event(&EventCode, modifier, cidx);
+    if (retval != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_enum_cmp_event", retval);
+    }
+
+    /* enumerate through all lmsensor events found on the current machine */ 
+    modifier = PAPI_ENUM_EVENTS;
+    do {
+        /* print output header  */
+        if (event_cnt == 0 && !TESTS_QUIET) {
+            printf("%s %s", "Event code", "Event name\n");
+        }
+
+        retval = PAPI_event_code_to_name(EventCode, EventName);
+        if (retval != PAPI_OK) {
+            test_fail(__FILE__, __LINE__, "PAPI_event_code_to_name", retval);
+        }
+
+        if (!TESTS_QUIET) {
+            printf("%d %s\n", EventCode, EventName);
+        }
+
+        /* increment lmsensors event count */
+        event_cnt++;
+    } while(PAPI_enum_cmp_event(&EventCode, modifier, cidx) == PAPI_OK);
+
+    if (!TESTS_QUIET) {
+        printf("Total number of events for lmsensors: %d\n", event_cnt);
+    }
+
+    PAPI_shutdown();
+
+    /* if we make it here everything ran succesfully */
+    test_pass(__FILE__);
+
+    return PAPI_OK;
+}

--- a/src/components/lmsensors/tests/lmsensors_read.c
+++ b/src/components/lmsensors/tests/lmsensors_read.c
@@ -1,0 +1,135 @@
+/****************************/
+/* THIS IS OPEN SOURCE CODE */
+/****************************/
+
+/**
+ * @author  Treece Burgess (tburgess@icl.utk.edu)
+ *
+ * Test case for the lmsensors component.
+ * For GitHub CI and terminal use.
+ *
+ * Tested on Leconte at ICL in winter 2024 with an 
+ * Intel(R) Xeon(R) CPU E5-2698.
+ *
+ * @brief
+ *   Creating a PAPI EventSet with lmsensor events
+ *   to add, start, read, and stop. 
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "papi.h"
+#include "papi_test.h"
+
+/* number of events we want to add to the PAPI EventSet */
+#define NUM_EVENTS 3
+
+int main(int argc, char **argv)
+{
+    int retval, i, event_cnt = 0, cidx;
+    int EventCode, EventSet = PAPI_NULL;
+    long long values[NUM_EVENTS];
+    char EventName[PAPI_MAX_STR_LEN], lm_events[NUM_EVENTS][PAPI_MAX_STR_LEN];
+
+    /* determine if we quiet output */
+    tests_quiet(argc, argv);
+
+    /* initialize the PAPI library */
+    retval = PAPI_library_init(PAPI_VER_CURRENT);
+    if (retval != PAPI_VER_CURRENT) {
+        test_fail(__FILE__, __LINE__, "PAPI_library_init", retval);
+    }
+
+    /* get the lmsensors component index */
+    cidx = PAPI_get_component_index("lmsensors");
+    if (cidx < 0) {
+        test_fail(__FILE__, __LINE__, "PAPI_get_component_index, failed for lmsensors", cidx);
+    }
+    
+    if (!TESTS_QUIET) { 
+        printf("Component index for lmsensors: %d\n", cidx);
+    }
+
+    /* create a PAPI eventset */
+    retval = PAPI_create_eventset(&EventSet);
+    if (retval != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_create_eventset", retval);
+    }
+
+    int modifier = PAPI_ENUM_FIRST;
+    EventCode = PAPI_NATIVE_MASK;
+    retval = PAPI_enum_cmp_event(&EventCode, modifier, cidx);
+    if (retval != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_enum_cmp_event", retval);
+    }   
+
+    /* enumerate UNITL we find 3 Core and max temp events  */ 
+    modifier = PAPI_ENUM_EVENTS;
+    do {
+        retval = PAPI_event_code_to_name(EventCode, EventName);
+        if (retval != PAPI_OK) {
+            test_fail(__FILE__, __LINE__, "PAPI_event_code_to_name", retval);
+        }
+
+        /* filter for only core and max temp events, max of three events to be added  */
+        if (strstr(EventName, "Core") && strstr(EventName, "max")) {
+            retval = PAPI_add_named_event(EventSet, EventName);
+            if (retval != PAPI_OK) {
+                test_fail(__FILE__, __LINE__, "PAPI_add_named_event", retval); 
+            }
+              
+            if (!TESTS_QUIET) { 
+                printf("Successfully added %s to the EventSet.\n", EventName);
+            }
+            
+            /* store current event name and increment count */
+            strncpy(lm_events[event_cnt], EventName, PAPI_MAX_STR_LEN);
+            event_cnt++;
+        }
+    } while( ( PAPI_enum_cmp_event(&EventCode, modifier, cidx) == PAPI_OK ) && ( event_cnt < NUM_EVENTS ) );
+
+    /* start counting */
+    retval = PAPI_start(EventSet);
+    if (retval != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_start", retval);
+    }
+
+    /* read temp values */
+    retval = PAPI_read(EventSet, values);
+    if (retval != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_read", retval);
+    }
+
+    /* stop counting and ignore values */
+    retval = PAPI_stop(EventSet, NULL);
+    if (retval != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_stop", retval);
+    }
+
+    /* print out temp values for each event  */
+    if (!TESTS_QUIET) {
+        printf("Max temp output for events:\n");
+        for (i = 0; i < NUM_EVENTS; i++) {
+            printf("%s: %d\n", lm_events[i], values[i]);       
+        }
+    } 
+   
+    /* cleanup for PAPI */
+    retval = PAPI_cleanup_eventset(EventSet);
+    if (retval != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_cleanup_eventset", retval);
+    }
+
+    retval = PAPI_destroy_eventset(&EventSet);
+    if (retval != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_destory_eventset", retval);
+    }
+
+    PAPI_shutdown();
+
+    /* if we make it here everything ran succesfully */
+    test_pass(__FILE__);
+
+    return PAPI_OK;
+}


### PR DESCRIPTION
## Pull Request Description
This PR addresses adding tests for the lmsensors component as currently none exist. 

This continues the updates for the overall GitHub CI for PAPI. As such, these tests will not take a command line argument; rather, we will search for events using `PAPI_enum_cmp_event`.

Truncated output for `lmsensors_list_events.c`:
```
Component index for lmsensors: 2
Event code Event name
1073741870 lmsensors:::coretemp-isa-0000.Package_id_0.temp1_input
1073741871 lmsensors:::coretemp-isa-0000.Package_id_0.temp1_max
1073741872 lmsensors:::coretemp-isa-0000.Package_id_0.temp1_crit
1073741873 lmsensors:::coretemp-isa-0000.Package_id_0.temp1_crit_alarm
....
Total number of events for lmsensor: 170
PASSED
```

Output for `lmsensors_read.c`:
```
Component index for lmsensors: 2
Successfully added lmsensors:::coretemp-isa-0000.Core_0.temp2_max to the EventSet.
Successfully added lmsensors:::coretemp-isa-0000.Core_1.temp3_max to the EventSet.
Successfully added lmsensors:::coretemp-isa-0000.Core_2.temp4_max to the EventSet.
Max temp output for events:
lmsensors:::coretemp-isa-0000.Core_0.temp2_max: 95000
lmsensors:::coretemp-isa-0000.Core_1.temp3_max: 95000
lmsensors:::coretemp-isa-0000.Core_2.temp4_max: 95000
PASSED
```

Tested with `run_tests.sh` when the `lmsensors` component is compiled in:
 - `lmsensors` tests show up in "The following test cases will be run" section when compiled in
 - `lmsensors` tests run and output in the "Running Component Tests" section
 
Tested with `run_tests.sh` when the `lmsensors` component is not compiled in:
- `lmsensors` tests show up in "The following test cases will NOT be run" section

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
