### PR TITLE
perf_event: Disable component if perf_event_paranoid is set to 4 

### DIFF
--- a/src/components/perf_event/perf_event.c
+++ b/src/components/perf_event/perf_event.c
@@ -2475,10 +2475,12 @@ _pe_handle_paranoid(papi_vector_t *component) {
 	if (retval!=1) fprintf(stderr,"Error reading paranoid level\n");
 	fclose(fff);
 
-	if (paranoid_level==3) {
-		strCpy=strncpy(component->cmp_info.disabled_reason,
-			"perf_event support disabled by Linux with paranoid=3",PAPI_MAX_STR_LEN);
-      if (strCpy == NULL) HANDLE_STRING_ERROR;
+	if (paranoid_level >= 3) {
+		int strLen = snprintf(component->cmp_info.disabled_reason, PAPI_MAX_STR_LEN, "perf_event support disabled by Linux with paranoid=%d", paranoid_level);
+		if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+			SUBDBG("Failed to fully write disabled reason due to paranoid level.\n");
+			return PAPI_EBUF;
+		}
 		return PAPI_ECMP;
 	}
 


### PR DESCRIPTION
## Pull Request Description
This PR addresses Issue #354, where the `perf_event` component will show as active if your paranoid level is set to 4.

## Tested on an AMD Ryzen 9 9950X 16-Core Processor where my paranoid level is set to 4

`./papi_component_avail`:
```
Available components and hardware information.
--------------------------------------------------------------------------------
PAPI version             : 7.2.0.0
Operating system         : Linux 6.8.0-58-generic
Vendor string and code   : AuthenticAMD (2, 0x2)
Model string and code    : AMD Ryzen 9 9950X 16-Core Processor (68, 0x44)
CPU revision             : 0.000000
CPUID                    : Family/Model/Stepping 26/68/0, 0x1a/0x44/0x00
CPU Max MHz              : 5752
CPU Min MHz              : 600
Total cores              : 32
SMT threads per core     : 2
Cores per socket         : 16
Sockets                  : 1
Cores per NUMA region    : 32
NUMA regions             : 1
Running in a VM          : no
Number Hardware Counters : 0
Max Multiplex Counters   : 384
Fast counter read (rdpmc): no
--------------------------------------------------------------------------------

Compiled-in components:
Name:   perf_event              Linux perf_event CPU counters
   \-> Disabled: perf_event support disabled by Linux with paranoid=4
Name:   perf_event_uncore       Linux perf_event CPU uncore and northbridge
   \-> Disabled: Insufficient permissions for uncore access.  Set /proc/sys/kernel/perf_event_paranoid to 0, run as root or get CAP_PERFMON.
Name:   sysdetect               System info detection component

Active components:
Name:   sysdetect               System info detection component
                                Native: 0, Preset: 0, Counters: 0
```

`./papi_native_avail`
```
Available native events and hardware information.
--------------------------------------------------------------------------------
PAPI version             : 7.2.0.0
Operating system         : Linux 6.8.0-58-generic
Vendor string and code   : AuthenticAMD (2, 0x2)
Model string and code    : AMD Ryzen 9 9950X 16-Core Processor (68, 0x44)
CPU revision             : 0.000000
CPUID                    : Family/Model/Stepping 26/68/0, 0x1a/0x44/0x00
CPU Max MHz              : 5752
CPU Min MHz              : 600
Total cores              : 32
SMT threads per core     : 2
Cores per socket         : 16
Sockets                  : 1
Cores per NUMA region    : 32
NUMA regions             : 1
Running in a VM          : no
Number Hardware Counters : 0
Max Multiplex Counters   : 384
Fast counter read (rdpmc): no
--------------------------------------------------------------------------------

===============================================================================
 Native Events in Component: sysdetect
===============================================================================

Total events reported: 0

No events detected!  Check papi_component_avail to find out why.
```

Note: I tested as well on a machine where my `perf_event_paranoid` level is set to -1 and the PAPI utilities worked as expected too.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
