### PR TITLE
Cuda/ROCm components: Add stricter qualifiers checks

### DIFF
--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -2075,7 +2075,6 @@ static int cuda_verify_no_repeated_qualifiers(const char *eventName)
     return PAPI_OK;
 }
 
-
 /** @class cuda_verify_qualifiers
   * @brief Verify that the device and/or stats qualifier provided by the user
   *        is valid. E.g. :device=# or :stat=avg.
@@ -2089,7 +2088,7 @@ static int cuda_verify_no_repeated_qualifiers(const char *eventName)
   *   Position of where the equal sign is located in the qualifier string name.
   * @param *qualifierValue
   *   Upon verifying the provided qualifier is valid. Store either a device index
-  *   or statistic.
+  *   or a statistic index.
 */
 static int cuda_verify_qualifiers(int flag, char *qualifierName, int equalitySignPosition, int *qualifierValue)
 {


### PR DESCRIPTION
## Pull Request Description
As stands the Cuda and ROCm components will allow the following cases of events to be added:

Cuda:
```
cuda:::dram__bytes:stat=max:device=0:stat=max:device=0
cuda:::dram__bytes:stat=max:device=0:stat=max:device-0
cuda:::dram__bytes:stat=max:device=0:stat=max:device=-0
```

ROCm:
```
rocm:::TCC_EA1_WRREQ_64B:device=0:instance=1:device=0:instance=0
rocm:::TCC_EA1_WRREQ_64B:device=-0:instance=1
```

None of the above cases are valid events. This PR addresses this and adds stricter checks for qualifiers and will now fail on the above instances. Verification for the new behavior was done with `papi_command_line` for the following setups:

 - Cuda component: 8 * A100s with Cuda Toolkit 12.8
 - ROCm component: 2 * Vega 20s with ROCm 6.3.2

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
