### PR TITLE
Parse event qualifiers for the Rocm and Cuda components to make sure no excess characters are appended

### DIFF
--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -2920,7 +2920,12 @@ static int evt_name_to_device(const char *name, int *device, const char *base)
     char *p = strstr(name, ":device=");
     // User did provide :device=# qualifier
     if (p != NULL) {
-        *device = (int) strtol(p + strlen(":device="), NULL, 10);
+        char *endPtr;
+        *device = (int) strtol(p + strlen(":device="), &endPtr, 10);
+        // Check to make sure no excess characters have been appeneded
+        if (*endPtr != '\0') {
+            return PAPI_ENOEVNT;
+        }
     }
     // User did not provide :device=# qualifier
     else {

--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -2922,9 +2922,11 @@ static int evt_name_to_device(const char *name, int *device, const char *base)
     if (p != NULL) {
         char *endPtr;
         *device = (int) strtol(p + strlen(":device="), &endPtr, 10);
-        // Check to make sure no excess characters have been appeneded
+        // Check to make sure only qualifiers have been appended
         if (*endPtr != '\0') {
-            return PAPI_ENOEVNT;
+            if (strncmp(endPtr, ":stat", 5) != 0) {
+                return PAPI_ENOEVNT;
+            }
         }
     }
     // User did not provide :device=# qualifier
@@ -2961,15 +2963,20 @@ static int evt_name_to_stat(const char *name, int *stat, const char *base)
     cuptiu_event_t *event;
     char *p = strstr(name, ":stat=");
     if (p != NULL) {
-      p += 6; // Move past ":stat="
-      int i;
-      for (i = 0; i < NUM_STATS_QUALS; i++) {
-          size_t token_len = strlen(stats[i]);
-          if (strncmp(p, stats[i], token_len) == 0) {
-                *stat = i;
-                return PAPI_OK;
-          }
+        p += 6; // Move past ":stat="
+        int i;
+        for (i = 0; i < NUM_STATS_QUALS; i++) {
+            size_t token_len = strlen(stats[i]);
+            if (strncmp(p, stats[i], token_len) == 0) {
+                // Check to make sure only qualifiers have been appended 
+                char *no_excess_chars = p + token_len;
+                if (strlen(no_excess_chars) == 0 || strncmp(no_excess_chars, ":device", 7) == 0) {
+                    *stat = i;
+                    return PAPI_OK;
+                }
+            }
         }
+        return PAPI_ENOEVNT;
     } else {
         htable_errno = htable_find(cuptiu_table_p->htable, base, (void **) &event);
         if (htable_errno != HTABLE_SUCCESS) {
@@ -2984,5 +2991,4 @@ static int evt_name_to_stat(const char *name, int *stat, const char *base)
           }
         }
     }
-    return PAPI_OK;
 }

--- a/src/components/rocm/roc_profiler.c
+++ b/src/components/rocm/roc_profiler.c
@@ -812,7 +812,15 @@ evt_name_to_device(const char *name, int *device)
     if (!p) {
         return PAPI_ENOEVNT;
     }
-    *device = (int) strtol(p + strlen(":device="), NULL, 10);
+
+    char *endPtr;
+    *device = (int) strtol(p + strlen(":device="), &endPtr, 10);
+    /* check to make sure only qualifiers have been appended */
+    if (*endPtr != '\0') {
+        if (strncmp(endPtr, ":instance=", 10) != 0) {
+            return PAPI_ENOEVNT;
+        }
+    }
     return PAPI_OK;
 }
 
@@ -837,7 +845,15 @@ evt_name_to_instance(const char *name, int *instance)
         if (!p) {
             return PAPI_ENOEVNT;
         }
-        *instance = (int) strtol(p + strlen(":instance="), NULL, 10);
+
+        char *endPtr;
+        *instance = (int) strtol(p + strlen(":instance="), &endPtr, 10);
+        /* check to make sure only qualifiers have been appended */
+        if (*endPtr != '\0') {
+            if (strncmp(endPtr, ":device=", 8) != 0) {
+                return PAPI_ENOEVNT;
+            }
+        }
     } else {
         if (p) {
             return PAPI_ENOEVNT;


### PR DESCRIPTION
## Pull Request Description
For both the Cuda component and the ROCm component, when adding events there is a an edge case where a user could successfully add events that had excess characters after the appended qualifier.  Example of this is shown below with the Cuda component:

```
./papi_command_line cuda:::dram__bytes.avg:device=0test

This utility lets you add events from the command line interface to see if they work.

Successfully added: cuda:::dram__bytes.avg:device=0test

cuda:::dram__bytes.avg:device=0test : 	268 
```

This PR addresses adding conditional checks to test for excess characters and properly return `PAPI_ENOEVNT` if applicable. The new behavior is outlined below:

```
[ICL:methane bin]$ ./papi_command_line cuda:::dram__bytes:stat=max:device=0dfdf

This utility lets you add events from the command line interface to see if they work.

Failed adding: cuda:::dram__bytes:stat=max:device=0dfdf
because: Event does not exist
No events specified!
Try running something like: ./papi_command_line PAPI_TOT_CYC
```

```
[ICL:methane bin]$ ./papi_command_line cuda:::dram__bytes:stat=max01dfdf:device=0

This utility lets you add events from the command line interface to see if they work.

Failed adding: cuda:::dram__bytes:stat=max01dfdf:device=0
because: Event does not exist
No events specified!
Try running something like: ./papi_command_line PAPI_TOT_CYC
```

The Cuda component has been verified on Methane (1 * A100) and Leconte (8 * V100s) with `papi_command_line` using Cuda Toolkit 12.5.
The ROCm component has been verified on Dopamine (1 * MI210s as of April 17th, 2025) with `papi_command_line`.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
