### PR TITLE
Eliminate conflicting type errors generated by GCC15

### DIFF
--- a/src/high-level/papi_hl.c
+++ b/src/high-level/papi_hl.c
@@ -167,7 +167,7 @@ static int _internal_hl_checkCounter ( char* counter );
 static int _internal_hl_determine_rank();
 static char *_internal_hl_remove_spaces( char *str, int mode );
 static int _internal_hl_determine_default_events();
-static int _internal_hl_read_user_events();
+static int _internal_hl_read_user_events(const char *user_events);
 static int _internal_hl_new_component(int component_id, components_t *component);
 static int _internal_hl_add_event_to_component(char *event_name, int event,
                                         short event_type, components_t *component);

--- a/src/papi_vector.c
+++ b/src/papi_vector.c
@@ -218,7 +218,7 @@ _papi_hwi_innoculate_os_vector( papi_os_vector_t * v )
 	if ( !v->update_shlib_info )
 		v->update_shlib_info = ( int ( * )( papi_mdi_t * ) ) vec_int_dummy;
 	if ( !v->get_system_info )
-		v->get_system_info = ( int ( * )(  ) ) vec_int_dummy;
+		v->get_system_info = ( int ( * )( papi_mdi_t * ) ) vec_int_dummy;
 
 	if ( !v->get_memory_info )
 		v->get_memory_info =


### PR DESCRIPTION
Recent PAPI compiles on Fedora rawhide (F42) fail because of "conflicting types" errors produced by GCC15.  Proper arguments types have been added to _internal_hl_read_user_events function declaration in papi_hl.c and the typecasting in papi_vector.c.

## Pull Request Description


## Author Checklist
- [x ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x ] **Tests**
The PR needs to pass all the tests
