### PR TITLE
Cuda component: Properly set return value in cuptid_init

### DIFF
--- a/src/components/cuda/cupti_dispatch.c
+++ b/src/components/cuda/cupti_dispatch.c
@@ -62,12 +62,13 @@ int cuptid_device_get_count(int *num_gpus)
 
 int cuptid_init(void)
 {
+    int papi_errno;
     int init_errno = cuptic_init();
     if (init_errno != PAPI_OK && init_errno != PAPI_PARTIAL) {
+        papi_errno = init_errno;
         goto fn_exit;
     }
 
-    int papi_errno;
     int cupti_api = cuptic_determine_runtime_api();
     if (cupti_api == API_PERFWORKS) {
 


### PR DESCRIPTION
## Pull Request Description
Currently there is a case where `cuptid_init` will not properly return a PAPI error code if you enter the following conditional block:

```
int init_errno = cuptic_init();
 if (init_errno != PAPI_OK && init_errno != PAPI_PARTIAL) {
     goto fn_exit;
 }   
```

As when you hit the `goto fn_exit` we jump to `fn_exit` and return `papi_errno`. Which at this point has not been set. This can end up resulting in a segfault if the Cuda shared objects are not found (tested on 1 * GH200):

```
[tburgess@hopper1 bin]$ unset PAPI_CUDA_ROOT
[tburgess@hopper1 bin]$ module unload cuda/12.6.3
[tburgess@hopper1 bin]$ ./papi_component_avail
Segmentation fault (core dumped)
```

This PR updates the conditional block to now be:

```
int papi_errno;
int init_errno = cuptic_init();
if (init_errno != PAPI_OK && init_errno != PAPI_PARTIAL) {
     papi_errno = init_errno;
     goto fn_exit;
 }   
```

The above seg fault now does not occur:
```
[tburgess@hopper1 bin]$ unset PAPI_CUDA_ROOT
[tburgess@hopper1 bin]$ module unload cuda/12.6.3 
[tburgess@hopper1 bin]$ ./papi_component_avail
Available components and hardware information.
--------------------------------------------------------------------------------
PAPI version             : 7.2.0.0
Operating system         : Linux 5.14.0-362.13.1.el9_3.aarch64
Vendor string and code   : ARM_ARM (65, 0x41)
Model string and code    : Arm Neoverse V2 (0, 0x0)
CPU revision             : 0.000000
CPUID                    : Family/Model/Stepping 8/3407/0, 0x08/0xd4f/0x00
CPU Max MHz              : 3447
CPU Min MHz              : 81
Total cores              : 72
SMT threads per core     : 1
Cores per socket         : 72
Sockets                  : 1
Cores per NUMA region    : 8
NUMA regions             : 9
Running in a VM          : no
Number Hardware Counters : 6
Max Multiplex Counters   : 384
Fast counter read (rdpmc): no
--------------------------------------------------------------------------------

Compiled-in components:
Name:   perf_event              Linux perf_event CPU counters
Name:   perf_event_uncore       Linux perf_event CPU uncore and northbridge
   \-> Disabled: No uncore PMUs or events found
Name:   cuda                    CUDA profiling via NVIDIA CuPTI interfaces
   \-> Disabled: Unable to load CUDA library functions.
Name:   sysdetect               System info detection component

Active components:
Name:   perf_event              Linux perf_event CPU counters
                                Native: 243, Preset: 47, Counters: 6
                                PMUs supported: perf, perf_raw, arm_v2

Name:   sysdetect               System info detection component
                                Native: 0, Preset: 0, Counters: 0


--------------------------------------------------------------------------------
```


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
