### PR TITLE
Add Support for Heterogeneous GPU Configurations in the Cuda Component

### DIFF
--- a/src/components/cuda/cupti_dispatch.c
+++ b/src/components/cuda/cupti_dispatch.c
@@ -262,7 +262,7 @@ int cuptid_evt_code_to_name(uint64_t event_code, char *name, int len)
         return cuptip_evt_code_to_name(event_code, name, len);
 #endif
 
-    } else if(cuptic_is_runtime_perfworks_api()) {
+    } else if(cuptic_is_runtime_events_api()) {
 
 #if defined(API_EVENTS)
         return cuptie_evt_code_to_name(event_code, name, len);
@@ -280,7 +280,7 @@ int cuptid_evt_code_to_info(uint64_t event_code, PAPI_event_info_t *info)
         return cuptip_evt_code_to_info(event_code, info);
 #endif
 
-    } else if(cuptic_is_runtime_perfworks_api()) {
+    } else if(cuptic_is_runtime_events_api()) {
 
 #if defined(API_EVENTS)
         return cuptie_evt_code_to_info(event_code, info);

--- a/src/components/cuda/cupti_utils.h
+++ b/src/components/cuda/cupti_utils.h
@@ -9,10 +9,14 @@
 #define __CUPTI_UTILS_H__
 
 #include <papi.h>
+
+#include <nvperf_cuda_host.h> 
+
 #include <stdint.h>
 
 typedef int64_t cuptiu_bitmap_t;
 typedef int (*cuptiu_dev_get_map_cb)(uint64_t event_id, int *dev_id);
+typedef NVPW_CUDA_MetricsContext_Create_Params MCCP_t;
 
 typedef struct event_record_s {
     char name[PAPI_2MAX_STR_LEN];
@@ -20,11 +24,20 @@ typedef struct event_record_s {
     cuptiu_bitmap_t device_map;
 } cuptiu_event_t;
 
+typedef struct gpu_record_s {
+    char chip_name[PAPI_MIN_STR_LEN];
+    MCCP_t *pmetricsContextCreateParams;
+    int num_metrics;
+    const char* const* metric_names;
+} gpu_record_t;
+
 typedef struct event_table_s {
-    unsigned int count;
+    int count;
     unsigned int capacity;
-    char added_cuda_evts[30][PAPI_2MAX_STR_LEN];
-    int added_cuda_dev[30];
+    char cuda_evts[30][PAPI_2MAX_STR_LEN];
+    int cuda_devs[30];
+    int evt_pos[30];
+    gpu_record_t *avail_gpu_info;
     cuptiu_event_t *events;
     void *htable;
 } cuptiu_event_table_t;

--- a/src/components/cuda/papi_cupti_common.h
+++ b/src/components/cuda/papi_cupti_common.h
@@ -65,7 +65,7 @@ int cuptic_shutdown(void);
 
 /* context management interfaces */
 int cuptic_ctxarr_create(cuptic_info_t *pinfo);
-int cuptic_ctxarr_update_current(cuptic_info_t info);
+int cuptic_ctxarr_update_current(cuptic_info_t info, int evt_dev_id);
 int cuptic_ctxarr_get_ctx(cuptic_info_t info, int gpu_idx, CUcontext *ctx);
 int cuptic_ctxarr_destroy(cuptic_info_t *pinfo);
 


### PR DESCRIPTION
## Pull Request Description
This PR adds support for heterogeneous gpu configurations. As a consequence the following were also updated:
 - How we internally handle the default device id
 - How we handle creating a context for users if one is not provided

Tested on Leconte (8 * V100) and Hexane (1 * V100 & 1 * H100):

| Test  | Pass |
| :-------------: | :-------------: |
| HelloWorld.cu  | :white_check_mark:   |
| HelloWorld_noCuCtx.cu  | :white_check_mark:  |
| concurrent_profiling.cu  | :white_check_mark:  |
| concurrent_profiling_noCuCtx.cu  | :white_check_mark:  |
| cudaOpenMP.cu | :white_check_mark:  |
| cudaOpenMP_noCuCtx.cu | :white_check_mark:  |
| pthreads.cu | :white_check_mark: |
| pthreads_noCuCtx.cu  | :white_check_mark: |
| simpleMultiGPU.cu  | :white_check_mark:  |
| simpleMultiGPU_noCuCtx.cu | :white_check_mark:  |
| test_2thr_1gpu_not_allowed.cu  | :white_check_mark: |
| test_multi_read_and_reset.cu  | :white_check_mark: |
| test_multipass_event_fail.cu | :white_check_mark:  |


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
