### PR TITLE
components: improper usage of PAPI_END macro

### DIFF
--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -2521,7 +2521,7 @@ int cuptip_evt_enum(uint32_t *event_code, int modifier)
                 papi_errno = evt_id_create(&info, event_code);
                 break;
             }
-            papi_errno = PAPI_END;
+            papi_errno = PAPI_ENOEVNT;
             break;
         case PAPI_NTV_ENUM_UMASKS:
             papi_errno = evt_id_to_info(*event_code, &info);
@@ -2543,7 +2543,7 @@ int cuptip_evt_enum(uint32_t *event_code, int modifier)
                 papi_errno = evt_id_create(&info, event_code);
                 break;
             }
-            papi_errno = PAPI_END;
+            papi_errno = PAPI_ENOEVNT;
             break;
         default:
             papi_errno = PAPI_EINVAL;

--- a/src/components/rocm/roc_profiler.c
+++ b/src/components/rocm/roc_profiler.c
@@ -222,7 +222,7 @@ rocp_evt_enum(uint64_t *event_code, int modifier)
                 papi_errno = evt_id_create(&info, event_code);
                 break;
             }
-            papi_errno = PAPI_END;
+            papi_errno = PAPI_ENOEVNT;
             break;
         case PAPI_NTV_ENUM_UMASKS:
             papi_errno = evt_id_to_info(*event_code, &info);
@@ -245,7 +245,7 @@ rocp_evt_enum(uint64_t *event_code, int modifier)
                     break;
                 }
             }
-            papi_errno = PAPI_END;
+            papi_errno = PAPI_ENOEVNT;
             break;
         default:
             papi_errno = PAPI_EINVAL;

--- a/src/components/rocm_smi/rocs.c
+++ b/src/components/rocm_smi/rocs.c
@@ -396,7 +396,7 @@ rocs_evt_enum(unsigned int *event_code, int modifier)
             if (*event_code + 1 < (unsigned int) ntv_table_p->count) {
                 ++(*event_code);
             } else {
-                papi_errno = PAPI_END;
+                papi_errno = PAPI_ENOEVNT;
             }
             break;
         default:

--- a/src/components/template/vendor_profiler_v1.c
+++ b/src/components/template/vendor_profiler_v1.c
@@ -281,7 +281,7 @@ vendorp1_evt_enum(unsigned int *event_code, int modifier)
                 papi_errno = evt_id_create(&info, event_code);
                 break;
             }
-            papi_errno = PAPI_END;
+            papi_errno = PAPI_ENOEVNT;
             break;
         default:
             papi_errno = PAPI_EINVAL;


### PR DESCRIPTION
## Pull Request Description
PAPI_END is a macro defined in papiStdEventDefs.h to denote the end of the list of preset macros. However, it was being used as an error code in various components in cases unrelated to the number of presets.

This commit changes this to a more appropriate error code: PAPI_ENOEVNT.

These changes have been tested with ROCm 6.3.1 on Frontier and CUDA 12.1.1 on Methane.

This pull request addresses Issue #337.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
