### PR TITLE
Fix for Bug in Counter Analysis Toolkit Workflow for PAPI CI

### DIFF
--- a/.github/workflows/cat_workflow.yml
+++ b/.github/workflows/cat_workflow.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  cat tests:
+  cat_tests:
     strategy:
       matrix:
         debug: [yes, no] 


### PR DESCRIPTION
## Pull Request Description
This PR fixes a small bug in the counter analysis toolkit CI where `cat tests` needs to be `cat_tests` in the `cat_workflow.yml`.


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
