### PR TITLE
Updating error messages for function check_exclude_guest() in perf_event.c

### DIFF
--- a/src/components/perf_event/perf_event.c
+++ b/src/components/perf_event/perf_event.c
@@ -289,7 +289,8 @@ check_exclude_guest( void )
 
 	ev_fd = sys_perf_event_open( &attr, 0, -1, -1, 0 );
 	if ( ev_fd == -1 ) {
-		PAPIERROR("Couldn't open hw_instructions in exclude_guest=0 test");
+		PAPIERROR("Couldn't open hw_instructions in exclude_guest=0 test. " 
+			      "Set /proc/sys/kernel/perf_event_paranoid to 2 (or less) or run as root.");
 		return;
 	}
 	close(ev_fd);
@@ -306,7 +307,8 @@ check_exclude_guest( void )
 			exclude_guest_unsupported=1;
 		}
 		else {
-		  PAPIERROR("Couldn't open hw_instructions in exclude_guest=1 test");
+		  PAPIERROR("Couldn't open hw_instructions in exclude_guest=1 test. "
+			        "Set /proc/sys/kernel/perf_event_paranoid to 2 (or less) or run as root.");
 		}
 	} else {
 		exclude_guest_unsupported=0;


### PR DESCRIPTION
## Pull Request Description
As stands, if a failure occurs in `check_exclude_guest` then one of the following errors will output: 
```
Couldn't open hw_instructions in exclude_guest=0 test.
or
Couldn't open hw_instructions in exclude_guest=1 test.
```
This PR updates both error messages to include:
```
Set /proc/sys/kernel/perf_event_paranoid to 2 (or less) or run as root.
```
Such that it indicates to users this is a `perf_event_paranoid` issue.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
