### PR TITLE
Remove maxPassCount from NVPW_RawMetricsConfig_BeginPassGroup_Params Initialization

### DIFF
--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -557,7 +557,6 @@ static int calculate_num_passes(struct NVPA_RawMetricsConfig *pRawMetricsConfig,
         .structSize = NVPW_RawMetricsConfig_BeginPassGroup_Params_STRUCT_SIZE,
         .pPriv = NULL, // assign to NULL
         .pRawMetricsConfig = pRawMetricsConfig,
-        .maxPassCount = 1,
     };
     nvpa_err = NVPW_RawMetricsConfig_BeginPassGroupPtr(&beginPassGroupParams);
     if (nvpa_err != NVPA_STATUS_SUCCESS) {


### PR DESCRIPTION
## Pull Request Description

Building PAPI with the Cuda component compiled in with Cuda versions >= 12.3 (specifically tested 12.3, 12.4, and 12.5) would result in a subset of native events showing a `Numpass=0` when running `papi_native_avail`.  From my testing this did not occur with Cuda versions 12.1 and 12.2.  See below for more details.

## Bug output for `papi_native_avail`
This behavior was able to be reproduced on a machine with an A100 and on a machine with an H200. 

Event from the A100:
```
--------------------------------------------------------------------------------
| cuda:::gpu__compute_memory_access_throughput.avg.pct_of_peak_sustained_elapsed    |
|            Compute Memory Pipeline : throughput of internal activity within c|
|            aches and DRAM. Units=(percent) Numpass=0                         |       
|     :device=0                                                                |       
|            Mandatory device qualifier [0]                                    |       
--------------------------------------------------------------------------------
```
Event from the H200:
```
--------------------------------------------------------------------------------
| cuda:::sm__ops_path_tensor_src_fp16.sum                                      |       
|            # of math ops executed in Tensor path with source FP16. Units=(mat|
|            h_ops) Numpass=0                                                  |       
|     :device=0                                                                |       
|            Mandatory device qualifier [0]                                    |       
--------------------------------------------------------------------------------
```

## Reason for the Bug Occurring

The error `NVPA_STATUS_ERROR` was occurring at the call of `NVPW_RawMetricsConfig_AddMetrics` and would result in the above behavior. The error and above behavior stemmed from setting the member variable `maxPassCount = 1` for the structure `NVPW_RawMetricsConfig_BeginPassGroup_Params`. Upon removing this member variable, the Numpass values were correctly set. 

## Output for `papi_native_avail` with `maxPassCount` removed

Event from the A100:
```
--------------------------------------------------------------------------------
| cuda:::gpu__compute_memory_access_throughput.avg.pct_of_peak_sustained_elapsed    |
|            Compute Memory Pipeline : throughput of internal activity within c|
|            aches and DRAM. Units=(percent) Numpass=4 (multi-pass not supporte|
|            d)                                                                |       
|     :device=0                                                                |       
|            Mandatory device qualifier [0]                                    |       
--------------------------------------------------------------------------------

```

Event from the H200:
```
--------------------------------------------------------------------------------
| cuda:::sm__ops_path_tensor_src_fp16.sum                                      |       
|            # of math ops executed in Tensor path with source FP16. Units=(mat|
|            h_ops) Numpass=2 (multi-pass not supported)                       |       
|     :device=0                                                                |       
|            Mandatory device qualifier [0]                                    |       
--------------------------------------------------------------------------------
```

## Replicating Bug in Source File with Only Cuda Code
The sample codes provided by NVIDIA in the Cuda toolkit installations (`$CUDA_HOME/extras/CUPTI/samples/cupti_metric_properties/`) did not show them actually setting `maxPassCount`. Upon me setting `maxPassCount = 1`, I observed the same error of `NVPA_STATUS_ERROR` for the function call of `NVPW_RawMetricsConfig_AddMetrics`. 


## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
