### PR TITLE
Fix compilation when CAP_PERFMON is missing

### DIFF
--- a/src/components/perf_event_uncore/perf_event_uncore.c
+++ b/src/components/perf_event_uncore/perf_event_uncore.c
@@ -643,8 +643,12 @@ _peu_init_component( int cidx )
      goto fn_fail;
    }
 
-   perfmon_capabilities = (cap_data[0].permitted & (1 << CAP_SYS_ADMIN)) ||
-                          (cap_data[1].permitted & (1 << (CAP_PERFMON - 32)));
+   #ifdef CAP_PERFMON
+      perfmon_capabilities = (cap_data[0].permitted & (1 << CAP_SYS_ADMIN)) ||
+                             (cap_data[1].permitted & (1 << (CAP_PERFMON - 32)));
+   #else
+      perfmon_capabilities = cap_data[0].permitted & (1 << CAP_SYS_ADMIN);
+   #endif
 
    /* Run the libpfm4-specific setup */
 


### PR DESCRIPTION
## Pull Request Description

Fix #338, where compiling `papi` fails due to the `CAP_PERFMON` macro not being defined.

## Author Checklist
- [X] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [X] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [X] **Tests**
The PR needs to pass all the tests
