### PR TITLE
Adjust NVIDIA library names

### DIFF
--- a/src/components/cuda/papi_cupti_common.c
+++ b/src/components/cuda/papi_cupti_common.c
@@ -54,13 +54,13 @@ cudaError_t ( *cudaRuntimeGetVersionPtr ) (int *);
 CUptiResult ( *cuptiGetVersionPtr ) (uint32_t* );
 
 /**@class load_cuda_sym
- * @brief Search for libcuda.so.
+ * @brief Search for libcuda.so.1.
  */
 static int load_cuda_sym(void)
 {
-    dl_drv = dlopen("libcuda.so", RTLD_NOW | RTLD_GLOBAL);
+    dl_drv = dlopen("libcuda.so.1", RTLD_NOW | RTLD_GLOBAL);
     if (!dl_drv) {
-        ERRDBG("Loading installed libcuda.so failed. Check that cuda drivers are installed.\n");
+        ERRDBG("Loading installed libcuda.so.1 failed. Check that cuda drivers are installed.\n");
         goto fn_fail;
     }
 

--- a/src/components/cuda/papi_cupti_common.c
+++ b/src/components/cuda/papi_cupti_common.c
@@ -141,24 +141,24 @@ void *cuptic_load_dynamic_syms(const char *parent_path, const char *dlname, cons
 }
 
 /**@class load_cudart_sym
- * @brief Search for libcudart.so. Order of search is outlined below.
+ * @brief Search for libcudart.so.12. Order of search is outlined below.
  *
  * 1. If a user sets PAPI_CUDA_RUNTIME, this will take precedent over
  *    the options listed below to be searched.
- * 2. If we fail to collect libcudart.so from PAPI_CUDA_RUNTIME or it is not set,
+ * 2. If we fail to collect libcudart.so.12 from PAPI_CUDA_RUNTIME or it is not set,
  *    we will search the path defined with PAPI_CUDA_ROOT; as this is supposed to always be set.
- * 3. If we fail to collect libcudart.so from steps 1 and 2, then we will search the linux
+ * 3. If we fail to collect libcudart.so.12 from steps 1 and 2, then we will search the linux
  *    default directories listed by /etc/ld.so.conf. As a note, updating the LD_LIBRARY_PATH is
  *    advised for this option.
- * 4. We use dlopen to search for libcudart.so.
- *    If this fails, then we failed to find libcudart.so
+ * 4. We use dlopen to search for libcudart.so.12.
+ *    If this fails, then we failed to find libcudart.so.12
  */
 static int load_cudart_sym(void)
 {
-    char dlname[] = "libcudart.so";
+    char dlname[] = "libcudart.so.12";
     char lookup_path[PATH_MAX];
 
-    /* search PAPI_CUDA_RUNTIME for libcudart.so (takes precedent over PAPI_CUDA_ROOT) */
+    /* search PAPI_CUDA_RUNTIME for libcudart.so.12 (takes precedent over PAPI_CUDA_ROOT) */
     char *papi_cuda_runtime = getenv("PAPI_CUDA_RUNTIME");
     if (papi_cuda_runtime) {
         sprintf(lookup_path, "%s/%s", papi_cuda_runtime, dlname);
@@ -170,22 +170,22 @@ static int load_cudart_sym(void)
         NULL,
     };
 
-    /* search PAPI_CUDA_ROOT for libcudart.so */
+    /* search PAPI_CUDA_ROOT for libcudart.so.12 */
     char *papi_cuda_root = getenv("PAPI_CUDA_ROOT");
     if (papi_cuda_root && !dl_rt) {
         dl_rt = cuptic_load_dynamic_syms(papi_cuda_root, dlname, standard_paths);
     }
 
-    /* search linux default directories for libcudart.so */
+    /* search linux default directories for libcudart.so.12 */
     if (linked_cudart_path && !dl_rt) {
         dl_rt = cuptic_load_dynamic_syms(linked_cudart_path, dlname, standard_paths);
     }
 
-    /* last ditch effort to find libcudart.so */
+    /* last ditch effort to find libcudart.so.12 */
     if (!dl_rt) {
         dl_rt = dlopen(dlname, RTLD_NOW | RTLD_GLOBAL);
         if (!dl_rt) {
-            ERRDBG("Loading libcudart.so failed. Try setting PAPI_CUDA_ROOT\n");
+            ERRDBG("Loading libcudart.so.12 failed. Try setting PAPI_CUDA_ROOT\n");
             goto fn_fail;
         }
     }
@@ -450,7 +450,7 @@ void cuptic_disabled_reason_get(const char **pmsg)
 
 static int dl_iterate_phdr_cb(struct dl_phdr_info *info, __attribute__((unused)) size_t size, __attribute__((unused)) void *data)
 {
-    const char *library_name = "libcudart.so";
+    const char *library_name = "libcudart.so.12";
     char *library_path = strdup(info->dlpi_name);
 
     if (library_path != NULL && strstr(library_path, library_name) != NULL) {

--- a/src/components/nvml/Rules.nvml
+++ b/src/components/nvml/Rules.nvml
@@ -19,12 +19,12 @@ PAPI_CUDA_ROOT ?= /opt/cuda
 # There are three libraries used by the NVML component, they are 
 # libcuda.so
 # libcudart.so 
-# libnvidia-ml.so
+# libnvidia-ml.so.1
 
 # The standard installed locations for these libraries, with overrides:
 # $(PAPI_CUDA_ROOT)/lib64/libcuda.so               #O.R. PAPI_CUDA_MAIN
 # $(PAPI_CUDA_ROOT)/lib64/libcudart.so             #O.R. PAPI_CUDA_RUNTIME
-# $(PAPI_CUDA_ROOT)/lib64/libnvidia-ml.so          #O.R. PAPI_NVML_MAIN
+# $(PAPI_CUDA_ROOT)/lib64/libnvidia-ml.so.1        #O.R. PAPI_NVML_MAIN
 # 
 # There are many ways to cause these paths to be known. 
 # Spack is a package manager used on supercomputers, Linux and MacOS. If Spack
@@ -58,7 +58,7 @@ PAPI_CUDA_RUNTIME = \"\"
 PAPI_NVML_MAIN = \"\"
 
 # An example of an override:
-# PAPI_NVML_MAIN = \"$(PAPI_CUDA_ROOT)/lib64/libnvidia-ml.so\"
+# PAPI_NVML_MAIN = \"$(PAPI_CUDA_ROOT)/lib64/libnvidia-ml.so.1\"
 
 # Note:  PAPI_CUDA_MAIN and PAPI_CUDA_RUNTIME, if set, will also apply to the
 #        CUDA component, which uses the same libraries.

--- a/src/components/nvml/Rules.nvml
+++ b/src/components/nvml/Rules.nvml
@@ -18,12 +18,12 @@ PAPI_CUDA_ROOT ?= /opt/cuda
 # Both at compile time and run time, the software depends on PAPI_CUDA_ROOT.
 # There are three libraries used by the NVML component, they are 
 # libcuda.so.1
-# libcudart.so 
+# libcudart.so.12
 # libnvidia-ml.so.1
 
 # The standard installed locations for these libraries, with overrides:
 # $(PAPI_CUDA_ROOT)/lib64/libcuda.so.1             #O.R. PAPI_CUDA_MAIN
-# $(PAPI_CUDA_ROOT)/lib64/libcudart.so             #O.R. PAPI_CUDA_RUNTIME
+# $(PAPI_CUDA_ROOT)/lib64/libcudart.so.12          #O.R. PAPI_CUDA_RUNTIME
 # $(PAPI_CUDA_ROOT)/lib64/libnvidia-ml.so.1        #O.R. PAPI_NVML_MAIN
 # 
 # There are many ways to cause these paths to be known. 

--- a/src/components/nvml/Rules.nvml
+++ b/src/components/nvml/Rules.nvml
@@ -17,12 +17,12 @@ PAPI_CUDA_ROOT ?= /opt/cuda
 
 # Both at compile time and run time, the software depends on PAPI_CUDA_ROOT.
 # There are three libraries used by the NVML component, they are 
-# libcuda.so
+# libcuda.so.1
 # libcudart.so 
 # libnvidia-ml.so.1
 
 # The standard installed locations for these libraries, with overrides:
-# $(PAPI_CUDA_ROOT)/lib64/libcuda.so               #O.R. PAPI_CUDA_MAIN
+# $(PAPI_CUDA_ROOT)/lib64/libcuda.so.1             #O.R. PAPI_CUDA_MAIN
 # $(PAPI_CUDA_ROOT)/lib64/libcudart.so             #O.R. PAPI_CUDA_RUNTIME
 # $(PAPI_CUDA_ROOT)/lib64/libnvidia-ml.so.1        #O.R. PAPI_NVML_MAIN
 # 

--- a/src/components/nvml/linux-nvml.c
+++ b/src/components/nvml/linux-nvml.c
@@ -1260,7 +1260,7 @@ linkCudaLibraries()
     // getenv returns NULL if environment variable is not found.
     char *cuda_root = getenv("PAPI_CUDA_ROOT");
 
-    // We need the NVML main library, normally libnvidia-ml.so. 
+    // We need the NVML main library, normally libnvidia-ml.so.1.
     dl3 = NULL;                                                 // Ensure reset to NULL.
 
     // Step 1: Process override if given.   
@@ -1274,22 +1274,22 @@ linkCudaLibraries()
 
     // Step 2: Try system paths, will work with Spack, LD_LIBRARY_PATH, default paths.
     if (dl3 == NULL) {                                              // If no override,
-        dl3 = dlopen("libnvidia-ml.so", RTLD_NOW | RTLD_GLOBAL);    // Try system paths.
+        dl3 = dlopen("libnvidia-ml.so.1", RTLD_NOW | RTLD_GLOBAL);    // Try system paths.
     }
 
     // Step 3: Try the explicit install default. 
     if (dl3 == NULL && cuda_root != NULL) {                                         // If ROOT given, it doesn't HAVE to work.
-        snprintf(path_lib, 1024, "%s/lib64/libnvidia-ml.so", cuda_root);            // PAPI Root check.
+        snprintf(path_lib, 1024, "%s/lib64/libnvidia-ml.so.1", cuda_root);            // PAPI Root check.
         dl3 = dlopen(path_lib, RTLD_NOW | RTLD_GLOBAL);                             // Try to open that path.
     }
 
     // Check for failure.
     if (dl3 == NULL) {
-        snprintf(_nvml_vector.cmp_info.disabled_reason, PAPI_MAX_STR_LEN, "libnvidia-ml.so not found.");
+        snprintf(_nvml_vector.cmp_info.disabled_reason, PAPI_MAX_STR_LEN, "libnvidia-ml.so.1 not found.");
         return(PAPI_ENOSUPP);   // Not found on default paths.
     }
 
-    // We have a dl3. (libnvidia-ml.so).
+    // We have a dl3. (libnvidia-ml.so.1).
 
     nvmlDeviceGetClockInfoPtr = dlsym(dl3, "nvmlDeviceGetClockInfo");
     if (dlerror() != NULL) {

--- a/src/components/nvml/tests/benchSANVML.c
+++ b/src/components/nvml/tests/benchSANVML.c
@@ -210,9 +210,9 @@ int _local_linkDynamicLibraries(void)
       return (-1);
    }
 
-   dl2 = dlopen("libcudart.so", RTLD_NOW | RTLD_GLOBAL | RTLD_NODELETE);
+   dl2 = dlopen("libcudart.so.12", RTLD_NOW | RTLD_GLOBAL | RTLD_NODELETE);
    if (!dl2) {
-      fprintf(stderr, "CUDA runtime library libcudart.so not found.");
+      fprintf(stderr, "CUDA runtime library libcudart.so.12 not found.");
       return (-1);
    }
 

--- a/src/components/nvml/tests/benchSANVML.c
+++ b/src/components/nvml/tests/benchSANVML.c
@@ -216,9 +216,9 @@ int _local_linkDynamicLibraries(void)
       return (-1);
    }
 
-   dl3 = dlopen("libnvidia-ml.so", RTLD_NOW | RTLD_GLOBAL);
+   dl3 = dlopen("libnvidia-ml.so.1", RTLD_NOW | RTLD_GLOBAL);
    if (!dl3) {
-      fprintf(stderr, "NVML runtime library libnvidia-ml.so not found.");
+      fprintf(stderr, "NVML runtime library libnvidia-ml.so.1 not found.");
        return (-1);
    }
 

--- a/src/components/nvml/tests/benchSANVML.c
+++ b/src/components/nvml/tests/benchSANVML.c
@@ -204,9 +204,9 @@ int _local_linkDynamicLibraries(void)
    }
 
    // Exit if we cannot link the cuda or NVML libs.
-   dl1 = dlopen("libcuda.so", RTLD_NOW | RTLD_GLOBAL);
+   dl1 = dlopen("libcuda.so.1", RTLD_NOW | RTLD_GLOBAL);
    if (!dl1) {
-      fprintf(stderr, "CUDA library libcuda.so not found.");
+      fprintf(stderr, "CUDA library libcuda.so.1 not found.");
       return (-1);
    }
 

--- a/src/components/sysdetect/nvidia_gpu.c
+++ b/src/components/sysdetect/nvidia_gpu.c
@@ -197,7 +197,7 @@ cuda_is_enabled( void )
 int
 load_cuda_sym( char *status )
 {
-    cuda_dlp = dlopen("libcuda.so", RTLD_NOW | RTLD_GLOBAL);
+    cuda_dlp = dlopen("libcuda.so.1", RTLD_NOW | RTLD_GLOBAL);
     if (cuda_dlp == NULL) {
         int count = snprintf(status, PAPI_MAX_STR_LEN, "%s", dlerror());
         if (count >= PAPI_MAX_STR_LEN) {

--- a/src/components/sysdetect/nvidia_gpu.c
+++ b/src/components/sysdetect/nvidia_gpu.c
@@ -291,7 +291,7 @@ nvml_is_enabled( void )
 int
 load_nvml_sym( char *status )
 {
-    nvml_dlp = dlopen("libnvidia-ml.so", RTLD_NOW | RTLD_GLOBAL);
+    nvml_dlp = dlopen("libnvidia-ml.so.1", RTLD_NOW | RTLD_GLOBAL);
     if (nvml_dlp == NULL) {
         int count = snprintf(status, PAPI_MAX_STR_LEN, "%s", dlerror());
         if (count >= PAPI_MAX_STR_LEN) {


### PR DESCRIPTION
## Pull Request Description

The NVIDIA driver packages have historically been shipping symlinks for some unversioned libraries in various subpackages. This was a mistake, most of the libraries could not be used for linking and as a consequence they should have not been packaged at all.

Some of the these libraries, had even duplicate unversioned library symlink in the CUDA repository along with appropriate headers in a different package. For example `libnvidia-ml.so` is provided by the `cuda-nvml-devel` package along with the headers, while the driver provides only the runtime part `libnvidia-ml.so.1`.

In general unversioned shared libraries should not be used for runtime loding, only for linking, so change the code to always load the versioned library for `libcuda`, `libvndia-ml` and `libcudart`.

Sample output for the RPM (deb is similar):

```
$ rpm -qpl cuda-nvml-devel-12-6-12.6.77-1.x86_64.rpm | grep targets
/usr/local/cuda-12.6/targets
/usr/local/cuda-12.6/targets/x86_64-linux
/usr/local/cuda-12.6/targets/x86_64-linux/include
/usr/local/cuda-12.6/targets/x86_64-linux/include/nvml.h
/usr/local/cuda-12.6/targets/x86_64-linux/lib
/usr/local/cuda-12.6/targets/x86_64-linux/lib/stubs
/usr/local/cuda-12.6/targets/x86_64-linux/lib/stubs/libnvidia-ml.a
/usr/local/cuda-12.6/targets/x86_64-linux/lib/stubs/libnvidia-ml.so
```

```
$ rpm -qpvl cuda-cudart-devel-12-8-12.8.90-1.x86_64.rpm | grep libcudart.so
lrwxrwxrwx    1 root     root                       15 Jul  8  2015 /usr/local/cuda-12.8/targets/x86_64-linux/lib/libcudart.so -> libcudart.so.12
```


Some references:
- https://github.com/NVIDIA/yum-packaging-nvidia-driver/issues/9
- https://github.com/NVIDIA/go-nvml/blob/0e815c71ca6e8184387d8b502b2ef2d2722165b9/pkg/nvml/lib.go#L30
- https://github.com/rust-nvml/nvml-wrapper/pull/63
- https://pypi.org/project/nvidia-ml-py/ - official python library from NVIDIA (`nvmlLib = CDLL("libnvidia-ml.so.1")`

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
