### PR TITLE
ROCP_SDK: Accomodate machines with fewer AMD GPUs.

### DIFF
--- a/src/components/rocp_sdk/Rules.rocp_sdk
+++ b/src/components/rocp_sdk/Rules.rocp_sdk
@@ -2,9 +2,11 @@ COMPSRCS += components/rocp_sdk/rocp_sdk.c components/rocp_sdk/sdk_class.cpp
 
 COMPOBJS += rocp_sdk.o sdk_class.o
 
-ROCP_SDK_INCL=$(PAPI_ROCP_SDK_ROOT)/include
+ROCP_SDK_INCL=-I$(PAPI_ROCP_SDK_ROOT)/include     \
+              -I$(PAPI_ROCP_SDK_ROOT)/include/hsa \
+              -I$(PAPI_ROCP_SDK_ROOT)/hsa/include
 
-CFLAGS  += -g -I$(ROCP_SDK_INCL) -D__HIP_PLATFORM_AMD__
+CFLAGS  += -g $(ROCP_SDK_INCL) -D__HIP_PLATFORM_AMD__
 LDFLAGS += $(LDL)
 
 rocp_sdk.o: components/rocp_sdk/rocp_sdk.c $(HEADERS)

--- a/src/components/rocp_sdk/tests/Makefile
+++ b/src/components/rocp_sdk/tests/Makefile
@@ -1,25 +1,29 @@
 NAME=template
 include ../../Makefile_comp_tests.target
 
+ROCP_SDK_INCL=-I$(PAPI_ROCP_SDK_ROOT)/include     \
+              -I$(PAPI_ROCP_SDK_ROOT)/include/hsa \
+              -I$(PAPI_ROCP_SDK_ROOT)/hsa/include
+
 AMDCXX   ?= amdclang++
 CFLAGS    = $(OPTFLAGS)
-CPPFLAGS += $(INCLUDE)
+CPPFLAGS += $(INCLUDE) $(ROCP_SDK_INCL)
 LDFLAGS  += $(PAPILIB) $(TESTLIB) $(UTILOBJS)
 
 GPUARCH = $(shell rocm_agent_enumerator 2>/dev/null | head -1)
-ifeq ($(GPUARCH),)
-    GPUARCH = native
+ifneq ($(GPUARCH),)
+    ARCHFLAG=--offload-arch=$(GPUARCH)
 endif
-GPUFLAGS=--offload-arch=$(GPUARCH) --hip-link --rtlib=compiler-rt -unwindlib=libgcc
+GPUFLAGS=$(ARCHFLAG) --hip-link --rtlib=compiler-rt -unwindlib=libgcc
 
 TESTS = simple advanced two_eventsets simple_sampling
 template_tests: $(TESTS)
 
 %.o: %.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(OPTFLAGS) -c -o $@ $<
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(OPTFLAGS) -D__HIP_PLATFORM_AMD__ -c -o $@ $<
 
 kernel.o: kernel.cpp
-	$(AMDCXX) -D__HIP_ROCclr__=1 -O2 -g -DNDEBUG --offload-arch=$(GPUARCH) -W -Wall -Wextra -Wshadow -o kernel.o -x hip -c kernel.cpp
+	$(AMDCXX) -D__HIP_ROCclr__=1 -O2 -g -DNDEBUG $(ARCHFLAG) -W -Wall -Wextra -Wshadow -o kernel.o -x hip -c kernel.cpp
 
 simple: simple.o kernel.o
 	$(AMDCXX) -O2 -g -DNDEBUG $(GPUFLAGS) simple.o kernel.o -o simple $(LDFLAGS)
@@ -31,7 +35,7 @@ two_eventsets: two_eventsets.o kernel.o
 	$(AMDCXX) -O2 -g -DNDEBUG $(GPUFLAGS) two_eventsets.o kernel.o -o two_eventsets $(LDFLAGS)
 
 simple_sampling: simple_sampling.o kernel.o
-	$(AMDCXX) -O2 -g -DNDEBUG $(GPUFLAGS) simple_sampling.o kernel.o -o simple_sampling $(LDFLAGS)
+	$(AMDCXX) -O2 -g -DNDEBUG $(GPUFLAGS) simple_sampling.o kernel.o -o simple_sampling $(LDFLAGS) -pthread
 
 clean:
 	rm -f $(TESTS) *.o

--- a/src/components/rocp_sdk/tests/kernel.cpp
+++ b/src/components/rocp_sdk/tests/kernel.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <hip/hip_runtime.h>
 
-extern "C" void launch_kernel(int device_id);
+extern "C" int launch_kernel(int device_id);
 
 #define HIP_CALL(call)                                                                             \
     do                                                                                             \
@@ -10,7 +10,7 @@ extern "C" void launch_kernel(int device_id);
         if(err != hipSuccess)                                                                      \
         {                                                                                          \
             std::cerr << hipGetErrorString(err) << std::endl;                                      \
-            abort();                                                                               \
+            return(-1);                                                                            \
         }                                                                                          \
     } while(0)
 
@@ -36,7 +36,7 @@ kernelC(T* C_d, const T* A_d, size_t N)
     }
 }
 
-void launch_kernel(int device_id) {
+int launch_kernel(int device_id) {
     const int NUM_LAUNCH = 1;
 
     HIP_CALL(hipSetDevice(device_id));
@@ -47,4 +47,6 @@ void launch_kernel(int device_id) {
     }
 
     HIP_CALL(hipDeviceSynchronize());
+
+    return 0;
 }

--- a/src/components/rocp_sdk/tests/simple.c
+++ b/src/components/rocp_sdk/tests/simple.c
@@ -3,7 +3,7 @@
 #include <papi.h>
 #include <papi_test.h>
 
-extern void launch_kernel(int device_id);
+extern int launch_kernel(int device_id);
 
 int main(int argc, char *argv[])
 {
@@ -44,9 +44,11 @@ int main(int argc, char *argv[])
         test_fail(__FILE__, __LINE__, "PAPI_start", papi_errno);
     }
 
-
     printf("---------------------  launch_kernel(0)\n");
-    launch_kernel(0);
+    papi_errno = launch_kernel(0);
+    if (papi_errno != 0) {
+        test_fail(__FILE__, __LINE__, "launch_kernel(0)", papi_errno);
+    }
 
     usleep(10000);
 

--- a/src/components/rocp_sdk/tests/simple_sampling.c
+++ b/src/components/rocp_sdk/tests/simple_sampling.c
@@ -6,7 +6,7 @@
 
 #define NUM_EVENTS (12)
 
-extern void launch_kernel(int device_id);
+extern int launch_kernel(int device_id);
 int eventset = PAPI_NULL;
 volatile int gv=0;
 
@@ -79,7 +79,10 @@ int main(int argc, char *argv[])
 
     printf("---------------------  launch_kernel(0)\n");
     gv = 1;
-    launch_kernel(0);
+    papi_errno = launch_kernel(0);
+    if (papi_errno != 0) {
+        test_fail(__FILE__, __LINE__, "launch_kernel(0)", papi_errno);
+    }
 
     usleep(20000);
 

--- a/src/components/rocp_sdk/tests/two_eventsets.c
+++ b/src/components/rocp_sdk/tests/two_eventsets.c
@@ -3,7 +3,7 @@
 #include <papi.h>
 #include <papi_test.h>
 
-extern void launch_kernel(int device_id);
+extern int launch_kernel(int device_id);
 
 int main(int argc, char *argv[])
 {
@@ -71,7 +71,10 @@ int main(int argc, char *argv[])
     }
     for(int rep=0; rep<=3; ++rep){
 
-        launch_kernel(1);
+        papi_errno = launch_kernel(1);
+        if (papi_errno != 0) {
+            test_fail(__FILE__, __LINE__, "launch_kernel(1)", papi_errno);
+        }
 
         usleep(1000);
 
@@ -106,7 +109,10 @@ int main(int argc, char *argv[])
     }
     for(int rep=0; rep<=3; ++rep){
 
-        launch_kernel(1);
+        papi_errno = launch_kernel(1);
+        if (papi_errno != 0) {
+            test_fail(__FILE__, __LINE__, "launch_kernel(1)", papi_errno);
+        }
 
         usleep(1000);
 
@@ -140,7 +146,10 @@ int main(int argc, char *argv[])
     }
     for(int rep=0; rep<=2; ++rep){
 
-        launch_kernel(0);
+        papi_errno = launch_kernel(0);
+        if (papi_errno != 0) {
+            test_fail(__FILE__, __LINE__, "launch_kernel(0)", papi_errno);
+        }
 
         usleep(1000);
 


### PR DESCRIPTION
## Pull Request Description

This PR enables the rocp_sdk component to check the number of AMD GPUs on the system and gracefully fail if none are present. The tests also fail more gracefully in the absence of GPUs to run the kernels on.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
