### PR TITLE
Cuda Component: Support Partially Disabled Cuda Component with CCs >= 7.0 (Perfworks API)

### DIFF
--- a/src/components/cuda/cupti_config.h
+++ b/src/components/cuda/cupti_config.h
@@ -20,12 +20,11 @@
 #   define API_PERFWORKS 1
 #endif
 
-/*
- * TODO: When NVIDIA removes the event API #define CUPTI_EVENTS_API_MAX_SUPPORTED_VERSION
- * and set it to last version that supports it.
- * Then conditionally define the following macro if the version lies within this range.
- * Note: Introduce a runtime check in `cuptic_is_runtime_events_api()` to satisfy this.
- */
-#define API_EVENTS 1
+// The Events API has been deprecated in Cuda Toolkit 12.8 and will be removed in a future
+// CUDA release (https://docs.nvidia.com/cupti/api/group__CUPTI__EVENT__API.html).
+// TODO: When the Events API has been removed #define CUPTI_EVENTS_API_MAX_SUPPORTED_VERSION
+// and set it to the last version that is supported. Use this macro as a runtime check in
+// `cuptic_determine_runtime_api`.
+#define API_EVENTS 2
 
 #endif  /* __LCUDA_CONFIG_H__ */

--- a/src/components/cuda/cupti_dispatch.c
+++ b/src/components/cuda/cupti_dispatch.c
@@ -21,7 +21,8 @@
 int cuptid_shutdown(void)
 {
     int papi_errno;
-    if (cuptic_is_runtime_perfworks_api()) {
+    int cupti_api = cuptic_determine_runtime_api();
+    if (cupti_api == API_PERFWORKS) {
 
 #if defined(API_PERFWORKS)
         papi_errno = cuptip_shutdown();
@@ -30,7 +31,7 @@ int cuptid_shutdown(void)
         }
 #endif
 
-    } else if (cuptic_is_runtime_events_api()) {
+    } else if (cupti_api == API_EVENTS) {
 
 #if defined(API_EVENTS)
         papi_errno = cuptie_shutdown();
@@ -44,40 +45,48 @@ int cuptid_shutdown(void)
     return cuptic_shutdown();
 }
 
-void cuptid_disabled_reason_get(const char **msg)
+int cuptid_err_get_last(const char **error_str)
 {
-    cuptic_disabled_reason_get(msg);
+    return cuptic_err_get_last(error_str);
 }
 
 int cuptid_init(void)
 {
-    int papi_errno;
-    papi_errno = cuptic_init();
-    if (papi_errno != PAPI_OK) {
+    int init_errno = cuptic_init();
+    if (init_errno != PAPI_OK && init_errno != PAPI_PARTIAL) {
         goto fn_exit;
     }
 
-    if (cuptic_is_runtime_perfworks_api()) {
+    int papi_errno;
+    int cupti_api = cuptic_determine_runtime_api();
+    if (cupti_api == API_PERFWORKS) {
 
 #if defined(API_PERFWORKS)
         papi_errno = cuptip_init();
+        if (papi_errno == PAPI_OK) {
+            if (init_errno == PAPI_PARTIAL) {
+                papi_errno = init_errno;
+            }
+        }
 #else
-        cuptic_disabled_reason_set("PAPI not built with NVIDIA profiler API support.");
+        cuptic_err_set_last("PAPI not built with NVIDIA profiler API support.");
         papi_errno = PAPI_ECMP;
         goto fn_exit;
 #endif
 
-    } else if (cuptic_is_runtime_events_api()) {
+    } else if (cupti_api == API_EVENTS) {
 
 #if defined(API_EVENTS)
+        // TODO: When the Events API is added back, add a similar check
+        // as above
         papi_errno = cuptie_init();
 #else
-        cuptic_disabled_reason_set("Unknown events API problem.");
+        cuptic_err_set_last("Unknown events API problem.");
         papi_errno = PAPI_ECMP;
 #endif
 
     } else {
-        cuptic_disabled_reason_set("CUDA configuration not supported.");
+        cuptic_err_set_last("CUDA configuration not supported.");
         papi_errno = PAPI_ECMP;
     }
 fn_exit:
@@ -96,13 +105,14 @@ int cuptid_thread_info_destroy(cuptid_info_t *info)
 
 int cuptid_ctx_create(cuptid_info_t info,  cuptip_control_t *pcupti_ctl, uint32_t *events_id, int num_events)
 {
-    if (cuptic_is_runtime_perfworks_api()) {
+    int cupti_api = cuptic_determine_runtime_api();
+    if (cupti_api == API_PERFWORKS) {
 
 #if defined(API_PERFWORKS)
         return cuptip_ctx_create((cuptic_info_t) info, pcupti_ctl, events_id, num_events);
 #endif
 
-    } else if (cuptic_is_runtime_events_api()) {
+    } else if (cupti_api == API_EVENTS) {
 
 #if defined (API_EVENTS)
         return cuptie_ctx_create((cuptic_info_t) info, (cuptie_control_t *) pcupti_ctl);
@@ -114,13 +124,14 @@ int cuptid_ctx_create(cuptid_info_t info,  cuptip_control_t *pcupti_ctl, uint32_
 
 int cuptid_ctx_start(cuptip_control_t cupti_ctl)
 {
-    if (cuptic_is_runtime_perfworks_api()) {
+    int cupti_api = cuptic_determine_runtime_api();
+    if (cupti_api == API_PERFWORKS) {
 
 #if defined(API_PERFWORKS)
         return cuptip_ctx_start(cupti_ctl);
 #endif
 
-    } else if (cuptic_is_runtime_events_api()) {
+    } else if (cupti_api == API_EVENTS) {
 
 #if defined(API_EVENTS)
         return cuptie_ctx_start((cuptie_control_t) cupti_ctl);
@@ -132,13 +143,14 @@ int cuptid_ctx_start(cuptip_control_t cupti_ctl)
 
 int cuptid_ctx_read(cuptip_control_t cupti_ctl, long long **counters)
 {
-    if (cuptic_is_runtime_perfworks_api()) {
+    int cupti_api = cuptic_determine_runtime_api();
+    if (cupti_api == API_PERFWORKS) {
 
 #if defined(API_PERFWORKS)
         return cuptip_ctx_read(cupti_ctl, counters);
 #endif
 
-    } else if (cuptic_is_runtime_events_api()) {
+    } else if (cupti_api == API_EVENTS) {
 
 #if defined(API_EVENTS)
         return cuptie_ctx_read((cuptie_control_t) cupti_ctl, counters);
@@ -150,12 +162,13 @@ int cuptid_ctx_read(cuptip_control_t cupti_ctl, long long **counters)
 
 int cuptid_ctx_reset(cuptip_control_t cupti_ctl)
 {
-    if (cuptic_is_runtime_perfworks_api()) {
+    int cupti_api = cuptic_determine_runtime_api();
+    if (cupti_api == API_PERFWORKS) {
 
 #if defined(API_PERFWORKS)
         return cuptip_ctx_reset(cupti_ctl);
 #endif
-    } else if (cuptic_is_runtime_events_api()) {
+    } else if (cupti_api == API_EVENTS) {
 
 #if defined(API_EVENTS)
         return cuptie_ctx_reset((cuptie_control_t) cupti_ctl);
@@ -166,13 +179,14 @@ int cuptid_ctx_reset(cuptip_control_t cupti_ctl)
 
 int cuptid_ctx_stop(cuptip_control_t cupti_ctl)
 {
-    if (cuptic_is_runtime_perfworks_api()) {
+    int cupti_api = cuptic_determine_runtime_api();
+    if (cupti_api == API_PERFWORKS) {
 
 #if defined(API_PERFWORKS)
         return cuptip_ctx_stop(cupti_ctl);
 #endif
 
-    } else if (cuptic_is_runtime_events_api()) {
+    } else if (cupti_api == API_EVENTS) {
 
 #if defined(API_EVENTS)
         return cuptie_ctx_stop((cuptie_control_t) cupti_ctl);
@@ -184,13 +198,14 @@ int cuptid_ctx_stop(cuptip_control_t cupti_ctl)
 
 int cuptid_ctx_destroy(cuptip_control_t *pcupti_ctl)
 {
-    if (cuptic_is_runtime_perfworks_api()) {
+    int cupti_api = cuptic_determine_runtime_api();
+    if (cupti_api == API_PERFWORKS) {
 
 #if defined(API_PERFWORKS)
         return cuptip_ctx_destroy(pcupti_ctl);
 #endif
 
-    } else if (cuptic_is_runtime_events_api()) {
+    } else if (cupti_api == API_EVENTS) {
 
 #if defined(API_EVENTS)
         return cuptie_ctx_destroy((cuptie_control_t *) pcupti_ctl);
@@ -202,13 +217,14 @@ int cuptid_ctx_destroy(cuptip_control_t *pcupti_ctl)
 
 int cuptid_evt_enum(uint32_t *event_code, int modifier)
 {
-    if (cuptic_is_runtime_perfworks_api()) {
+    int cupti_api = cuptic_determine_runtime_api();
+    if (cupti_api == API_PERFWORKS) {
 
 #if defined(API_PERFWORKS)
         return cuptip_evt_enum(event_code, modifier);
 #endif
 
-    } else if (cuptic_is_runtime_events_api()) {
+    } else if (cupti_api == API_EVENTS) {
 
 #if defined(API_EVENTS)
         return cuptie_evt_enum(event_code, modifier);
@@ -220,13 +236,14 @@ int cuptid_evt_enum(uint32_t *event_code, int modifier)
 
 int cuptid_evt_code_to_descr(uint32_t event_code, char *descr, int len)
 {
-    if (cuptic_is_runtime_perfworks_api()) {
+    int cupti_api = cuptic_determine_runtime_api();
+    if (cupti_api == API_PERFWORKS) {
 
 #if defined(API_PERFWORKS)
         return cuptip_evt_code_to_descr(event_code, descr, len);
 #endif
 
-    } else if (cuptic_is_runtime_events_api()) {
+    } else if (cupti_api == API_EVENTS) {
 
 #if defined(API_EVENTS)
         return cuptie_evt_code_to_descr(event_code, descr, len);
@@ -238,13 +255,14 @@ int cuptid_evt_code_to_descr(uint32_t event_code, char *descr, int len)
 
 int cuptid_evt_name_to_code(const char *name, uint32_t *event_code)
 {
-    if (cuptic_is_runtime_perfworks_api()) {
+    int cupti_api = cuptic_determine_runtime_api();
+    if (cupti_api == API_PERFWORKS) {
 
 #if defined(API_PERFWORKS)
         return cuptip_evt_name_to_code(name, event_code);
 #endif
 
-    } else if (cuptic_is_runtime_events_api()) {
+    } else if (cupti_api == API_EVENTS) {
 
 #if defined(API_EVENTS)
         return cuptie_evt_name_to_code(name, event_code);
@@ -256,13 +274,14 @@ int cuptid_evt_name_to_code(const char *name, uint32_t *event_code)
 
 int cuptid_evt_code_to_name(uint32_t event_code, char *name, int len)
 {
-    if (cuptic_is_runtime_perfworks_api()) {
+    int cupti_api = cuptic_determine_runtime_api();
+    if (cupti_api == API_PERFWORKS) {
 
 #if defined(API_PERFWORKS)
         return cuptip_evt_code_to_name(event_code, name, len);
 #endif
 
-    } else if(cuptic_is_runtime_events_api()) {
+    } else if(cupti_api == API_EVENTS) {
 
 #if defined(API_EVENTS)
         return cuptie_evt_code_to_name(event_code, name, len);
@@ -274,13 +293,14 @@ int cuptid_evt_code_to_name(uint32_t event_code, char *name, int len)
 
 int cuptid_evt_code_to_info(uint32_t event_code, PAPI_event_info_t *info)
 {
-    if (cuptic_is_runtime_perfworks_api()) {
+    int cupti_api = cuptic_determine_runtime_api();
+    if (cupti_api == API_PERFWORKS) {
 
 #if defined(API_PERFWORKS)
         return cuptip_evt_code_to_info(event_code, info);
 #endif
 
-    } else if(cuptic_is_runtime_events_api()) {
+    } else if(cupti_api == API_EVENTS) {
 
 #if defined(API_EVENTS)
         return cuptie_evt_code_to_info(event_code, info);

--- a/src/components/cuda/cupti_dispatch.h
+++ b/src/components/cuda/cupti_dispatch.h
@@ -42,6 +42,6 @@ int cuptid_thread_info_create(cuptid_info_t *info);
 int cuptid_thread_info_destroy(cuptid_info_t *info);
 
 /* misc. */
-void cuptid_disabled_reason_get(const char **msg);
+int cuptid_err_get_last(const char **error_str);
 
 #endif /* __CUPTI_DISPATCH_H__ */

--- a/src/components/cuda/cupti_events.c
+++ b/src/components/cuda/cupti_events.c
@@ -17,7 +17,7 @@
 
 int cuptie_init(void)
 {
-    cuptic_disabled_reason_set("CUDA events API not implemented.");
+    cuptic_err_set_last("CUDA events API not implemented.");
     return PAPI_ENOIMPL;
 }
 

--- a/src/components/cuda/papi_cupti_common.c
+++ b/src/components/cuda/papi_cupti_common.c
@@ -17,9 +17,62 @@
 
 static void *dl_drv, *dl_rt;
 
+static char cuda_error_string[PAPI_HUGE_STR_LEN];
+
 void *dl_cupti;
 
 unsigned int _cuda_lock;
+
+typedef int64_t gpu_occupancy_t;
+static gpu_occupancy_t global_gpu_bitmask;
+
+// Variables to handle partially disabled Cuda component
+static int isCudaPartial = 0;
+static int enabledDeviceIds[PAPI_CUDA_MAX_DEVICES];
+static size_t enabledDevicesCnt = 0;
+
+typedef enum
+{
+    sys_gpu_ccs_unknown = 0,
+    sys_gpu_ccs_mixed,
+    sys_gpu_ccs_all_lt_70,
+    sys_gpu_ccs_all_eq_70,
+    sys_gpu_ccs_all_gt_70,
+    sys_gpu_ccs_all_lte_70,
+    sys_gpu_ccs_all_gte_70
+} sys_compute_capabilities_e;
+
+struct cuptic_info {
+    CUcontext ctx;
+};
+
+// Load necessary functions from Cuda toolkit e.g. cupti or runtime 
+static int util_load_cuda_sym(void);
+static int load_cuda_sym(void);
+static int load_cudart_sym(void);
+static int load_cupti_common_sym(void);
+
+// Unload the loaded functions from Cuda toolkit e.g. cupti or runtime
+static int unload_cudart_sym(void);
+static int unload_cupti_common_sym(void);
+static void unload_linked_cudart_path(void);
+
+// Functions to get library versions 
+static int util_dylib_cu_runtime_version(void);
+static int util_dylib_cupti_version(void);
+
+// Functions to get cuda runtime library path
+static int dl_iterate_phdr_cb(struct dl_phdr_info *info, __attribute__((unused)) size_t size, __attribute__((unused)) void *data);
+static int get_user_cudart_path(void);
+
+// Function to determine compute capabilities
+static int compute_capabilities_on_system(sys_compute_capabilities_e *system_ccs);
+
+// Functions to handle a partially disabled Cuda component
+static int get_enabled_devices(void); 
+
+// misc.
+static int _devmask_events_get(cuptiu_event_table_t *evt_table, gpu_occupancy_t *bitmask);
 
 /* cuda driver function pointers */
 CUresult ( *cuCtxGetCurrentPtr ) (CUcontext *);
@@ -56,7 +109,7 @@ CUptiResult ( *cuptiGetVersionPtr ) (uint32_t* );
 /**@class load_cuda_sym
  * @brief Search for a variation of the shared object libcuda.
  */
-static int load_cuda_sym(void)
+int load_cuda_sym(void)
 {
     int soNamesToSearchCount = 3;
     const char *soNamesToSearchFor[] = {"libcuda.so", "libcuda.so.1", "libcuda"};
@@ -252,7 +305,7 @@ void *search_and_load_from_system_paths(const char *soNamesToSearchFor[], int so
  *    If this fails, then we failed to find a variation of the shared object
  *    libcudart.
  */
-static int load_cudart_sym(void)
+int load_cudart_sym(void)
 {
     int soNamesToSearchCount = 3;
     const char *soNamesToSearchFor[] = {"libcudart.so", "libcudart.so.1", "libcudart"};
@@ -297,7 +350,7 @@ fn_fail:
     return PAPI_EMISC;
 }
 
-static int unload_cudart_sym(void)
+int unload_cudart_sym(void)
 {
     if (dl_rt) {
         dlclose(dl_rt);
@@ -330,7 +383,7 @@ static int unload_cudart_sym(void)
  *    If this fails, then we failed to find a variation of the shared object
  *    libcupti.
  */
-static int load_cupti_common_sym(void)
+int load_cupti_common_sym(void)
 {
     int soNamesToSearchCount = 3;
     const char  *soNamesToSearchFor[] = {"libcupti.so", "libcupti.so.1", "libcupti"};
@@ -367,7 +420,7 @@ fn_fail:
     return PAPI_EMISC;
 }
 
-static int unload_cupti_common_sym(void)
+int unload_cupti_common_sym(void)
 {
     if (dl_cupti) {
         dlclose(dl_cupti);
@@ -377,7 +430,7 @@ static int unload_cupti_common_sym(void)
     return PAPI_OK;
 }
 
-static int util_load_cuda_sym(void)
+int util_load_cuda_sym(void)
 {
     int papi_errno;
     papi_errno = load_cuda_sym();
@@ -398,17 +451,17 @@ int cuptic_shutdown(void)
     return PAPI_OK;
 }
 
-static int util_dylib_cu_runtime_version(void)
+int util_dylib_cu_runtime_version(void)
 {
     int runtimeVersion;
-    cudaArtCheckErrors(cudaRuntimeGetVersionPtr(&runtimeVersion), return PAPI_EMISC );
+    cudaArtCheckErrors(cudaRuntimeGetVersionPtr(&runtimeVersion), return PAPI_EMISC);
     return runtimeVersion;
 }
 
-static int util_dylib_cupti_version(void)
+int util_dylib_cupti_version(void)
 {
     unsigned int cuptiVersion;
-    cuptiCheckErrors(cuptiGetVersionPtr(&cuptiVersion), return PAPI_EMISC );
+    cuptiCheckErrors(cuptiGetVersionPtr(&cuptiVersion), return PAPI_EMISC);
     return cuptiVersion;
 }
 
@@ -426,195 +479,265 @@ int cuptic_device_get_count(int *num_gpus)
     /* find the total number of compute-capable devices */
     cuda_err = cudaGetDeviceCountPtr(num_gpus);
     if (cuda_err != cudaSuccess) {
-        cuptic_disabled_reason_set(cudaGetErrorStringPtr(cuda_err));
+        cuptic_err_set_last(cudaGetErrorStringPtr(cuda_err));
         return PAPI_EMISC;
     }
     return PAPI_OK;
 }
 
-static int get_gpu_compute_capability(int dev_num, int *cc)
+int get_gpu_compute_capability(int dev_num, int *cc)
 {
     int cc_major, cc_minor;
     cudaError_t cuda_errno;
     cuda_errno = cudaDeviceGetAttributePtr(&cc_major, cudaDevAttrComputeCapabilityMajor, dev_num);
     if (cuda_errno != cudaSuccess) {
-        cuptic_disabled_reason_set(cudaGetErrorStringPtr(cuda_errno));
+        cuptic_err_set_last(cudaGetErrorStringPtr(cuda_errno));
         return PAPI_EMISC;
     }
     cuda_errno = cudaDeviceGetAttributePtr(&cc_minor, cudaDevAttrComputeCapabilityMinor, dev_num);
     if (cuda_errno != cudaSuccess) {
-        cuptic_disabled_reason_set(cudaGetErrorStringPtr(cuda_errno));
+        cuptic_err_set_last(cudaGetErrorStringPtr(cuda_errno));
         return PAPI_EMISC;
     }
     *cc = cc_major * 10 + cc_minor;
     return PAPI_OK;
 }
 
-typedef enum {GPU_COLLECTION_UNKNOWN, GPU_COLLECTION_ALL_PERF, GPU_COLLECTION_MIXED, GPU_COLLECTION_ALL_EVENTS, GPU_COLLECTION_ALL_CC70} gpu_collection_e;
-
-static int util_gpu_collection_kind(gpu_collection_e *coll_kind)
+int compute_capabilities_on_system(sys_compute_capabilities_e *system_ccs)
 {
-    int papi_errno = PAPI_OK;
-    static gpu_collection_e kind = GPU_COLLECTION_UNKNOWN;
-    if (kind != GPU_COLLECTION_UNKNOWN) {
-        goto fn_exit;
-    }
-
     int total_gpus;
-    papi_errno = cuptic_device_get_count(&total_gpus);
+    int papi_errno = cuptic_device_get_count(&total_gpus);
     if (papi_errno != PAPI_OK) {
-        goto fn_exit;
+        return papi_errno;
     }
 
     int i, cc;
-    int count_perf = 0, count_evt = 0, count_cc70 = 0;
-    for (i=0; i<total_gpus; i++) {
+    int num_gpus_with_ccs_gt_cc70 = 0, num_gpus_with_ccs_eq_cc70 = 0, num_gpus_with_ccs_lt_cc70 = 0;
+    for (i = 0; i < total_gpus; i++) {
         papi_errno = get_gpu_compute_capability(i, &cc);
         if (papi_errno != PAPI_OK) {
             return papi_errno;
         }
+
+        if (cc > 70) {
+            ++num_gpus_with_ccs_gt_cc70;
+        }
         if (cc == 70) {
-            ++count_cc70;
+            ++num_gpus_with_ccs_eq_cc70;
         }
-        if (cc >= 70) {
-            ++count_perf;
-        }
-        if (cc <= 70) {
-            ++count_evt;
+        if (cc < 70) {
+            ++num_gpus_with_ccs_lt_cc70;
         }
     }
-    if (count_cc70 == total_gpus) {
-        kind = GPU_COLLECTION_ALL_CC70;
-        goto fn_exit;
-    }
-    if (count_perf == total_gpus) {
-        kind = GPU_COLLECTION_ALL_PERF;
-        goto fn_exit;
-    }
-    if (count_evt == total_gpus) {
-        kind = GPU_COLLECTION_ALL_EVENTS;
-        goto fn_exit;
-    }
-    kind = GPU_COLLECTION_MIXED;
 
-fn_exit:
-    *coll_kind = kind;
-    return papi_errno;
+    sys_compute_capabilities_e sys_ccs = sys_gpu_ccs_unknown;
+    // All devices have CCs > 7.0.
+    if (num_gpus_with_ccs_gt_cc70 == total_gpus) {
+        sys_ccs = sys_gpu_ccs_all_gt_70;
+    }
+    // All devices have CCs = 7.0
+    else if (num_gpus_with_ccs_eq_cc70 == total_gpus) {
+        sys_ccs = sys_gpu_ccs_all_eq_70;
+    }
+    // All devices have CCs < 7.0
+    else if (num_gpus_with_ccs_lt_cc70 == total_gpus) {
+        sys_ccs = sys_gpu_ccs_all_lt_70;
+    }
+    // Devices can result in a partially disabled Cuda component
+    else {
+        sys_ccs = sys_gpu_ccs_mixed;
+
+        int all_ccs_gte_cc70 = num_gpus_with_ccs_eq_cc70 + num_gpus_with_ccs_gt_cc70;
+        if (all_ccs_gte_cc70 == total_gpus) {
+            sys_ccs = sys_gpu_ccs_all_gte_70;
+        }
+ 
+        int all_ccs_lte_cc70 = num_gpus_with_ccs_eq_cc70 + num_gpus_with_ccs_lt_cc70;
+        if (all_ccs_lte_cc70 == total_gpus) {
+            sys_ccs = sys_gpu_ccs_all_lte_70;
+        }
+    }
+    *system_ccs = sys_ccs;
+
+    return PAPI_OK;
 }
 
-const char *cuptic_disabled_reason_g;
-
-/** @class cuptic_disabled_reason_set
-  * @brief Updating the current Cuda context.
-  * @param *msg
-  *    Cuda error message.
+/** @class cuptic_err_set_last
+  * @brief For the last error, set an error message.
+  * @param *error_str
+  *    Error message to be set.
 */
-void cuptic_disabled_reason_set(const char *msg)
+int cuptic_err_set_last(const char *error_str)
 {
-    cuptic_disabled_reason_g = msg;
+    int strLen = snprintf(cuda_error_string, PAPI_HUGE_STR_LEN, "%s", error_str);
+    if (strLen < 0 || strLen >= PAPI_HUGE_STR_LEN) {
+        SUBDBG("Last set error message not fully written.\n");
+    }
+    
+    return PAPI_OK;
 }
 
-void cuptic_disabled_reason_get(const char **pmsg)
+/** @class cuptic_err_get_last
+  * @brief Get the last error message set.
+  * @param **error_str
+  *    Error message to be returned.
+*/
+int cuptic_err_get_last(const char **error_str)
 {
-    *pmsg = cuptic_disabled_reason_g;
+    *error_str = cuda_error_string;
+    return PAPI_OK;
 }
 
 int cuptic_init(void)
 {
     int papi_errno = util_load_cuda_sym();
     if (papi_errno != PAPI_OK) {
-        cuptic_disabled_reason_set("Unable to load CUDA library functions.");
-        goto fn_exit;
+        cuptic_err_set_last("Unable to load CUDA library functions.");
+        return papi_errno;
     }
 
-    gpu_collection_e kind;
-    papi_errno = util_gpu_collection_kind(&kind);
+    sys_compute_capabilities_e system_ccs;
+    papi_errno = compute_capabilities_on_system(&system_ccs);
     if (papi_errno != PAPI_OK) {
-        goto fn_exit;
+        return papi_errno;
     }
- 
-    if (kind == GPU_COLLECTION_MIXED) {
-        cuptic_disabled_reason_set("No support for systems with mixed compute capabilities, such as CC < 7.0 and CC > 7.0 GPUS.");
-        papi_errno = PAPI_ECMP;
-        goto fn_exit;
+
+    // Get an array of the available devices on the system
+    papi_errno = get_enabled_devices();
+    if (papi_errno != PAPI_OK) {
+        return papi_errno;
     }
-fn_exit:
-    return papi_errno;
+
+    // Handle a partially disabled Cuda component
+    // TODO: Once the Events API is added back, this conditional will need to be updated for Issue #297 section 2
+    if (system_ccs == sys_gpu_ccs_mixed || system_ccs == sys_gpu_ccs_all_lte_70) {
+        char *PAPI_CUDA_API = getenv("PAPI_CUDA_API");
+        char *cc_support = ">=7.0";
+        if (PAPI_CUDA_API != NULL) {
+            int result = strcasecmp(PAPI_CUDA_API, "EVENTS");
+            if (result == 0) {
+                cc_support = "<=7.0";
+            }
+        }
+
+        char errMsg[PAPI_HUGE_STR_LEN];
+        int strLen = snprintf(errMsg, PAPI_HUGE_STR_LEN,
+                              "System includes multiple compute capabilities: <7.0, =7.0, >7.0."
+                              " Only support for CC %s enabled.", cc_support);
+        if (strLen < 0 || strLen >= PAPI_HUGE_STR_LEN) {
+            SUBDBG("Failed to fully write the partially disabled error message.\n");
+            return PAPI_ENOMEM;
+        }
+        cuptic_err_set_last(errMsg);
+
+        isCudaPartial = 1;
+
+        return PAPI_PARTIAL;
+    }
+
+    return PAPI_OK;
 }
 
-int cuptic_is_runtime_perfworks_api(void)
+void cuptic_partial(int *isCmpPartial, int **cudaEnabledDeviceIds, size_t *totalNumEnabledDevices)
 {
-    static int is_perfworks_api = -1;
-    if (is_perfworks_api != -1) {
-        goto fn_exit;
-    }
-    char *papi_cuda_110_cc70_perfworks_api = getenv("PAPI_CUDA_110_CC_70_PERFWORKS_API");
+    *isCmpPartial = isCudaPartial;
+    *cudaEnabledDeviceIds = enabledDeviceIds;
+    *totalNumEnabledDevices = enabledDevicesCnt;
+    return;
+}
 
-    gpu_collection_e gpus_kind;
-    int papi_errno = util_gpu_collection_kind(&gpus_kind);
-    if (papi_errno != PAPI_OK) {
-        goto fn_exit;
-    }
+int cuptic_determine_runtime_api(void) 
+{
+    int cupti_api = -1;
+    char *PAPI_CUDA_API = getenv("PAPI_CUDA_API");
 
+    // For the Perfworks API to be operational in the Cuda component,
+    // users must link with a Cuda toolkit version that has a CUPTI version >= 13.
+    // TODO: Once the Events API is added back into the Cuda component. Add a similar
+    // check as the one shown below.
     unsigned int cuptiVersion = util_dylib_cupti_version();
-
-    if (gpus_kind == GPU_COLLECTION_ALL_CC70 && 
-        (cuptiVersion == CUPTI_PROFILER_API_MIN_SUPPORTED_VERSION || util_dylib_cu_runtime_version() == 11000))
-    {
-        if (papi_cuda_110_cc70_perfworks_api != NULL) {
-            is_perfworks_api = 1;
-            goto fn_exit;
-        }
-        else {
-            is_perfworks_api = 0;
-            goto fn_exit;
-        }
+    if (!(cuptiVersion >= CUPTI_PROFILER_API_MIN_SUPPORTED_VERSION) && PAPI_CUDA_API == NULL) {
+        return cupti_api; 
     }
 
-    if ((gpus_kind == GPU_COLLECTION_ALL_PERF || gpus_kind == GPU_COLLECTION_ALL_CC70) && cuptiVersion >= CUPTI_PROFILER_API_MIN_SUPPORTED_VERSION) {
-        is_perfworks_api = 1;
-        goto fn_exit;
-    } else {
-        is_perfworks_api = 0;
-        goto fn_exit;
-    }
-
-fn_exit:
-    return is_perfworks_api;
-}
-
-int cuptic_is_runtime_events_api(void)
-{
-    static int is_events_api = -1;
-    if (is_events_api != -1) {
-        goto fn_exit;
-    }
-
-    gpu_collection_e gpus_kind;
-    int papi_errno = util_gpu_collection_kind(&gpus_kind);
+    // Determine the compute capabilities on the system
+    sys_compute_capabilities_e system_ccs;
+    int papi_errno = compute_capabilities_on_system(&system_ccs);
     if (papi_errno != PAPI_OK) {
-        goto fn_exit;
+        return papi_errno;
     }
 
-    /*
-     * See cupti_config.h: When NVIDIA removes the events API add a check in the following condition
-     * to check the `util_dylib_cupti_version()` is also <= CUPTI_EVENTS_API_MAX_SUPPORTED_VERSION.
-     */
-    if ((gpus_kind == GPU_COLLECTION_ALL_EVENTS || gpus_kind == GPU_COLLECTION_ALL_CC70)) {
-        is_events_api = 1;
-        goto fn_exit;
-    } else {
-        is_events_api = 0;
-        goto fn_exit;
+    // Determine which CUPTI API will be in use
+    switch (system_ccs) {
+        // All devices have CCs < 7.0
+        case sys_gpu_ccs_all_lt_70:
+            cupti_api = API_EVENTS;
+            break;
+        // All devices have CCs > 7.0
+        case sys_gpu_ccs_all_gt_70:
+            cupti_api = API_PERFWORKS;
+            break;
+        // All devices have CCs <= 7.0
+        // TODO: Once the Events API is added back, this case will default to use the Events API
+        case sys_gpu_ccs_all_lte_70:
+        // All devices have CCs >= 7.0
+        case sys_gpu_ccs_all_gte_70:
+        // ALL devices have CC's = 7.0
+        case sys_gpu_ccs_all_eq_70:
+        // Devices are mixed with CC's > 7.0 and CC's < 7.0
+        case sys_gpu_ccs_mixed:
+            // Default will be to use Perfworks API, user can change this by setting PAPI_CUDA_API.
+            cupti_api = API_PERFWORKS;
+            if (PAPI_CUDA_API != NULL) {
+                int result = strcasecmp(PAPI_CUDA_API, "EVENTS");
+                if (result == 0)
+                    cupti_api = API_EVENTS;
+            }
+            break;
+        default:
+            SUBDBG("Implemented CUPTI APIs do not support the current GPU configuration.\n");
+            break;
     }
-fn_exit:
-    return is_events_api;
+
+    return cupti_api;
 }
 
-struct cuptic_info {
-    CUcontext ctx;
-};
+int get_enabled_devices(void)
+{
+    int total_gpus; 
+    int papi_errno = cuptic_device_get_count(&total_gpus);
+    if (papi_errno != PAPI_OK) {
+        return papi_errno;
+    }   
 
+    int cupti_api = cuptic_determine_runtime_api();
+    if (cupti_api < 0) {
+        return PAPI_ECMP;
+    }   
+
+    int i, cc, collectCudaDevice;
+    for (i = 0; i < total_gpus; i++) {
+        collectCudaDevice = 0;
+        papi_errno = get_gpu_compute_capability(i, &cc);
+        if (papi_errno != PAPI_OK) {
+            return papi_errno;
+        }
+
+        if (cupti_api == API_PERFWORKS && cc >= 70) {
+            collectCudaDevice = 1;    
+        }
+        else if (cupti_api == API_EVENTS && cc <= 70) {
+            collectCudaDevice = 1;
+        }
+
+        if (collectCudaDevice) {
+            enabledDeviceIds[enabledDevicesCnt] = i;
+            enabledDevicesCnt++; 
+        }
+    }
+
+    return PAPI_OK;
+}
 
 /** @class cuptic_ctxarr_create
   * @brief Allocate memory for pinfo.
@@ -715,11 +838,7 @@ int cuptic_ctxarr_destroy(cuptic_info_t *pinfo)
     return PAPI_OK;
 }
 
-/* Functions based on bitmasking to detect gpu exclusivity */
-typedef int64_t gpu_occupancy_t;
-static gpu_occupancy_t global_gpu_bitmask;
-
-static int _devmask_events_get(cuptiu_event_table_t *evt_table, gpu_occupancy_t *bitmask)
+int _devmask_events_get(cuptiu_event_table_t *evt_table, gpu_occupancy_t *bitmask)
 {
     gpu_occupancy_t acq_mask = 0;
     long i;

--- a/src/components/cuda/papi_cupti_common.h
+++ b/src/components/cuda/papi_cupti_common.h
@@ -15,6 +15,10 @@
 #include "cupti_utils.h"
 #include "lcuda_debug.h"
 
+// Set to match the maximum number of devices allowed for the event identifier
+// encoding format. See README_internal.md for more details.
+#define PAPI_CUDA_MAX_DEVICES 128
+
 typedef struct cuptic_info *cuptic_info_t;
 
 extern void *dl_cupti;
@@ -54,13 +58,12 @@ extern CUptiResult ( *cuptiGetVersionPtr ) (uint32_t* );
 
 /* utility functions to check runtime api, disabled reason, etc. */
 int cuptic_init(void);
-int cuptic_is_runtime_perfworks_api(void);
-int cuptic_is_runtime_events_api(void);
+int cuptic_determine_runtime_api(void);
 int cuptic_device_get_count(int *num_gpus);
-void cuptic_disabled_reason_set(const char *msg);
-void cuptic_disabled_reason_get(const char **pmsg);
 void *search_and_load_shared_objects(const char *parentPath, const char *soMainName, const char *soNamesToSearchFor[], int soNamesToSearchCount);
 void *search_and_load_from_system_paths(const char *soNamesToSearchFor[], int soNamesToSearchCount);
+int cuptic_err_get_last(const char **error_str);
+int cuptic_err_set_last(const char *error_str);
 int cuptic_shutdown(void);
 
 /* context management interfaces */
@@ -76,6 +79,12 @@ int cuptic_device_release(cuptiu_event_table_t *evt_table);
 /* device qualifier interfaces */
 int cuptiu_dev_set(cuptiu_bitmap_t *bitmap, int i);
 int cuptiu_dev_check(cuptiu_bitmap_t bitmap, int i);
+
+/* functions to handle a partially disabled Cuda component */
+void cuptic_partial(int *isCmpPartial, int **cudaEnabledDeviceIds, size_t *totalNumEnabledDevices);
+
+/* function to get a devices compute capability */
+int get_gpu_compute_capability(int dev_num, int *cc);
 
 #define DLSYM_AND_CHECK( dllib, name ) dlsym( dllib, name );  \
     if (dlerror() != NULL) {  \

--- a/src/papi.h
+++ b/src/papi.h
@@ -280,7 +280,8 @@ failure.
 #define PAPI_ECMP_DISABLED	-25    /**< Component containing event is disabled */
 #define PAPI_EDELAY_INIT -26   /**< Delayed initialization component */
 #define PAPI_EMULPASS   -27    /**< Event exists, but cannot be counted due to multiple passes required by hardware */
-#define PAPI_NUM_ERRORS	 28    /**< Number of error messages specified in this API */
+#define PAPI_PARTIAL    -28    /**< Component is partially disabled */
+#define PAPI_NUM_ERRORS	 29    /**< Number of error messages specified in this API */
 
 #define PAPI_NOT_INITED		0
 #define PAPI_LOW_LEVEL_INITED 	1       /* Low level has called library init */
@@ -634,6 +635,8 @@ typedef void *vptr_t;
      char kernel_version[PAPI_MIN_STR_LEN];  /**< Version of the kernel PMC support driver */
      char disabled_reason[PAPI_HUGE_STR_LEN]; /**< Reason for failure of initialization */
      int disabled;   /**< 0 if enabled, otherwise error code from initialization */
+     char partially_disabled_reason[PAPI_HUGE_STR_LEN]; /**< Reason for partial initialization */
+     int partially_disabled; /**< 1 if component is partially disabled, 0 otherwise */
      int initialized;                        /**< Component is ready to use */
      int CmpIdx;				/**< Index into the vector array for this component; set at init time */
      int num_cntrs;               /**< Number of hardware counters the component supports */

--- a/src/papi_internal.c
+++ b/src/papi_internal.c
@@ -509,6 +509,7 @@ _papi_hwi_init_errors(void) {
 	/* 25 PAPI_ECMP_DISABLED */_papi_hwi_add_error("Component containing event is disabled");
     /* 26 PAPI_EDELAY_INIT */ _papi_hwi_add_error("Delayed initialization component");
     /* 27 PAPI_EMULPASS */ _papi_hwi_add_error("Event exists, but cannot be counted due to multiple passes required by hardware");
+    /* 28 PAPI_PARTIAL */ _papi_hwi_add_error("Component in use is partially disabled, see utils/papi_component_avail for more information.");
 }
 
 int

--- a/src/utils/papi_component_avail.c
+++ b/src/utils/papi_component_avail.c
@@ -118,11 +118,15 @@ main( int argc, char **argv )
 
 	  printf( "Name:   %-23s %s\n", cmpinfo->name ,cmpinfo->description);
 
-      if (cmpinfo->disabled == PAPI_EDELAY_INIT) {
-          force_cmp_init(cid);
-      }
+	  if (cmpinfo->disabled == PAPI_EDELAY_INIT) {
+	      force_cmp_init(cid);
+	  }
 	  if (cmpinfo->disabled) {
 	    printf("   \\-> Disabled: %s\n",cmpinfo->disabled_reason);
+	  }
+
+	  if (cmpinfo->partially_disabled) {
+	      printf("   \\-> Partially disabled: %s\n", cmpinfo->partially_disabled_reason);
 	  }
 
 	  if ( flags.details ) {


### PR DESCRIPTION
## Pull Request Description
This PR will address half of the topic **Systems with multiple GPU configurations**  in Issue #297.  This is done by creating a partially disabled `Cuda` component to monitor NVIDIA devices with compute capabilities greater than or equal to 7.0 on machines with mixed compute capabilities (e.g. 6.0 - P100, 7.0 - V100, and 8.0 - A100). 


Cuda component output from `papi_component_avail` on a machine with an A100, V100, and P100:
```
Compiled-in components:
Name:   cuda                    CUDA profiling via NVIDIA CuPTI interfaces
   \-> Partially disabled: System includes multiple compute capabilities: <7.0, =7.0, >7.0. Only support for CC >=7.0 enabled. As a result, Device IDs: 0,1 are available.

Active components:
Name:   cuda                    CUDA profiling via NVIDIA CuPTI interfaces
                                Native: 268032, Preset: 0, Counters: 30
```

## Testing
 - 1 * A100
    - PAPI Utilities: ✅
    - Cuda tests: ✅ 
 - 1 * H100 && 1 * V100
    - PAPI Utilities: ✅ 
    - Cuda tests: ✅   
 - 1 * A100 && 1 * V100 && 1 * P100
    - PAPI Utilities: ✅ 
    - Cuda tests: ✅    


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
