### PR TITLE
Adding location of rocm_smi header files for newer versions of rocm

### DIFF
--- a/src/components/rocm_smi/Rules.rocm_smi
+++ b/src/components/rocm_smi/Rules.rocm_smi
@@ -87,6 +87,7 @@ COMPOBJS += linux-rocm-smi.o \
 CFLAGS += -I$(PAPI_ROCMSMI_ROOT)/../include/rocm_smi
 CFLAGS += -I$(PAPI_ROCMSMI_ROOT)/../include
 CFLAGS += -I$(PAPI_ROCMSMI_ROOT)/include/rocm_smi
+CFLAGS += -I$(PAPI_ROCMSMI_ROOT)/include
 CFLAGS += -g
 LDFLAGS += $(LDL) -g
 


### PR DESCRIPTION
## Pull Request Description

In rocm 6.3, the location of rocm_smi has changed.  Setting `PAPI_ROCMSMI_ROOT=/opt/rocm/` is insufficient to point to the new location because the rocm_smi component "Rules" file appends "rocm_smi" to the include search path.  THis change to the Rules file will allow the component to find the header.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
