### PR TITLE
Replace actions/upload-artifact@v3 with actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/papi_framework_workflow.yml
+++ b/.github/workflows/papi_framework_workflow.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Run static analysis
         run: .github/workflows/clang_analysis.sh clang-analysis-output
       - name: Archive analysis results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: clang-analysis-output


### PR DESCRIPTION
## Pull Request Description
As of January 30th, 2025 `actions/upload-artifact@v3` has been deprecated and replaced with `actions/upload-artifact@v4`. See the following [article](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) for more details.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
