### PR TITLE
Fix shared build for rocp_sdk

### DIFF
--- a/src/components/rocp_sdk/Rules.rocp_sdk
+++ b/src/components/rocp_sdk/Rules.rocp_sdk
@@ -1,4 +1,4 @@
-COMPSRCS += components/rocp_sdk/rocp_sdk.c
+COMPSRCS += components/rocp_sdk/rocp_sdk.c components/rocp_sdk/sdk_class.cpp
 
 COMPOBJS += rocp_sdk.o sdk_class.o
 


### PR DESCRIPTION
## Pull Request Description
Fixes #313. 

## Author Checklist
- [x ] **Description**
The `sdk_class` source file was missing from the source files list and thus not included in `libpapi.so`, leading to errors at load time. Fixed.
- [x] **Commits**
- [ ] **Tests**
