### PR TITLE
ROCP_SDK: Change tests/Makefile for spack builds.

### DIFF
--- a/src/components/rocp_sdk/tests/Makefile
+++ b/src/components/rocp_sdk/tests/Makefile
@@ -1,6 +1,7 @@
 NAME=template
 include ../../Makefile_comp_tests.target
 
+AMDCXX   ?= amdclang++
 CFLAGS    = $(OPTFLAGS)
 CPPFLAGS += $(INCLUDE)
 LDFLAGS  += $(PAPILIB) $(TESTLIB) $(UTILOBJS)
@@ -18,19 +19,19 @@ template_tests: $(TESTS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(OPTFLAGS) -c -o $@ $<
 
 kernel.o: kernel.cpp
-	$(PAPI_ROCP_SDK_ROOT)/bin/amdclang++ -D__HIP_ROCclr__=1 -O2 -g -DNDEBUG --offload-arch=$(GPUARCH) -W -Wall -Wextra -Wshadow -o kernel.o -x hip -c kernel.cpp
+	$(AMDCXX) -D__HIP_ROCclr__=1 -O2 -g -DNDEBUG --offload-arch=$(GPUARCH) -W -Wall -Wextra -Wshadow -o kernel.o -x hip -c kernel.cpp
 
 simple: simple.o kernel.o
-	$(PAPI_ROCP_SDK_ROOT)/bin/amdclang++ -O2 -g -DNDEBUG $(GPUFLAGS) simple.o kernel.o -o simple $(LDFLAGS)
+	$(AMDCXX) -O2 -g -DNDEBUG $(GPUFLAGS) simple.o kernel.o -o simple $(LDFLAGS)
 
 advanced: advanced.o kernel.o
-	$(PAPI_ROCP_SDK_ROOT)/bin/amdclang++ -O2 -g -DNDEBUG $(GPUFLAGS) advanced.o kernel.o -o advanced $(LDFLAGS)
+	$(AMDCXX) -O2 -g -DNDEBUG $(GPUFLAGS) advanced.o kernel.o -o advanced $(LDFLAGS)
 
 two_eventsets: two_eventsets.o kernel.o
-	$(PAPI_ROCP_SDK_ROOT)/bin/amdclang++ -O2 -g -DNDEBUG $(GPUFLAGS) two_eventsets.o kernel.o -o two_eventsets $(LDFLAGS)
+	$(AMDCXX) -O2 -g -DNDEBUG $(GPUFLAGS) two_eventsets.o kernel.o -o two_eventsets $(LDFLAGS)
 
 simple_sampling: simple_sampling.o kernel.o
-	$(PAPI_ROCP_SDK_ROOT)/bin/amdclang++ -O2 -g -DNDEBUG $(GPUFLAGS) simple_sampling.o kernel.o -o simple_sampling $(LDFLAGS)
+	$(AMDCXX) -O2 -g -DNDEBUG $(GPUFLAGS) simple_sampling.o kernel.o -o simple_sampling $(LDFLAGS)
 
 clean:
 	rm -f $(TESTS) *.o


### PR DESCRIPTION
## Pull Request Description

Instead of explicitly setting the path for amdclang++ in the tests/Makefile, assuming that the compiler will be in the rocprofiler directory structure, allow it to be picked up from the environment PATH, or explicitly set through the new variable AMDCXX

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
