### PR TITLE
ROCP_SDK: call configure_device_counting_service as early as possible.

### DIFF
--- a/src/components/rocp_sdk/rocp_sdk.c
+++ b/src/components/rocp_sdk/rocp_sdk.c
@@ -154,9 +154,9 @@ rocp_sdk_init_component(int cid)
         return papi_errno;
     }
 
-    sprintf(_rocp_sdk_vector.cmp_info.disabled_reason, "Not initialized. Access component events to initialize it.");
-    _rocp_sdk_vector.cmp_info.disabled = PAPI_EDELAY_INIT;
-    return PAPI_EDELAY_INIT;
+    // This component needs to be fully initialized from the beginning,
+    // because interleaving hip calls and PAPI calls leads to errors.
+    return check_n_initialize();
 }
 
 int

--- a/src/components/rocp_sdk/rocp_sdk.c
+++ b/src/components/rocp_sdk/rocp_sdk.c
@@ -235,6 +235,9 @@ int
 rocp_sdk_shutdown_component(void)
 {
     _rocp_sdk_vector.cmp_info.initialized = 0;
+    if (rocm_dlp != NULL) {
+        dlclose(rocm_dlp);
+    }
     return rocprofiler_sdk_shutdown();
 }
 
@@ -532,10 +535,6 @@ unload_hsa_sym( void )
 {
     if (hsa_is_enabled())
         (*hsa_shut_downPtr)();
-
-    if (rocm_dlp != NULL) {
-        dlclose(rocm_dlp);
-    }
 
     hsa_initPtr           = NULL;
     hsa_shut_downPtr      = NULL;


### PR DESCRIPTION
When applications are linked against libpapi.a rocprofiler_configure() is not called on-load, so we have to explicitly initialize everything. This PR moves some of the necessary steps earlier, so that everything is initialized after PAPI_library_init().

## Pull Request Description


## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
