### PR TITLE
Add loongarch64 support

### DIFF
--- a/src/linux-context.h
+++ b/src/linux-context.h
@@ -35,6 +35,8 @@ typedef ucontext_t hwd_ucontext_t;
 #define OVERFLOW_ADDRESS(ctx) ctx.ucontext->uc_mcontext.arm_pc
 #elif defined(__aarch64__)
 #define OVERFLOW_ADDRESS(ctx) ctx.ucontext->uc_mcontext.pc
+#elif defined(__loongarch64)
+#define OVERFLOW_ADDRESS(ctx) ctx.ucontext->uc_mcontext.__pc
 #elif defined(__mips__)
 #define OVERFLOW_ADDRESS(ctx) ctx.ucontext->uc_mcontext.pc
 #elif defined(__hppa__)

--- a/src/linux-timer.c
+++ b/src/linux-timer.c
@@ -246,6 +246,22 @@ get_cycles( void )
 }
 
 /************************/
+/* loongarch64 get_cycles() */
+/************************/
+
+#elif defined(__loongarch64)
+static inline long long
+get_cycles( void )
+{
+	int rid = 0;
+	unsigned long ret;
+
+	__asm__ __volatile__ ( "rdtime.d %0, %1" : "=r" (ret), "=r" (rid) );
+
+	return ret;
+}
+
+/************************/
 /* POWER get_cycles()   */
 /************************/
 

--- a/src/mb.h
+++ b/src/mb.h
@@ -39,6 +39,9 @@
 #elif defined(__aarch64__)
 #define rmb()           asm volatile("dmb ld" ::: "memory")
 
+#elif defined(__loongarch64)
+#define rmb()           __asm__ __volatile__("dbar 0" : : : "memory")
+
 #elif defined(__mips__)
 #define rmb()           asm volatile(                                   \
                                 ".set   mips2\n\t"                      \


### PR DESCRIPTION
## Pull Request Description
Add loongarch64 support.

## Author Checklist
- [ ] **Description**
Compiling the papi failed for loong64 in the Debian Package Auto-Building environment.
The full compilation log can be found at 
https://buildd.debian.org/status/logs.php?pkg=papi&ver=7.0.1-1&arch=loong64
```
./linux-context.h:43:2: error: #error "OVERFLOW_ADDRESS() undefined!"
   43 | #error "OVERFLOW_ADDRESS() undefined!"
      |  ^~~~~
In file included from ./linux-lock.h:4,
                 from ./papi_lock.h:20,
                 from ./papi_internal.h:437:
./mb.h:67:2: error: #error Need to define rmb for this architecture!
   67 | #error Need to define rmb for this architecture!
```
- [ ] **Tests**
Now, papi was built successfully on loongarch64.
Details can be found at https://buildd.debian.org/status/logs.php?pkg=papi&ver=7.1.0-5%2Bb1&arch=loong64.

Please review.
