### PR TITLE
Configure: Correctly output the tests chosen by a user with `--with-tests` and default value for `--with-debug`

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -4678,30 +4678,32 @@ else
             if test "x$NO_MPI_TESTS" = "x"; then
               mpi_tests=yes
               # mpitests only works together with ctests
-              if test "x$tmp_tests" = "x"; then
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-              else
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: $tmp_tests mpitests" >&5
-$as_echo "$tmp_tests mpitests" >&6; }
+              if test "x$tmp_tests" != "x"; then
+                tmp_tests+="mpitests "
               fi
-            fi
-          else
-            NO_MPI_TESTS=yes
-            if test "x$tmp_tests" = "x"; then
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-            else
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: $tmp_tests" >&5
-$as_echo "$tmp_tests" >&6; }
             fi
           fi
           ;;
   esac
-  # do not list mpi_tests for makefile target
+
+  if test "x$tmp_tests" = "x"; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+  else
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $tmp_tests" >&5
+$as_echo "$tmp_tests" >&6; }
+  fi
+
+  # do not list mpitests for makefile target
+  case "$tmp_tests" in
+    *mpitests* )
+        tmp_tests=$(echo "$tmp_tests" | sed 's/ mpitests//')
+        ;;
+  esac
+
   tests=$tmp_tests
 
-  # mpi_tests is not listed by the user
+  # mpitests is not listed by the user
   if test "$mpi_tests" = "no"; then
     NO_MPI_TESTS=yes
   fi

--- a/src/configure
+++ b/src/configure
@@ -4712,6 +4712,9 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for debug build" >&5
 $as_echo_n "checking for debug build... " >&6; }
 
+# default value for --with-debug if not set by user
+debug="no"
+
 # Check whether --with-debug was given.
 if test "${with_debug+set}" = set; then :
   withval=$with_debug; debug=$withval

--- a/src/configure.in
+++ b/src/configure.in
@@ -371,26 +371,30 @@ else
             if test "x$NO_MPI_TESTS" = "x"; then
               mpi_tests=yes
               # mpitests only works together with ctests
-              if test "x$tmp_tests" = "x"; then
-                AC_MSG_RESULT(no)
-              else
-                AC_MSG_RESULT($tmp_tests mpitests)
+              if test "x$tmp_tests" != "x"; then
+                tmp_tests+="mpitests "
               fi
-            fi
-          else
-            NO_MPI_TESTS=yes
-            if test "x$tmp_tests" = "x"; then
-              AC_MSG_RESULT(no)
-            else
-              AC_MSG_RESULT($tmp_tests)
             fi
           fi
           ;;
   esac
-  # do not list mpi_tests for makefile target
+
+  if test "x$tmp_tests" = "x"; then
+    AC_MSG_RESULT(no)
+  else
+    AC_MSG_RESULT($tmp_tests)
+  fi
+
+  # do not list mpitests for makefile target
+  case "$tmp_tests" in
+    *mpitests* )
+        tmp_tests=$(echo "$tmp_tests" | sed 's/ mpitests//')
+        ;;
+  esac
+
   tests=$tmp_tests
   
-  # mpi_tests is not listed by the user
+  # mpitests is not listed by the user
   if test "$mpi_tests" = "no"; then
     NO_MPI_TESTS=yes
   fi

--- a/src/configure.in
+++ b/src/configure.in
@@ -401,6 +401,9 @@ else
 fi
 
 AC_MSG_CHECKING(for debug build)
+
+# default value for --with-debug if not set by user
+debug="no"
 AC_ARG_WITH(debug,
             [AS_HELP_STRING([--with-debug=<yes,memory,no>],
             [Build a debug version, debug version plus memory tracker or none])],


### PR DESCRIPTION
## Pull Request Description
As stands, if a user configures with the following: `./configure --prefix=$PWD/test-install --with-tests="comp_tests"` then the output for "checking for tests" will be incorrect:
```
checking for tests... checking for debug build... 
```
This will also occur for other options of `--with-tests` such as "comp_tests ftests" or "comp_tests ftests ctests".

Along with the above issue with `--with-tests`, if `--with-debug` is not set then configure will output:
```
checking for debug build...
```

This PR resolves both of these bugs/behaviors:
```
--with-tests:
./configure --prefix=$PWD/test-install --with-tests="comp_tests"
checking for tests... comp_tests

./configure --prefix=$PWD/test-install --with-tests="comp_tests ftests ctests"
checking for tests... ctests ftests comp_tests

Without --with-debug:
./configure --prefix=$PWD/test-install
checking for debug build... no
```

## Testing Changes
Primary testing was done on a machine with an Intel Xeon Gold 6140 and an OS of Rocky Linux release 9.4. Secondary testing was done on a machine with an AMD EPYC 7513 and an OS of Debian 6.12. For the testing combinations shown below, if secondary testing was done for it then a blue circle (🔵) will show in the left most block (note that the utilities were not ran in the case of secondary testing as I lacked the necessary permissions for the CPU components).

`--with-debug`:
| Value of `--with-debug`| Built Successfully | PAPI Utilities |
| :-------------: | :-------------: | ------------- |
| Not set (🔵) | ✅  | * `papi_component_avail`: ✅  <br> * `papi_native_avail`: ✅  <br>  * `papi_command_line`: ✅ |
| no (🔵) | ✅  |* `papi_component_avail`: ✅  <br> * `papi_native_avail`: ✅  <br>  * `papi_command_line`: ✅ |
| yes (🔵) | ✅  |* `papi_component_avail`: ✅  <br> * `papi_native_avail`: ✅  <br>  * `papi_command_line`: ✅ <br> <br> Note that setting `export PAPI_DEBUG=ALL` showed debug messages |
| memory  | ✅  | See Issue #366 |

`--with-tests`:
| Value of `--with-tests`| Built Successfully | PAPI Utilities |
| :-------------: | :-------------: | ------------- |
| Not set (🔵) | ✅  | * `papi_component_avail`: ✅  <br> * `papi_native_avail`: ✅  <br>  * `papi_command_line`: ✅ |
| no (🔵) | ✅  | * `papi_component_avail`: ✅  <br> * `papi_native_avail`: ✅  <br>  * `papi_command_line`: ✅ |
| "comp_tests" | ✅  | * `papi_component_avail`: ✅  <br> * `papi_native_avail`: ✅  <br>  * `papi_command_line`: ✅ |
| "ctests" (🔵) | ✅  | * `papi_component_avail`: ✅  <br> * `papi_native_avail`: ✅  <br>  * `papi_command_line`: ✅ |
| "ftests" | ✅  | * `papi_component_avail`: ✅  <br> * `papi_native_avail`: ✅  <br>  * `papi_command_line`: ✅ |
| "mpitests" | ✅  | * `papi_component_avail`: ✅  <br> * `papi_native_avail`: ✅  <br>  * `papi_command_line`: ✅  <br> <br> Note that if no other test is set, then `--with-tests` will be no|
| "ctests ftests" | ✅  | * `papi_component_avail`: ✅  <br> * `papi_native_avail`: ✅  <br>  * `papi_command_line`: ✅ |
| "ctests comp_tests" (🔵) | ✅  | * `papi_component_avail`: ✅  <br> * `papi_native_avail`: ✅  <br>  * `papi_command_line`: ✅ |
| "ftests comp_tests" | ✅  | * `papi_component_avail`: ✅  <br> * `papi_native_avail`: ✅  <br>  * `papi_command_line`: ✅ |
| "mpitests comp_tests" | ✅  | * `papi_component_avail`: ✅  <br> * `papi_native_avail`: ✅  <br>  * `papi_command_line`: ✅ |
| "mpitests ctests" (🔵) | ✅  | * `papi_component_avail`: ✅  <br> * `papi_native_avail`: ✅  <br>  * `papi_command_line`: ✅ |
| "mpitests ftests" | ✅  | * `papi_component_avail`: ✅  <br> * `papi_native_avail`: ✅  <br>  * `papi_command_line`: ✅ |
| "comp_tests ftests ctests" | ✅  | * `papi_component_avail`: ✅  <br> * `papi_native_avail`: ✅  <br>  * `papi_command_line`: ✅ |
| "comp_tests ftests ctests mpitests" (🔵) | ✅  | * `papi_component_avail`: ✅  <br> * `papi_native_avail`: ✅  <br>  * `papi_command_line`: ✅ |


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
