### PR TITLE
Update libpfm4 to commit 69550d

### DIFF
--- a/src/libpfm4/lib/events/arm_neoverse_n1_events.h
+++ b/src/libpfm4/lib/events/arm_neoverse_n1_events.h
@@ -99,6 +99,12 @@ static const arm_entry_t arm_n1_pe[]={
 	 .code = 0x14,
 	 .desc = "Level 1 instruction cache accesses"
 	},
+	{.name = "L1I_CACHE",
+	 .modmsk = ARMV9_ATTRS,
+	 .equiv = "L1I_CACHE",
+	 .code = 0x14,
+	 .desc = "Level 1 instruction cache accesses (deprecated)"
+	},
 	{.name = "L1D_CACHE_WB",
 	 .modmsk = ARMV8_ATTRS,
 	 .code = 0x15,

--- a/src/libpfm4/lib/events/arm_neoverse_n2_events.h
+++ b/src/libpfm4/lib/events/arm_neoverse_n2_events.h
@@ -96,6 +96,12 @@ static const arm_entry_t arm_n2_pe[]={
 	},
 	{.name = "L1I_CACHE_ACCESS",
 	 .modmsk = ARMV9_ATTRS,
+	 .equiv = "L1I_CACHE",
+	 .code = 0x14,
+	 .desc = "Level 1 instruction cache accesses (deprecated)"
+	},
+	{.name = "L1I_CACHE",
+	 .modmsk = ARMV9_ATTRS,
 	 .code = 0x14,
 	 .desc = "Level 1 instruction cache accesses"
 	},

--- a/src/libpfm4/lib/events/arm_neoverse_v1_events.h
+++ b/src/libpfm4/lib/events/arm_neoverse_v1_events.h
@@ -104,6 +104,12 @@ static const arm_entry_t arm_v1_pe[]={
 	},
 	{.name = "L1I_CACHE_ACCESS",
 	 .modmsk = ARMV8_ATTRS,
+	 .equiv = "L1I_CACHE",
+	 .code = 0x14,
+	 .desc = "Level 1 instruction cache accesses (deprecated)"
+	},
+	{.name = "L1I_CACHE",
+	 .modmsk = ARMV9_ATTRS,
 	 .code = 0x14,
 	 .desc = "Level 1 instruction cache accesses"
 	},

--- a/src/libpfm4/lib/events/arm_neoverse_v2_events.h
+++ b/src/libpfm4/lib/events/arm_neoverse_v2_events.h
@@ -102,6 +102,12 @@ static const arm_entry_t arm_v2_pe[]={
 	},
 	{.name = "L1I_CACHE_ACCESS",
 	 .modmsk = ARMV9_ATTRS,
+	 .equiv = "L1I_CACHE",
+	 .code = 0x14,
+	 .desc = "Level 1 instruction cache accesses (deprecated)"
+	},
+	{.name = "L1I_CACHE",
+	 .modmsk = ARMV9_ATTRS,
 	 .code = 0x14,
 	 .desc = "Level 1 instruction cache accesses"
 	},


### PR DESCRIPTION
Current with
commit d22403ec9bddaf62c59d847904918b30db69550d
Author: Stephane Eranian <eranian@gmail.com>
Date:   Fri Dec 13 00:42:42 2024 -0800

    make L1I_CACHE_ACCESS an alias to the official L1I_CACHE event

    Covers Neoverse N1, N2, N3, V1, V2.
    L1I_CACHE_ACCESS is marked as deprecated.

    Signed-off-by: Stephane Eranian <eranian@gmail.com>

commit 0003418f8b698cbb2709e7f6931c6fd94e634f98
Author: Stephane Eranian <eranian@gmail.com>
Date:   Fri Dec 13 00:23:03 2024 -0800

    update perf_events interface header to 6.12

    Update perf_event.h to reflect state in 6.12.

    Signed-off-by: Stephane Eranian <eranian@gmail.com>

Testing was only done on an ARM Neoverse V2 as the PAPI team does not have access to an N1, N2, N3, or V1.

Testing:
- papi_avail successfully runs
- papi_component_avail successfully runs
- papi_native_avail shows the new event L1I_CACHE and that L1I_CACHE_ACCESS is deprecated
- papi_command_line works with L1I_CACHE (tested with qualifiers cpu and u)

## Pull Request Description


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
