### PR TITLE
Coretemp: Enable support for multiplexing

### DIFF
--- a/src/components/coretemp/linux-coretemp.c
+++ b/src/components/coretemp/linux-coretemp.c
@@ -762,6 +762,7 @@ papi_vector_t _coretemp_vector = {
 				 .fast_virtual_timer = 0,
 				 .attach = 0,
 				 .attach_must_ptrace = 0,
+				 .kernel_multiplex = 1,
 				 }
 	,
 


### PR DESCRIPTION
## Pull Request Description
As stands, the Coretemp component does not support multiplexing. Due to this, if you try to add a Coretemp event to a multiplexed EventSet you will be met with `PAPI_EINVAL`.

This PR updates the Coretemp component to allow for multiplexing. 

Tested with the below application code using `PAPI_assign_eventset_component` and `PAPI_add_event` on an Intel Xeon Gold 6140 (Methane at ICL as of May 7th, 2025):

```c
#include <papi.h>
#include <stdio.h>
#include <stdlib.h>

void handle_error (int retval)
{
    printf("PAPI error %d: %s\n", retval, PAPI_strerror(retval));
    exit(1);
}

int main()
{
    int retval = PAPI_library_init(PAPI_VER_CURRENT);
    if (retval != PAPI_VER_CURRENT) {
        handle_error(retval);
    }   
 
    retval = PAPI_multiplex_init();
    if (retval != PAPI_OK) {
        handle_error(retval);
    }   

    int EventSet = PAPI_NULL; 
    retval = PAPI_create_eventset(&EventSet);
    if (retval != PAPI_OK) {
        handle_error(retval);
    }   

    retval = PAPI_assign_eventset_component( EventSet, 2 );
    if (retval != PAPI_OK) {
        handle_error(retval);
    }   

    retval = PAPI_set_multiplex(EventSet);
    if (retval != PAPI_OK) {
        handle_error(retval);
    }   

    int eventCode;
    retval = PAPI_event_name_to_code("coretemp:::hwmon2:temp3_input", &eventCode);
    if (retval != PAPI_OK) {
        handle_error(retval);
    }   

    retval = PAPI_add_event(EventSet, eventCode);
    if (retval != PAPI_OK) {
        handle_error(retval);
    }   

    retval = PAPI_start(EventSet);
    if (retval != PAPI_OK) {
        handle_error(retval);
    }   

    long long values[1];
    retval = PAPI_read(EventSet, values);
    if (retval != PAPI_OK) {
        handle_error(retval);
    }   

    printf("Counter value: %d\n", values[0]);

    retval = PAPI_stop(EventSet, NULL);
    if (retval != PAPI_OK) {
        handle_error(retval);
    }   

    printf("\033[0;32mPASSED\n\033[0m");
    exit(0); 
}
```

Output:
```
Counter value: 47000
PASSED
```



## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
