### PR TITLE
Cuda component: Replace int typing with long long to avoid overflow with measured values

### DIFF
--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -178,7 +178,7 @@ static int get_metric_eval_request(NVPW_MetricsEvaluator *metricEvaluator, const
 static int create_raw_metric_requests(NVPW_MetricsEvaluator *pMetricsEvaluator, NVPW_MetricEvalRequest *metricEvalRequest, NVPA_RawMetricRequest **rawMetricRequests, int *rawMetricRequestsCount);
 // Metric Evaluation
 static int get_number_of_passes_for_eventsets(const char *pChipName, const char *metricName, int *numOfPasses);
-static int get_evaluated_metric_values(NVPW_MetricsEvaluator *pMetricsEvaluator, cuptip_gpu_state_t *gpu_ctl, int *evaluatedMetricValues);
+static int get_evaluated_metric_values(NVPW_MetricsEvaluator *pMetricsEvaluator, cuptip_gpu_state_t *gpu_ctl, long long *evaluatedMetricValues);
 // Destroy MetricsEvaluator
 static int destroy_metrics_evaluator(NVPW_MetricsEvaluator *pMetricsEvaluator);
 
@@ -994,7 +994,7 @@ int cuptip_ctx_read(cuptip_control_t state, long long **counters)
         nvpwCheckErrors( NVPW_CUDA_MetricsEvaluator_InitializePtr(&metricEvaluatorInitializeParams), return PAPI_EMISC );
         NVPW_MetricsEvaluator *pMetricsEvaluator = metricEvaluatorInitializeParams.pMetricsEvaluator;
 
-        int *metricValues = (int *) calloc(gpu_ctl->added_events->count, sizeof(int));
+        long long *metricValues = (long long *) calloc(gpu_ctl->added_events->count, sizeof(long long));
         if (metricValues == NULL) {
             SUBDBG("Failed to allocate memory for metricValues.\n");
             return PAPI_ENOMEM;
@@ -2822,7 +2822,7 @@ static int create_raw_metric_requests(NVPW_MetricsEvaluator *pMetricsEvaluator, 
  *  @param *evaluatedMetricValues
  *    Total number of raw metric requests created.
 */
-static int get_evaluated_metric_values(NVPW_MetricsEvaluator *pMetricsEvaluator, cuptip_gpu_state_t *gpu_ctl, int *evaluatedMetricValues)
+static int get_evaluated_metric_values(NVPW_MetricsEvaluator *pMetricsEvaluator, cuptip_gpu_state_t *gpu_ctl, long long *evaluatedMetricValues)
 {
     int i;
     for (i = 0; i < gpu_ctl->added_events->count; i++) {


### PR DESCRIPTION
## Pull Request Description
This PR replaces the `int` datatype of `metricValues` in `cuptip_ctx_read` with `long long` such that we avoid overflow with measured values.

As stands with the current master branch if you run the `concurrent_profiling` test with cuda:::sm__cycles_active:stat=sum:device=0 you will end up with a negative value: 
```
Metrics for device #0:
Look at the sm__cycles_elapsed.max values for each test.
This value represents the time spent on device to run the kernels in each case, and should be longest for the serial range, and roughly equal for the single and multi device concurrent ranges.
PAPI event name							Measured value
--------------------------------------------------------------------------------
cuda:::sm__cycles_active:stat=sum:device=0			-2147483648
PASSED
```

This PR resolves this issue:
```
Metrics for device #0:
Look at the sm__cycles_elapsed.max values for each test.
This value represents the time spent on device to run the kernels in each case, and should be longest for the serial range, and roughly equal for the single and multi device concurrent ranges.
PAPI event name							Measured value
--------------------------------------------------------------------------------
cuda:::sm__cycles_active:stat=sum:device=0			2160446356
PASSED
```

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
