### PR TITLE
Cuda component: Update tests to more gracefully handle multiple pass events

### DIFF
--- a/src/components/cuda/tests/HelloWorld.cu
+++ b/src/components/cuda/tests/HelloWorld.cu
@@ -49,75 +49,122 @@
 #define STEP_BY_STEP_DEBUG 0 /* helps debug CUcontext issues. */
 #define PRINT(quiet, format, args...) {if (!quiet) {fprintf(stderr, format, ## args);}}
 
-// Prototypes
-__global__ void helloWorld(char*);
+// Device kernel
+__global__ void helloWorld(char* str)
+{
+        // determine where in the thread grid we are
+        int idx = blockIdx.x * blockDim.x + threadIdx.x;
+        // unmangle output
+        str[idx] += idx;
+}
 
+/** @class add_events_from_command_line
+  * @brief Try and add each event provided on the command line by the user.
+  *
+  * @param EventSet
+  *   A PAPI eventset.
+  * @param totalEventCount
+  *   Number of events from the command line.
+  * @param **eventNamesFromCommandLine
+  *   Events provided on the command line.
+  * @param *numEventsSuccessfullyAdded
+  *   Total number of successfully added events.
+  * @param **eventsSuccessfullyAdded
+  *   Events that we are able to add to the EventSet.
+  * @param *numMultipassEvents
+  *   Counter to see if a multiple pass event was provided on the command line.
+*/
+static void add_events_from_command_line(int EventSet, int totalEventCount, char **eventNamesFromCommandLine, int *numEventsSuccessfullyAdded, char **eventsSuccessfullyAdded, int *numMultipassEvents)
+{
+    int i;
+    for (i = 0; i < totalEventCount; i++) {
+        int papi_errno = PAPI_add_named_event(EventSet, eventNamesFromCommandLine[i]);
+        if (papi_errno != PAPI_OK) {
+            if (papi_errno != PAPI_EMULPASS) {
+                fprintf(stderr, "Unable to add event %s to the EventSet with error code %d.\n", eventNamesFromCommandLine[i], papi_errno);
+                test_skip(__FILE__, __LINE__, "", 0);
+            }
+
+            // Handle multiple pass events
+            (*numMultipassEvents)++;
+            continue;
+        }
+
+        // Handle successfully added events
+        int strLen = snprintf(eventsSuccessfullyAdded[(*numEventsSuccessfullyAdded)], PAPI_MAX_STR_LEN, "%s", eventNamesFromCommandLine[i]);
+        if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+            fprintf(stderr, "Failed to fully write successfully added event.\n");
+            test_skip(__FILE__, __LINE__, "", 0);
+        }
+        (*numEventsSuccessfullyAdded)++;
+    }
+
+    return;
+}
 
 // Host function
 int main(int argc, char** argv)
 {
-	int quiet = 0;
+    int quiet = 0;
     CUcontext getCtx=NULL, sessionCtx=NULL;
     cudaError_t cudaError;
     CUresult cuError; (void) cuError;
 
+    cuError = cuInit(0);
+    if (cuError != CUDA_SUCCESS) {
+        fprintf(stderr, "Failed to initialize the CUDA driver API.\n");
+        exit(1);
+    }
+
 #ifdef PAPI
-	char *test_quiet = getenv("PAPI_CUDA_TEST_QUIET");
+    char *test_quiet = getenv("PAPI_CUDA_TEST_QUIET");
     if (test_quiet)
         quiet = (int) strtol(test_quiet, (char**) NULL, 10);
 
-	/* PAPI Initialization */
-	int papi_errno = PAPI_library_init( PAPI_VER_CURRENT );
-	if( papi_errno != PAPI_VER_CURRENT ) {
-		test_fail(__FILE__,__LINE__, "PAPI_library_init failed", 0 );
-	}
+    /* PAPI Initialization */
+    int papi_errno = PAPI_library_init( PAPI_VER_CURRENT );
+    if( papi_errno != PAPI_VER_CURRENT ) {
+        test_fail(__FILE__,__LINE__, "PAPI_library_init failed", 0 );
+    }
 
-	printf( "PAPI_VERSION     : %4d %6d %7d\n",
-		PAPI_VERSION_MAJOR( PAPI_VERSION ),
-		PAPI_VERSION_MINOR( PAPI_VERSION ),
-		PAPI_VERSION_REVISION( PAPI_VERSION ) );
+    printf( "PAPI_VERSION     : %4d %6d %7d\n",
+        PAPI_VERSION_MAJOR( PAPI_VERSION ),
+        PAPI_VERSION_MINOR( PAPI_VERSION ),
+        PAPI_VERSION_REVISION( PAPI_VERSION ) );
 
-	int i;
-	int EventSet = PAPI_NULL;
-	int eventCount = argc - 1;
+    int i;
+    int EventSet = PAPI_NULL;
+    int eventCount = argc - 1;
 
-	/* if no events passed at command line, just report test skipped. */
-	if (eventCount == 0) {
-		fprintf(stderr, "No eventnames specified at command line.");
-		test_skip(__FILE__, __LINE__, "", 0);
-	}
+    /* if no events passed at command line, just report test skipped. */
+    if (eventCount == 0) {
+        fprintf(stderr, "No eventnames specified at command line.");
+        test_skip(__FILE__, __LINE__, "", 0);
+    }
 
-	long long *values = (long long *) calloc(eventCount, sizeof (long long));
+    long long *values = (long long *) calloc(eventCount, sizeof (long long));
     if (values == NULL) {
         test_fail(__FILE__, __LINE__, "Failed to allocate memory for values.\n", 0);
     }
-	int *events = (int *) calloc(eventCount, sizeof (int));
+
+    int *events = (int *) calloc(eventCount, sizeof (int));
     if (events == NULL) {
         test_fail(__FILE__, __LINE__, "Failed to allocate memory for events.\n", 0);
     }
-	/* convert PAPI native events to PAPI code */
-	for( i = 0; i < eventCount; i++ ){
-        papi_errno = PAPI_event_name_to_code( argv[i+1], &events[i] );
-		if( papi_errno != PAPI_OK ) {
-			fprintf(stderr, "Check event name: %s", argv[i+1] );
-			test_skip(__FILE__, __LINE__, "", 0);
-		}
-        PRINT( quiet, "Name %s --- Code: %#x\n", argv[i+1], events[i] );
-	}
 
     if (STEP_BY_STEP_DEBUG) {
         cuCtxGetCurrent(&getCtx);
         fprintf(stderr, "%s:%s:%i before PAPI_create_eventset() getCtx=%p.\n", __FILE__, __func__, __LINE__, getCtx);
     }
 
-	papi_errno = PAPI_create_eventset( &EventSet );
-	if( papi_errno != PAPI_OK ) {
-		test_fail(__FILE__,__LINE__,"Cannot create eventset",papi_errno);
-	}
+    papi_errno = PAPI_create_eventset( &EventSet );
+    if( papi_errno != PAPI_OK ) {
+        test_fail(__FILE__,__LINE__,"Cannot create eventset",papi_errno);
+    }
 
     if (STEP_BY_STEP_DEBUG) {
         cuCtxGetCurrent(&getCtx);
-        fprintf(stderr, "%s:%s:%i before PAPI_add_events(), getCtx=%p.\n", __FILE__, __func__, __LINE__, getCtx);
+        fprintf(stderr, "%s:%s:%i after PAPI_create_eventset() getCtx=%p.\n", __FILE__, __func__, __LINE__, getCtx);
     }
 
     // If multiple GPUs/contexts were being used, you'd need to
@@ -127,7 +174,7 @@ int main(int argc, char** argv)
     // Context Create. We will use this one to run our kernel.
     cuError = cuCtxCreate(&sessionCtx, 0, 0); // Create a context, NULL flags, Device 0.
     if (cuError != CUDA_SUCCESS) {
-        fprintf(stderr, "Failed to create cuContext.\n");
+        fprintf(stderr, "Failed to create cuContext: %d\n", cuError);
         exit(-1);
     }
 
@@ -136,24 +183,39 @@ int main(int argc, char** argv)
         fprintf(stderr, "%s:%s:%i after cuCtxCreate(&sessionCtx), about to PAPI_start(), sessionCtx=%p, getCtx=%p.\n", __FILE__, __func__, __LINE__, sessionCtx, getCtx);
     }
 
-    papi_errno = PAPI_add_events( EventSet, events, eventCount );
-    if (papi_errno == PAPI_ENOEVNT) {
-        fprintf(stderr, "Event name does not exist for component.");
+    // Handle the events from the command line
+    int numEventsSuccessfullyAdded = 0, numMultipassEvents = 0;
+    char **eventsSuccessfullyAdded, **metricNames = argv + 1;
+    eventsSuccessfullyAdded = (char **) malloc(eventCount * sizeof(char *));
+    if (eventsSuccessfullyAdded == NULL) {
+        fprintf(stderr, "Failed to allocate memory for successfully added events.\n");
         test_skip(__FILE__, __LINE__, "", 0);
     }
-	if( papi_errno != PAPI_OK ) {
-		test_fail(__FILE__, __LINE__, "PAPI_add_events failed", papi_errno);
-	}
+    for (i = 0; i < eventCount; i++) {
+        eventsSuccessfullyAdded[i] = (char *) malloc(PAPI_MAX_STR_LEN * sizeof(char));
+        if (eventsSuccessfullyAdded[i] == NULL) {
+            fprintf(stderr, "Failed to allocate memory for command line argument.\n");
+            test_skip(__FILE__, __LINE__, "", 0);
+        }
+    }
+
+    add_events_from_command_line(EventSet, eventCount, metricNames, &numEventsSuccessfullyAdded, eventsSuccessfullyAdded, &numMultipassEvents);
+
+    // Only multiple pass events were provided on the command line
+    if (numEventsSuccessfullyAdded == 0) {
+        fprintf(stderr, "Events provided on the command line could not be added to an EventSet as they require multiple passes.\n");
+        test_skip(__FILE__, __LINE__, "", 0);
+    }
 
     if (STEP_BY_STEP_DEBUG) {
         cuCtxGetCurrent(&getCtx);
         fprintf(stderr, "%s:%s:%i before PAPI_start(), getCtx=%p.\n", __FILE__, __func__, __LINE__, getCtx);
     }
 
-	papi_errno = PAPI_start( EventSet );
-	if( papi_errno != PAPI_OK ) {
+    papi_errno = PAPI_start( EventSet );
+    if( papi_errno != PAPI_OK ) {
         test_fail(__FILE__, __LINE__, "PAPI_start failed.", papi_errno);
-	}
+    }
 
     if (STEP_BY_STEP_DEBUG) {
         cuCtxGetCurrent(&getCtx);
@@ -162,43 +224,43 @@ int main(int argc, char** argv)
 
 #endif
 
-	int j;
+    int j;
 
-	// desired output
-	char str[] = "Hello World!";
+    // desired output
+    char str[] = "Hello World!";
 
-	// mangle contents of output
-	// the null character is left intact for simplicity
-	for(j = 0; j < 12; j++) {
-		str[j] -= j;
-	}
+    // mangle contents of output
+    // the null character is left intact for simplicity
+    for(j = 0; j < 12; j++) {
+        str[j] -= j;
+    }
 
     PRINT(quiet, "mangled str=%s\n", str);
 
-	// allocate memory on the device
-	char *d_str;
-	size_t size = sizeof(str);
-	cudaMalloc((void**)&d_str, size);
+    // allocate memory on the device
+    char *d_str;
+    size_t size = sizeof(str);
+    cudaMalloc((void**)&d_str, size);
 
     if (STEP_BY_STEP_DEBUG) {
         cuCtxGetCurrent(&getCtx);
         fprintf(stderr, "%s:%s:%i after cudaMalloc() getCtx=%p.\n", __FILE__, __func__, __LINE__, getCtx);
     }
 
-	// copy the string to the device
-	cudaMemcpy(d_str, str, size, cudaMemcpyHostToDevice);
+    // copy the string to the device
+    cudaMemcpy(d_str, str, size, cudaMemcpyHostToDevice);
 
     if (STEP_BY_STEP_DEBUG) {
         cuCtxGetCurrent(&getCtx);
         fprintf(stderr, "%s:%s:%i after cudaMemcpy(ToDevice) getCtx=%p.\n", __FILE__, __func__, __LINE__, getCtx);
     }
 
-	// set the grid and block sizes
-	dim3 dimGrid(2); // one block per word
-	dim3 dimBlock(6); // one thread per character
+    // set the grid and block sizes
+    dim3 dimGrid(2); // one block per word
+    dim3 dimBlock(6); // one thread per character
 
-	// invoke the kernel
-	helloWorld<<< dimGrid, dimBlock >>>(d_str);
+    // invoke the kernel
+    helloWorld<<< dimGrid, dimBlock >>>(d_str);
 
     cudaError = cudaGetLastError();
     if (STEP_BY_STEP_DEBUG) {
@@ -210,16 +272,16 @@ int main(int argc, char** argv)
         fprintf(stderr, "%s:%s:%i After Kernel Execution: getCtx=%p.\n", __FILE__, __func__, __LINE__, getCtx);
     }
 
-	// retrieve the results from the device
-	cudaMemcpy(str, d_str, size, cudaMemcpyDeviceToHost);
+    // retrieve the results from the device
+    cudaMemcpy(str, d_str, size, cudaMemcpyDeviceToHost);
 
     if (STEP_BY_STEP_DEBUG) {
         cuCtxGetCurrent(&getCtx);
         fprintf(stderr, "%s:%s:%i after cudaMemcpy(ToHost) getCtx=%p.\n", __FILE__, __func__, __LINE__, getCtx);
     }
 
-	// free up the allocated memory on the device
-	cudaFree(d_str);
+    // free up the allocated memory on the device
+    cudaFree(d_str);
 
     if (STEP_BY_STEP_DEBUG) {
         cuCtxGetCurrent(&getCtx);
@@ -228,22 +290,23 @@ int main(int argc, char** argv)
 
 
 #ifdef PAPI
-	papi_errno = PAPI_read( EventSet, values );
-	if( papi_errno != PAPI_OK ) {
-		test_fail(__FILE__, __LINE__, "PAPI_read failed", papi_errno);
-	}
+    papi_errno = PAPI_read( EventSet, values );
+    if( papi_errno != PAPI_OK ) {
+        test_fail(__FILE__, __LINE__, "PAPI_read failed", papi_errno);
+    }
 
     if (STEP_BY_STEP_DEBUG) {
         cuCtxGetCurrent(&getCtx);
         fprintf(stderr, "%s:%s:%i after PAPI_read getCtx=%p.\n", __FILE__, __func__, __LINE__, getCtx);
     }
 
-	for( i = 0; i < eventCount; i++ )
-		PRINT( quiet, "read: %12lld \t=0X%016llX \t\t --> %s \n", values[i], values[i], argv[i+1] );
+    for( i = 0; i < numEventsSuccessfullyAdded; i++ ) {
+        PRINT( quiet, "read: %12lld \t=0X%016llX \t\t --> %s \n", values[i], values[i], eventsSuccessfullyAdded[i] );
+    }
 
     papi_errno = cuCtxPopCurrent(&getCtx);
-	if( papi_errno != CUDA_SUCCESS) {
-		fprintf( stderr, "cuCtxPopCurrent failed, papi_errno=%d (%s)\n", papi_errno, PAPI_strerror(papi_errno) );
+    if( papi_errno != CUDA_SUCCESS) {
+        fprintf( stderr, "cuCtxPopCurrent failed, papi_errno=%d (%s)\n", papi_errno, PAPI_strerror(papi_errno) );
         exit(1);
     }
 
@@ -252,9 +315,9 @@ int main(int argc, char** argv)
         fprintf(stderr, "%s:%s:%i after cuCtxPopCurrent() getCtx=%p.\n", __FILE__, __func__, __LINE__, getCtx);
     }
 
-	papi_errno = PAPI_stop( EventSet, values );
-	if( papi_errno != PAPI_OK ) {
-		test_fail(__FILE__, __LINE__, "PAPI_stop failed", papi_errno);
+    papi_errno = PAPI_stop( EventSet, values );
+    if( papi_errno != PAPI_OK ) {
+        test_fail(__FILE__, __LINE__, "PAPI_stop failed", papi_errno);
     }
 
     if (STEP_BY_STEP_DEBUG) {
@@ -262,9 +325,9 @@ int main(int argc, char** argv)
         fprintf(stderr, "%s:%s:%i after PAPI_stop getCtx=%p.\n", __FILE__, __func__, __LINE__, getCtx);
     }
 
-	papi_errno = PAPI_cleanup_eventset(EventSet);
-	if( papi_errno != PAPI_OK ) {
-		test_fail(__FILE__, __LINE__, "PAPI_cleanup_eventset failed", papi_errno);
+    papi_errno = PAPI_cleanup_eventset(EventSet);
+    if( papi_errno != PAPI_OK ) {
+        test_fail(__FILE__, __LINE__, "PAPI_cleanup_eventset failed", papi_errno);
     }
 
     if (STEP_BY_STEP_DEBUG) {
@@ -272,9 +335,9 @@ int main(int argc, char** argv)
         fprintf(stderr, "%s:%s:%i after PAPI_cleanup_eventset getCtx=%p.\n", __FILE__, __func__, __LINE__, getCtx);
     }
 
-	papi_errno = PAPI_destroy_eventset(&EventSet);
-	if (papi_errno != PAPI_OK) {
-		test_fail(__FILE__, __LINE__, "PAPI_destroy_eventset failed", papi_errno);
+    papi_errno = PAPI_destroy_eventset(&EventSet);
+    if (papi_errno != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_destroy_eventset failed", papi_errno);
     }
 
     if (STEP_BY_STEP_DEBUG) {
@@ -282,9 +345,9 @@ int main(int argc, char** argv)
         fprintf(stderr, "%s:%s:%i after PAPI_destroy_eventset getCtx=%p.\n", __FILE__, __func__, __LINE__, getCtx);
     }
 
-
-	for( i = 0; i < eventCount; i++ )
-		PRINT( quiet, "stop: %12lld \t=0X%016llX \t\t --> %s \n", values[i], values[i], argv[i+1] );
+    for( i = 0; i < numEventsSuccessfullyAdded; i++ ) {
+        PRINT( quiet, "stop: %12lld \t=0X%016llX \t\t --> %s \n", values[i], values[i], eventsSuccessfullyAdded[i] );
+    }
 #endif
 
     if (STEP_BY_STEP_DEBUG) {
@@ -301,27 +364,28 @@ int main(int argc, char** argv)
         fprintf(stderr, "%s:%s:%i after cuCtxDestroy(%p) getCtx=%p.\n", __FILE__, __func__, __LINE__, sessionCtx, getCtx);
     }
 
+    // Free allocated memory
+    free(values);
+    free(events);
+    for (i = 0; i < eventCount; i++) {
+        free(eventsSuccessfullyAdded[i]);
+    }
+    free(eventsSuccessfullyAdded);
+
 #ifdef PAPI
-	PAPI_shutdown();
+    PAPI_shutdown();
 
     if (STEP_BY_STEP_DEBUG) {
         cuCtxGetCurrent(&getCtx);
         fprintf(stderr, "%s:%s:%i after PAPI_shutdown getCtx=%p.\n", __FILE__, __func__, __LINE__, getCtx);
     }
 
-	test_pass(__FILE__);
+    // Output a note that a multiple pass event was provided on the command line
+    if (numMultipassEvents > 0) {
+        PRINT(quiet, "\033[0;33mNOTE: From the events provided on the command line, an event or events requiring multiple passes was detected and not added to the EventSet. Check your events with utils/papi_native_avail.\n\033[0m");
+    }
+
+    test_pass(__FILE__);
 #endif
-	return 0;
+    return 0;
 }
-
-
-// Device kernel
-__global__ void
-helloWorld(char* str)
-{
-	// determine where in the thread grid we are
-	int idx = blockIdx.x * blockDim.x + threadIdx.x;
-	// unmangle output
-	str[idx] += idx;
-}
-

--- a/src/components/cuda/tests/HelloWorld_noCuCtx.cu
+++ b/src/components/cuda/tests/HelloWorld_noCuCtx.cu
@@ -49,163 +49,226 @@
 #define STEP_BY_STEP_DEBUG 0 /* helps debug CUcontext issues. */
 #define PRINT(quiet, format, args...) {if (!quiet) {fprintf(stderr, format, ## args);}}
 
-// Prototypes
-__global__ void helloWorld(char*);
+// Device kernel
+__global__ void
+helloWorld(char* str)
+{
+        // determine where in the thread grid we are
+        int idx = blockIdx.x * blockDim.x + threadIdx.x;
+        // unmangle output
+        str[idx] += idx;
+}
 
+/** @class add_events_from_command_line
+  * @brief Try and add each event provided on the command line by the user.
+  *
+  * @param EventSet
+  *   A PAPI eventset.
+  * @param totalEventCount
+  *   Number of events from the command line.
+  * @param eventNamesFromCommandLine
+  *   Events provided on the command line.
+  * @param *numEventsSuccessfullyAdded
+  *   Total number of successfully added events.
+  * @param **eventsSuccessfullyAdded
+  *   Events that we are able to add to the EventSet.
+  * @param *numMultipassEvents
+  *   Counter to see if a multiple pass event was provided on the command line.
+*/
+static void add_events_from_command_line(int EventSet, int totalEventCount, char **eventNamesFromCommandLine, int *numEventsSuccessfullyAdded, char **eventsSuccessfullyAdded, int *numMultipassEvents)
+{
+    int i;
+    for (i = 0; i < totalEventCount; i++) {
+        int papi_errno = PAPI_add_named_event(EventSet, eventNamesFromCommandLine[i]);
+        if (papi_errno != PAPI_OK) {
+            if (papi_errno != PAPI_EMULPASS) {
+                fprintf(stderr, "Unable to add event %s to the EventSet with error code %d.\n", eventNamesFromCommandLine[i], papi_errno);
+                test_skip(__FILE__, __LINE__, "", 0);
+            }
+
+            // Handle multiple pass events
+            (*numMultipassEvents)++;
+            continue;
+        }
+
+        // Handle successfully added events
+        int strLen = snprintf(eventsSuccessfullyAdded[(*numEventsSuccessfullyAdded)], PAPI_MAX_STR_LEN, "%s", eventNamesFromCommandLine[i]);
+        if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+            fprintf(stderr, "Failed to fully write successfully added event.\n");
+            test_skip(__FILE__, __LINE__, "", 0);
+        }
+        (*numEventsSuccessfullyAdded)++;
+    }
+
+    return;
+}
 
 // Host function
 int main(int argc, char** argv)
 {
-	int quiet = 0;
+    int quiet = 0;
     cudaError_t cudaError;
     CUresult cuError; (void) cuError;
 
+    cuInit(0);
+
 #ifdef PAPI
-	char *test_quiet = getenv("PAPI_CUDA_TEST_QUIET");
+    char *test_quiet = getenv("PAPI_CUDA_TEST_QUIET");
     if (test_quiet)
         quiet = (int) strtol(test_quiet, (char**) NULL, 10);
 
-	/* PAPI Initialization */
-	int papi_errno = PAPI_library_init( PAPI_VER_CURRENT );
-	if( papi_errno != PAPI_VER_CURRENT ) {
-		test_fail(__FILE__,__LINE__, "PAPI_library_init failed", 0);
-	}
-
-	printf( "PAPI_VERSION     : %4d %6d %7d\n",
-		PAPI_VERSION_MAJOR( PAPI_VERSION ),
-		PAPI_VERSION_MINOR( PAPI_VERSION ),
-		PAPI_VERSION_REVISION( PAPI_VERSION ) );
-
-	int i;
-	int EventSet = PAPI_NULL;
-	int eventCount = argc - 1;
-
-	/* if no events passed at command line, just report test skipped. */
-	if (eventCount == 0) {
-		fprintf(stderr, "No events specified at command line.");
-		test_skip(__FILE__,__LINE__, "", 0);
-	}
-
-	long long *values = (long long *) calloc(eventCount, sizeof (long long));
-    if (values == NULL) {
-        test_fail(__FILE__, __LINE__, "Failed to allocate memory for values.\n", 0);
+    /* PAPI Initialization */
+    int papi_errno = PAPI_library_init( PAPI_VER_CURRENT );
+    if( papi_errno != PAPI_VER_CURRENT ) {
+        test_fail(__FILE__,__LINE__, "PAPI_library_init failed", 0);
     }
-	int *events = (int *) calloc(eventCount, sizeof (int));
+
+    printf( "PAPI_VERSION     : %4d %6d %7d\n",
+        PAPI_VERSION_MAJOR( PAPI_VERSION ),
+        PAPI_VERSION_MINOR( PAPI_VERSION ),
+        PAPI_VERSION_REVISION( PAPI_VERSION ) );
+
+    int i;
+    int EventSet = PAPI_NULL;
+    int eventCount = argc - 1;
+
+    /* if no events passed at command line, just report test skipped. */
+    if (eventCount == 0) {
+        fprintf(stderr, "No events specified at command line.");
+        test_skip(__FILE__,__LINE__, "", 0);
+    }
+
+    long long *values = (long long *) calloc(eventCount, sizeof (long long));
+    if (values == NULL) {
+       test_fail(__FILE__, __LINE__, "Failed to allocate memory for values.\n", 0);
+    }
+
+    int *events = (int *) calloc(eventCount, sizeof (int));
     if (events == NULL) {
         test_fail(__FILE__, __LINE__, "Failed to allocate memory for events.\n", 0);
     }
-	/* convert PAPI native events to PAPI code */
-	for( i = 0; i < eventCount; i++ ){
-		papi_errno = PAPI_event_name_to_code( argv[i+1], &events[i] );
-		if( papi_errno != PAPI_OK ) {
-			fprintf(stderr, "Check event name: %s", argv[i+1] );
-			test_skip(__FILE__, __LINE__, "", 0);
-		}
-		PRINT( quiet, "Name %s --- Code: %#x\n", argv[i+1], events[i] );
-	}
 
-	papi_errno = PAPI_create_eventset( &EventSet );
-	if( papi_errno != PAPI_OK ) {
-		test_fail(__FILE__,__LINE__,"Cannot create eventset",papi_errno);
-	}
+    papi_errno = PAPI_create_eventset( &EventSet );
+    if( papi_errno != PAPI_OK ) {
+        test_fail(__FILE__,__LINE__,"Cannot create eventset",papi_errno);
+    }
 
-    papi_errno = PAPI_add_events( EventSet, events, eventCount );
-    if (papi_errno == PAPI_ENOEVNT) {
-        fprintf(stderr, "Event name does not exist for component.");
+    // Handle the events from the command line
+    int numEventsSuccessfullyAdded = 0, numMultipassEvents = 0;
+    char **eventsSuccessfullyAdded, **metricNames = argv + 1;
+    eventsSuccessfullyAdded = (char **) malloc(eventCount * sizeof(char *));
+    if (eventsSuccessfullyAdded == NULL) {
+        fprintf(stderr, "Failed to allocate memory for successfully added events.\n");
         test_skip(__FILE__, __LINE__, "", 0);
     }
-	if( papi_errno != PAPI_OK ) {
-		test_fail(__FILE__, __LINE__, "PAPI_add_events failed", papi_errno);
-	}
+    for (i = 0; i < eventCount; i++) {
+        eventsSuccessfullyAdded[i] = (char *) malloc(PAPI_MAX_STR_LEN * sizeof(char));
+        if (eventsSuccessfullyAdded[i] == NULL) {
+            fprintf(stderr, "Failed to allocate memory for command line argument.\n");
+            test_skip(__FILE__, __LINE__, "", 0);
+        }
+    }
 
-	papi_errno = PAPI_start( EventSet );
-	if( papi_errno != PAPI_OK ) {
+    add_events_from_command_line(EventSet, eventCount, metricNames, &numEventsSuccessfullyAdded, eventsSuccessfullyAdded, &numMultipassEvents);
+
+    // Only multiple pass events were provided on the command line
+    if (numEventsSuccessfullyAdded == 0) {
+        fprintf(stderr, "Events provided on the command line could not be added to an EventSet as they require multiple passes.\n");
+        test_skip(__FILE__, __LINE__, "", 0);
+    }
+
+    papi_errno = PAPI_start( EventSet );
+    if( papi_errno != PAPI_OK ) {
         test_fail(__FILE__, __LINE__, "PAPI_start failed.", papi_errno);
-	}
+    }
 
 #endif
 
-	int j;
+    int j;
 
-	// desired output
-	char str[] = "Hello World!";
+    // desired output
+    char str[] = "Hello World!";
 
-	// mangle contents of output
-	// the null character is left intact for simplicity
-	for(j = 0; j < 12; j++) {
-		str[j] -= j;
-	}
+    // mangle contents of output
+    // the null character is left intact for simplicity
+    for(j = 0; j < 12; j++) {
+        str[j] -= j;
+    }
 
     PRINT( quiet, "mangled str=%s\n", str );
 
-	// allocate memory on the device
-	char *d_str;
-	size_t size = sizeof(str);
-	cudaMalloc((void**)&d_str, size);
+    // allocate memory on the device
+    char *d_str;
+    size_t size = sizeof(str);
+    cudaMalloc((void**)&d_str, size);
 
-	// copy the string to the device
-	cudaMemcpy(d_str, str, size, cudaMemcpyHostToDevice);
+    // copy the string to the device
+    cudaMemcpy(d_str, str, size, cudaMemcpyHostToDevice);
 
-	// set the grid and block sizes
-	dim3 dimGrid(2); // one block per word
-	dim3 dimBlock(6); // one thread per character
+    // set the grid and block sizes
+    dim3 dimGrid(2); // one block per word
+    dim3 dimBlock(6); // one thread per character
 
-	// invoke the kernel
-	helloWorld<<< dimGrid, dimBlock >>>(d_str);
+    // invoke the kernel
+    helloWorld<<< dimGrid, dimBlock >>>(d_str);
 
     cudaError = cudaGetLastError();
     if (STEP_BY_STEP_DEBUG) {
         fprintf(stderr, "%s:%s:%i Kernel Return Code: %s.\n", __FILE__, __func__, __LINE__, cudaGetErrorString(cudaError));
     }
 
-	// retrieve the results from the device
-	cudaMemcpy(str, d_str, size, cudaMemcpyDeviceToHost);
+    // retrieve the results from the device
+    cudaMemcpy(str, d_str, size, cudaMemcpyDeviceToHost);
 
-	// free up the allocated memory on the device
-	cudaFree(d_str);
+    // free up the allocated memory on the device
+    cudaFree(d_str);
 
 #ifdef PAPI
-	papi_errno = PAPI_read( EventSet, values );
-	if( papi_errno != PAPI_OK ) {
-		test_fail(__FILE__, __LINE__, "PAPI_read failed", papi_errno);
-	}
-
-	for( i = 0; i < eventCount; i++ )
-		PRINT( quiet, "read: %12lld \t=0X%016llX \t\t --> %s \n", values[i], values[i], argv[i+1] );
-
-	papi_errno = PAPI_stop( EventSet, values );
-	if( papi_errno != PAPI_OK ) {
-		test_fail(__FILE__, __LINE__, "PAPI_stop failed", papi_errno);
+    papi_errno = PAPI_read( EventSet, values );
+    if( papi_errno != PAPI_OK ) {
+        test_fail(__FILE__, __LINE__, "PAPI_read failed", papi_errno);
     }
 
-	papi_errno = PAPI_cleanup_eventset(EventSet);
-	if( papi_errno != PAPI_OK ) {
-		test_fail(__FILE__, __LINE__, "PAPI_cleanup_eventset failed", papi_errno);
+    for( i = 0; i < numEventsSuccessfullyAdded; i++ ) {
+        PRINT( quiet, "read: %12lld \t=0X%016llX \t\t --> %s \n", values[i], values[i], eventsSuccessfullyAdded[i] );
     }
 
-	papi_errno = PAPI_destroy_eventset(&EventSet);
-	if (papi_errno != PAPI_OK) {
-		test_fail(__FILE__, __LINE__, "PAPI_destroy_eventset failed", papi_errno);
+    papi_errno = PAPI_stop( EventSet, values );
+    if( papi_errno != PAPI_OK ) {
+        test_fail(__FILE__, __LINE__, "PAPI_stop failed", papi_errno);
     }
 
-	for( i = 0; i < eventCount; i++ )
-		PRINT( quiet, "stop: %12lld \t=0X%016llX \t\t --> %s \n", values[i], values[i], argv[i+1] );
+    papi_errno = PAPI_cleanup_eventset(EventSet);
+    if( papi_errno != PAPI_OK ) {
+        test_fail(__FILE__, __LINE__, "PAPI_cleanup_eventset failed", papi_errno);
+    }
 
-	PAPI_shutdown();
-	free(values);
-	free(events);
-	test_pass(__FILE__);
+    papi_errno = PAPI_destroy_eventset(&EventSet);
+    if (papi_errno != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_destroy_eventset failed", papi_errno);
+    }
+
+    for( i = 0; i < numEventsSuccessfullyAdded; i++ ) {
+        PRINT( quiet, "stop: %12lld \t=0X%016llX \t\t --> %s \n", values[i], values[i], eventsSuccessfullyAdded[i] );
+    }
+
+    // Free allocated memory
+    free(values);
+    free(events); 
+    for (i = 0; i < eventCount; i++) {
+        free(eventsSuccessfullyAdded[i]);
+    }
+    free(eventsSuccessfullyAdded);
+
+    PAPI_shutdown();
+
+    // Output a note that a multiple pass event was provided on the command line
+    if (numMultipassEvents > 0) {
+        PRINT(quiet, "\033[0;33mNOTE: From the events provided on the command line, an event or events requiring multiple passes was detected and not added to the EventSet. Check your events with utils/papi_native_avail.\n\033[0m");
+    }
+
+    test_pass(__FILE__);
 #endif
 
 	return 0;
-}
-
-// Device kernel
-__global__ void
-helloWorld(char* str)
-{
-	// determine where in the thread grid we are
-	int idx = blockIdx.x * blockDim.x + threadIdx.x;
-	// unmangle output
-	str[idx] += idx;
 }

--- a/src/components/cuda/tests/concurrent_profiling.cu
+++ b/src/components/cuda/tests/concurrent_profiling.cu
@@ -51,6 +51,9 @@ using ::std::thread;
 #include <vector>
 using ::std::vector;
 
+#include <algorithm>
+using ::std::find;
+
 #define PRINT(quiet, format, args...) {if (!quiet) {fprintf(stderr, format, ## args);}}
 int quiet;
 
@@ -140,6 +143,50 @@ vector<size_t> elements(numKernels);
 // For 4 calls, this is 4k elements * 2 arrays * (1 + 2 + 3 + 4 stream mul) * 8B/elem =~ 640KB
 int const blockSize = 4 * 1024;
 
+// Globals for successfully added and multiple pass events
+int numMultipassEvents = 0;
+vector<string> eventsSuccessfullyAdded;
+
+/** @class add_events_from_command_line
+  * @brief Try and add each event provided on the command line by the user.
+  *
+  * @param d
+  *   Per device data.
+  * @param EventSet
+  *   A PAPI eventset.
+  * @param metricNames
+  *   Events provided on the command line.
+  * @param successfullyAddedEvents
+  *   Events successfully added to the EventSet.
+  * @param *numMultipassEvents
+  *   Counter to see if a multiple pass event was provided on the command line.
+*/
+static void add_events_from_command_line(perDeviceData &d, int EventSet, vector<string> const &metricNames, vector<string> successfullyAddedEvents, int *numMultipassEvents)
+{
+    int i;
+    for (i = 0; i < metricNames.size(); i++) {
+        string evt_name = metricNames[i] + std::to_string(d.config.device);
+        int papi_errno = PAPI_add_named_event(EventSet, evt_name.c_str());
+        if (papi_errno != PAPI_OK) {
+            if (papi_errno != PAPI_EMULPASS) {
+                fprintf(stderr, "Unable to add event %s to the EventSet with error code %d.\n", evt_name.c_str(), papi_errno);
+                test_skip(__FILE__, __LINE__, "", 0);
+            }
+
+            // Handle multiple pass events
+            (*numMultipassEvents)++;
+            continue;
+        }
+
+        // Handle successfully added events
+        if (find(eventsSuccessfullyAdded.begin(), eventsSuccessfullyAdded.end(), metricNames[i]) == eventsSuccessfullyAdded.end()) {
+            eventsSuccessfullyAdded.push_back(metricNames[i]);
+        }
+    }
+
+    return;
+}
+
 // Wrapper which will launch numKernel kernel calls on a single device
 // The device streams vector is used to control which stream each call is made on
 // If 'serial' is non-zero, the device streams are ignored and instead the default stream is used
@@ -151,18 +198,17 @@ void profileKernels(perDeviceData &d,
     RUNTIME_API_CALL(cudaSetDevice(d.config.device));  // Orig code has mistake here
     DRIVER_API_CALL(cuCtxSetCurrent(d.config.context));
 #ifdef PAPI
-    int eventset = PAPI_NULL, i, papi_errno;
+    int eventset = PAPI_NULL;
     PAPI_CALL(PAPI_create_eventset(&eventset));
-    string evt_name;
-    for (i = 0; i < metricNames.size(); i++) {
-        evt_name = metricNames[i] + std::to_string(d.config.device);
-        PRINT(quiet, "Adding event name: %s\n", evt_name.c_str());
-        papi_errno = PAPI_add_named_event(eventset, evt_name.c_str());
-        if (papi_errno != PAPI_OK) {
-            fprintf(stderr, "Failed to add event %s\n", evt_name.c_str());
-            test_skip(__FILE__, __LINE__, "", 0);
-        }
+
+    add_events_from_command_line(d, eventset, metricNames, eventsSuccessfullyAdded, &numMultipassEvents);
+
+    // Only multiple pass events were provided on the command line
+    if (eventsSuccessfullyAdded.size() == 0) {
+        fprintf(stderr, "Events provided on the command line could not be added to an EventSet as they require multiple passes.\n");
+        test_skip(__FILE__, __LINE__, "", 0);
     }
+
     PAPI_CALL(PAPI_start(eventset));
 #endif
 
@@ -426,7 +472,7 @@ int main(int argc, char **argv)
     PRINT(quiet, "\nMetrics for device #0:\n");
     PRINT(quiet, "Look at the sm__cycles_elapsed.max values for each test.\n");
     PRINT(quiet, "This value represents the time spent on device to run the kernels in each case, and should be longest for the serial range, and roughly equal for the single and multi device concurrent ranges.\n");
-    print_measured_values(deviceData[0], metricNames);
+    print_measured_values(deviceData[0], eventsSuccessfullyAdded);
 
     // Only display next device info if needed
     if (numDevices > 1)
@@ -437,9 +483,16 @@ int main(int argc, char **argv)
     for (int i = 1; i < numDevices; i++)
     {
         PRINT(quiet, "\nMetrics for device #%d:\n", i);
-        print_measured_values(deviceData[i], metricNames);
+        print_measured_values(deviceData[i], eventsSuccessfullyAdded);
     }
+
     PAPI_shutdown();
+
+    // Output a note that a multiple pass event was provided on the command line
+    if (numMultipassEvents > 0) {
+        PRINT(quiet, "\033[0;33mNOTE: From the events provided on the command line, an event or events requiring multiple passes was detected and not added to the EventSet. Check your events with utils/papi_native_avail.\n\033[0m");
+    }
+
     test_pass(__FILE__);
 #endif
     return 0;

--- a/src/components/cuda/tests/cudaOpenMP.cu
+++ b/src/components/cuda/tests/cudaOpenMP.cu
@@ -75,6 +75,59 @@ do {                                                                           \
 
 #define MAX_THREADS (32)
 
+/** @class add_events_from_command_line
+  * @brief Try and add each event provided on the command line by the user.
+  *
+  * @param EventSet
+  *   A PAPI eventset.
+  * @param totalEventCount
+  *   Number of events from the command line.
+  * @param gpu_id
+  *   NVIDIA device index.
+  * @param **eventNamesFromCommandLine
+  *   Events provided on the command line.
+  * @param *numEventsSuccessfullyAdded
+  *   Total number of successfully added events.
+  * @param **eventsSuccessfullyAdded
+  *   Events that we are able to add to the EventSet.
+  * @param *numMultipassEvents
+  *   Counter to see if a multiple pass event was provided on the command line.
+*/
+static void add_events_from_command_line(int EventSet, int totalEventCount, int gpu_id, char **eventNamesFromCommandLine, int *numEventsSuccessfullyAdded, char **eventsSuccessfullyAdded, int *numMultipassEvents)
+{
+    int i;
+    for (i = 0; i < totalEventCount; i++) {
+        char tmpEventName[PAPI_MAX_STR_LEN];
+        int strLen = snprintf(tmpEventName, PAPI_MAX_STR_LEN, "%s:device=%d", eventNamesFromCommandLine[i], gpu_id);
+        if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+            fprintf(stderr, "Failed to fully write event name with appended device qualifier.\n");
+            test_skip(__FILE__, __LINE__, "", 0);
+        }
+
+        int papi_errno = PAPI_add_named_event(EventSet, tmpEventName);
+        if (papi_errno != PAPI_OK) {
+            if (papi_errno != PAPI_EMULPASS) {
+                fprintf(stderr, "Unable to add event %s to the EventSet with error code %d.\n", tmpEventName, papi_errno);
+                test_skip(__FILE__, __LINE__, "", 0);
+            }
+
+            // Handle multiple pass events
+            (*numMultipassEvents)++;
+            continue;
+        }
+
+        // Handle successfully added events
+        strLen = snprintf(eventsSuccessfullyAdded[(*numEventsSuccessfullyAdded)], PAPI_MAX_STR_LEN, "%s", tmpEventName);
+        if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+            fprintf(stderr, "Failed to fully write successfully added event.\n");
+            test_skip(__FILE__, __LINE__, "", 0);
+        }
+        (*numEventsSuccessfullyAdded)++;
+    }
+
+    return;
+}
+
 int main(int argc, char *argv[])
 {
     quiet = 0;
@@ -135,6 +188,7 @@ int main(int argc, char *argv[])
 
     PRINT(quiet, "Launching %d threads.\n", num_threads);
     omp_set_num_threads(num_threads);  // create as many CPU threads as there are CUDA devices
+    int numMultipassEvents = 0;
 #pragma omp parallel
     {
         unsigned int cpu_thread_id = omp_get_thread_num();
@@ -149,16 +203,30 @@ int main(int argc, char *argv[])
         int j, errno;
         PAPI_CALL(PAPI_create_eventset(&EventSet));
         PRINT(quiet, "CPU thread %d (of %d) uses CUDA device %d with context %p @ eventset %d\n", cpu_thread_id, num_cpu_threads, gpu_id, ctx_arr[cpu_thread_id], EventSet);
-        char tmpEventName[64];
-        for (j = 0; j < event_count; j++) {
-            snprintf(tmpEventName, 64, "%s:device=%d", argv[j+1], gpu_id);
-            PRINT(quiet, "Adding event name %s\n", tmpEventName);
-            errno = PAPI_add_named_event( EventSet, tmpEventName );
-            if (errno != PAPI_OK) {
-                fprintf(stderr, "Error adding event %s\n", tmpEventName);
+
+        int numEventsSuccessfullyAdded = 0;
+        char **eventsSuccessfullyAdded, **metricNames = argv + 1;
+        eventsSuccessfullyAdded = (char **) malloc(event_count * sizeof(char *));
+        if (eventsSuccessfullyAdded == NULL) {
+            fprintf(stderr, "Failed to allocate memory for successfully added events.\n");
+            test_skip(__FILE__, __LINE__, "", 0);
+        }
+        for (i = 0; i < event_count; i++) {
+            eventsSuccessfullyAdded[i] = (char *) malloc(PAPI_MAX_STR_LEN * sizeof(char));
+            if (eventsSuccessfullyAdded[i] == NULL) {
+                fprintf(stderr, "Failed to allocate memory for command line argument.\n");
                 test_skip(__FILE__, __LINE__, "", 0);
             }
         }
+
+        add_events_from_command_line(EventSet, event_count, gpu_id, metricNames, &numEventsSuccessfullyAdded, eventsSuccessfullyAdded, &numMultipassEvents);
+
+        // Only multiple pass events were provided on the command line
+        if (numEventsSuccessfullyAdded == 0) {
+            fprintf(stderr, "Events provided on the command line could not be added to an EventSet as they require multiple passes.\n");
+            test_skip(__FILE__, __LINE__, "", 0);
+        }
+
         PAPI_CALL(PAPI_start(EventSet));
 #endif
         VectorAddSubtract(50000*(cpu_thread_id+1), quiet);  // gpu work
@@ -166,10 +234,16 @@ int main(int argc, char *argv[])
         PAPI_CALL(PAPI_stop(EventSet, values));
 
         PRINT(quiet, "User measured values.\n");
-        for (j = 0; j < event_count; j++) {
-            snprintf(tmpEventName, 64, "%s:device=%d", argv[j+1], gpu_id);
-            PRINT(quiet, "%s\t\t%lld\n", tmpEventName, values[j]);
+        for (j = 0; j < numEventsSuccessfullyAdded; j++) {
+            PRINT(quiet, "%s\t\t%lld\n", eventsSuccessfullyAdded[j], values[j]);
         }
+
+        // Free allocated memory
+        for (i = 0; i < event_count; i++) {
+            free(eventsSuccessfullyAdded[i]);
+        }
+        free(eventsSuccessfullyAdded);
+
         DRIVER_API_CALL(cuCtxPopCurrent(&(ctx_arr[gpu_id])));
 
         errno = PAPI_cleanup_eventset(EventSet);
@@ -191,6 +265,12 @@ int main(int argc, char *argv[])
     omp_destroy_lock(&lock);
 #ifdef PAPI
     PAPI_shutdown();
+
+    // Output a note that a multiple pass event was provided on the command line
+    if (numMultipassEvents > 0) {
+        PRINT(quiet, "\033[0;33mNOTE: From the events provided on the command line, an event or events requiring multiple passes was detected and not added to the EventSet. Check your events with utils/papi_native_avail.\n\033[0m");
+    }
+
     test_pass(__FILE__);
 #endif
     return 0;

--- a/src/components/cuda/tests/pthreads_noCuCtx.cu
+++ b/src/components/cuda/tests/pthreads_noCuCtx.cu
@@ -53,9 +53,67 @@ int numGPUs;
 int g_event_count;
 char **g_evt_names;
 
+static volatile int global_thread_count = 0;
+pthread_mutex_t global_mutex;
 pthread_t tidarr[MAX_THREADS];
 CUcontext cuCtx[MAX_THREADS];
 pthread_mutex_t lock;
+
+// Globals for multiple pass events
+int numMultipassEvents = 0;
+
+/** @class add_events_from_command_line
+  * @brief Try and add each event provided on the command line by the user.
+  *
+  * @param EventSet
+  *   A PAPI eventset.
+  * @param totalEventCount
+  *   Number of events from the command line.
+  * @param **eventNamesFromCommandLine
+  *   Events provided on the command line.
+  * @param gpu_id
+  *   NVIDIA device index.
+  * @param *numEventsSuccessfullyAdded
+  *   Total number of successfully added events.
+  * @param **eventsSuccessfullyAdded
+  *   Events that we are able to add to the EventSet.
+  * @param *numMultipassEvents
+  *   Counter to see if a multiple pass event was provided on the command line.
+*/
+static void add_events_from_command_line(int EventSet, int totalEventCount, char **eventNamesFromCommandLine, int gpu_id, int *numEventsSuccessfullyAdded, char **eventsSuccessfullyAdded, int *numMultipassEvents)
+{
+    int i;
+    for (i = 0; i < totalEventCount; i++) {
+        char tmpEventName[PAPI_MAX_STR_LEN];
+        int strLen = snprintf(tmpEventName, PAPI_MAX_STR_LEN, "%s:device=%d", eventNamesFromCommandLine[i], gpu_id);
+        if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+            fprintf(stderr, "Failed to fully write event name with appended device qualifier.\n");
+            test_skip(__FILE__, __LINE__, "", 0);
+        }
+
+        int papi_errno = PAPI_add_named_event(EventSet, tmpEventName);
+        if (papi_errno != PAPI_OK) {
+            if (papi_errno != PAPI_EMULPASS) {
+                fprintf(stderr, "Unable to add event %s to the EventSet with error code %d.\n", tmpEventName, papi_errno);
+                test_skip(__FILE__, __LINE__, "", 0);
+            }
+
+            // Handle multiple pass events
+            (*numMultipassEvents)++;
+            continue;
+        }
+
+        // Handle successfully added events
+        strLen = snprintf(eventsSuccessfullyAdded[(*numEventsSuccessfullyAdded)], PAPI_MAX_STR_LEN, "%s", tmpEventName);
+        if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+            fprintf(stderr, "Failed to fully write successfully added event.\n");
+            test_skip(__FILE__, __LINE__, "", 0);
+        }
+        (*numEventsSuccessfullyAdded)++;
+    }
+
+    return;
+}
 
 void *thread_gpu(void * idx)
 {
@@ -64,7 +122,7 @@ void *thread_gpu(void * idx)
 
 #ifdef PAPI
     int gpuid = tid % numGPUs;
-    int papi_errno, i;
+    int i;
     int EventSet = PAPI_NULL;
     long long values[MAX_THREADS];
     PAPI_CALL(PAPI_create_eventset(&EventSet));
@@ -73,15 +131,35 @@ void *thread_gpu(void * idx)
     PRINT(quiet, "This is idx %d thread %lu - using GPU %d\n",
             tid, gettid, gpuid);
 
-    char tmpEventName[64];
+    int numEventsSuccessfullyAdded = 0;
+    char **eventsSuccessfullyAdded;
+    eventsSuccessfullyAdded = (char **) malloc(g_event_count * sizeof(char *));
+    if (eventsSuccessfullyAdded == NULL) {
+        fprintf(stderr, "Failed to allocate memory for successfully added events.\n");
+        test_skip(__FILE__, __LINE__, "", 0);
+    }
     for (i = 0; i < g_event_count; i++) {
-        snprintf(tmpEventName, 64, "%s:device=%d", g_evt_names[i], gpuid);
-        papi_errno = PAPI_add_named_event(EventSet, tmpEventName);
-        if (papi_errno != PAPI_OK) {
-            fprintf(stderr, "Failed to add event %s\n", tmpEventName);
+        eventsSuccessfullyAdded[i] = (char *) malloc(PAPI_MAX_STR_LEN * sizeof(char));
+        if (eventsSuccessfullyAdded[i] == NULL) {
+            fprintf(stderr, "Failed to allocate memory for command line argument.\n");
             test_skip(__FILE__, __LINE__, "", 0);
         }
     }
+
+    pthread_mutex_lock(&global_mutex);
+
+    add_events_from_command_line(EventSet, g_event_count, g_evt_names, gpuid, &numEventsSuccessfullyAdded, eventsSuccessfullyAdded, &numMultipassEvents);
+
+    // Only multiple pass events were provided on the command line
+    if (numEventsSuccessfullyAdded == 0) {
+        fprintf(stderr, "Events provided on the command line could not be added to an EventSet as they require multiple passes.\n");
+        test_skip(__FILE__, __LINE__, "", 0);
+    }
+
+    ++global_thread_count;
+    pthread_mutex_unlock(&global_mutex);
+
+    while(global_thread_count < numGPUs);
 
     PAPI_CALL(PAPI_start(EventSet));
 #endif
@@ -92,10 +170,15 @@ void *thread_gpu(void * idx)
     PAPI_CALL(PAPI_stop(EventSet, values));
 
     PRINT(quiet, "User measured values in thread id %d.\n", tid);
-    for (i = 0; i < g_event_count; i++) {
-        snprintf(tmpEventName, 64, "%s:device=%d", g_evt_names[i], gpuid);
-        PRINT(quiet, "%s\t\t%lld\n", tmpEventName, values[i]);
+    for (i = 0; i < numEventsSuccessfullyAdded; i++) {
+        PRINT(quiet, "%s\t\t%lld\n", eventsSuccessfullyAdded[i], values[i]);
     }
+
+    // Free allocated memory
+    for (i = 0; i < g_event_count; i++) {
+        free(eventsSuccessfullyAdded[i]);
+    }
+    free(eventsSuccessfullyAdded);
 
     PAPI_CALL(PAPI_cleanup_eventset(EventSet));
     PAPI_CALL(PAPI_destroy_eventset(&EventSet));
@@ -136,6 +219,7 @@ int main(int argc, char **argv)
     PRINT(quiet, "No. of threads to launch = %d\n", numGPUs);
 
 #ifdef PAPI
+    pthread_mutex_init(&global_mutex, NULL);
     int papi_errno = PAPI_library_init( PAPI_VER_CURRENT );
     if( papi_errno != PAPI_VER_CURRENT ) {
         test_fail(__FILE__, __LINE__, "PAPI_library_init failed.", 0);
@@ -169,7 +253,14 @@ int main(int argc, char **argv)
 
 #ifdef PAPI
     PAPI_shutdown();
+
     PRINT(quiet, "Main thread exit!\n");
+
+    // Output a note that a multiple pass event was provided on the command line
+    if (numMultipassEvents > 0) {
+        PRINT(quiet, "\033[0;33mNOTE: From the events provided on the command line, an event or events requiring multiple passes was detected and not added to the EventSet. Check your events with utils/papi_native_avail.\n\033[0m");
+    }
+
     test_pass(__FILE__);
 #endif
     return 0;

--- a/src/components/cuda/tests/runtest.sh
+++ b/src/components/cuda/tests/runtest.sh
@@ -26,8 +26,8 @@ echo -e "Running: \e[36m./test_multi_read_and_reset\e[0m" "${evt_names[@]}"
 echo -e "-------------------------------------\n"
 
 make test_2thr_1gpu_not_allowed
-echo -e "Running: \e[36m./test_2thr_1gpu_not_allowed\e[0m" "${evt_names[@]}"
-./test_2thr_1gpu_not_allowed "${evt_names[@]}"
+echo -e "Running: \e[36m./test_2thr_1gpu_not_allowed\e[0m" "${evt_names[@]:0:2}"
+./test_2thr_1gpu_not_allowed "${evt_names[@]:0:2}"
 echo -e "-------------------------------------\n"
 
 make HelloWorld

--- a/src/components/cuda/tests/simpleMultiGPU_noCuCtx.cu
+++ b/src/components/cuda/tests/simpleMultiGPU_noCuCtx.cu
@@ -105,6 +105,59 @@ __global__ static void reduceKernel( float *d_Result, float *d_Input, int N )
     d_Result[tid] = sum;
 }
 
+/** @class add_events_from_command_line
+  * @brief Try and add each event provided on the command line by the user.
+  *
+  * @param EventSet
+  *   A PAPI eventset.
+  * @param totalEventCount
+  *   Number of events from the command line.
+  * @param **eventsFromCommandLine
+  *   Events provided on the command line.
+  * @param gpu_id
+  *   Current gpu id.
+  * @param *numEventsSuccessfullyAdded
+  *   Total number of successfully added events.
+  * @param **eventsSuccessfullyAdded
+  *   Events that we are able to add to the EventSet.
+  * @param *numMultipassEvents
+  *   Counter to see if a multiple pass event was provided on the command line.
+*/
+static void add_events_from_command_line(int EventSet, int totalEventCount, char **eventNamesFromCommandLine, int gpu_id, int *numEventsSuccessfullyAdded, char **eventsSuccessfullyAdded, int *numMultipassEvents)
+{
+    int i;
+    for (i = 0; i < totalEventCount; i++) {
+        char tmpEventName[PAPI_MAX_STR_LEN];
+        int strLen = snprintf(tmpEventName, PAPI_MAX_STR_LEN, "%s:device=%d", eventNamesFromCommandLine[i], gpu_id);
+        if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+            fprintf(stderr, "Failed to fully write event name with appended device qualifier.\n");
+            test_skip(__FILE__, __LINE__, "", 0);
+        }
+
+        int papi_errno = PAPI_add_named_event(EventSet, tmpEventName);
+        if (papi_errno != PAPI_OK) {
+            if (papi_errno != PAPI_EMULPASS) {
+                fprintf(stderr, "Unable to add event %s to the EventSet with error code %d.\n", tmpEventName, papi_errno);
+                test_skip(__FILE__, __LINE__, "", 0);
+            }
+
+            // Handle multiple pass events
+            (*numMultipassEvents)++;
+            continue;
+        }
+
+        // Handle successfully added events
+        strLen = snprintf(eventsSuccessfullyAdded[(*numEventsSuccessfullyAdded)], PAPI_MAX_STR_LEN, "%s", tmpEventName);
+        if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+            fprintf(stderr, "Failed to fully write successfully added event.\n");
+            test_skip(__FILE__, __LINE__, "", 0);
+        }
+        (*numEventsSuccessfullyAdded)++;
+    }
+
+    return;
+}
+
 // //////////////////////////////////////////////////////////////////////////////
 // Program main
 // //////////////////////////////////////////////////////////////////////////////
@@ -152,14 +205,14 @@ int main( int argc, char **argv )
     // Report on the available CUDA devices
     int computeCapabilityMajor = 0, computeCapabilityMinor = 0;
     int runtimeVersion = 0, driverVersion = 0;
-    char deviceName[64];
+    char deviceName[PAPI_MIN_STR_LEN];
     CUdevice device[MAX_GPU_COUNT];
     CHECK_CUDA_ERROR( cudaGetDeviceCount( &num_gpus ) );
     if( num_gpus > MAX_GPU_COUNT ) num_gpus = MAX_GPU_COUNT;
     PRINT( quiet, "CUDA-capable device count: %i\n", num_gpus );
     for ( i=0; i<num_gpus; i++ ) {
         CHECK_CU_ERROR( cuDeviceGet( &device[i], i ), "cuDeviceGet" );
-        CHECK_CU_ERROR( cuDeviceGetName( deviceName, 64, device[i] ), "cuDeviceGetName" );
+        CHECK_CU_ERROR( cuDeviceGetName( deviceName, PAPI_MIN_STR_LEN, device[i] ), "cuDeviceGetName" );
         CHECK_CU_ERROR( cuDeviceGetAttribute( &computeCapabilityMajor, 
             CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device[i]), "cuDeviceGetAttribute");
         CHECK_CU_ERROR( cuDeviceGetAttribute( &computeCapabilityMinor, 
@@ -212,8 +265,6 @@ int main( int argc, char **argv )
     int EventSet = PAPI_NULL;
     int NUM_EVENTS = MAX_GPU_COUNT*MAX_NUM_EVENTS;
     long long values[NUM_EVENTS];
-    int total_events;
-    int ee;
 
     int cid = PAPI_get_component_index("cuda");
     if (cid < 0) {
@@ -238,30 +289,34 @@ int main( int argc, char **argv )
     // Similar to legacy CUpti API, we must change the contexts to the appropriate device to
     // add events to inform PAPI of the context that will run the kernels.
 
-    char *EventName[NUM_EVENTS];
-    char tmpEventName[64];
-    total_events = 0;
-    for( i = 0; i < num_gpus; i++ ) {
-        for ( ee=0; ee < event_count; ee++ ) {
-            CHECK_CUDA_ERROR(cudaSetDevice(device[i]));
-            // Create a device specific event.
-            snprintf( tmpEventName, 64, "%s:device=%d", argv[ee+1], i );
-            papi_errno = PAPI_add_named_event( EventSet, tmpEventName );
-            if (papi_errno==PAPI_OK) {
-                PRINT( quiet, "Add event success: '%s' GPU %i\n", tmpEventName, i );
-                EventName[total_events] = (char *)calloc( 64, sizeof(char) );
-                if (EventName[total_events] == NULL) {
-                    test_fail(__FILE__, __LINE__, "Failed to allocate string.\n", 0);
-                }
-                snprintf( EventName[total_events], 64, "%s", tmpEventName );
-                total_events++;
-            } else {
-                fprintf( stderr, "Add event failure: '%s' GPU %i error=%s\n", tmpEventName, i, PAPI_strerror(papi_errno));
-                test_skip(__FILE__, __LINE__, "", 0);
-            }
+    // Handle the events from the command line
+    int numEventsSuccessfullyAdded = 0, numMultipassEvents = 0;
+    char **eventsSuccessfullyAdded, **metricNames = argv + 1;
+    eventsSuccessfullyAdded = (char **) malloc(NUM_EVENTS * sizeof(char *));
+    if (eventsSuccessfullyAdded == NULL) {
+        fprintf(stderr, "Failed to allocate memory for successfully added events.\n");
+        test_skip(__FILE__, __LINE__, "", 0);
+    }
+    for (i = 0; i < NUM_EVENTS; i++) {
+        eventsSuccessfullyAdded[i] = (char *) malloc(PAPI_MAX_STR_LEN * sizeof(char));
+        if (eventsSuccessfullyAdded[i] == NULL) {
+            fprintf(stderr, "Failed to allocate memory for command line argument.\n");
+            test_skip(__FILE__, __LINE__, "", 0);
         }
     }
 
+    int gpu_id;
+    for (gpu_id = 0; gpu_id < num_gpus; gpu_id++) {
+        CHECK_CUDA_ERROR(cudaSetDevice(device[gpu_id]));
+        add_events_from_command_line(EventSet, event_count, metricNames, gpu_id, &numEventsSuccessfullyAdded, eventsSuccessfullyAdded, &numMultipassEvents);
+    }
+
+    // Only multiple pass events were provided on the command line
+    if (numEventsSuccessfullyAdded == 0) {
+        fprintf(stderr, "Events provided on the command line could not be added to an EventSet as they require multiple passes.\n");
+        test_skip(__FILE__, __LINE__, "", 0);
+    }
+ 
     // Invoke PAPI_start().
     papi_errno = PAPI_start( EventSet );
     if( papi_errno != PAPI_OK ) {
@@ -313,8 +368,8 @@ int main( int argc, char **argv )
 
     papi_errno = PAPI_stop( EventSet, values );                                         // Stop (will read values).
     if( papi_errno != PAPI_OK )  fprintf( stderr, "PAPI_stop failed\n" );
-    for( i = 0; i < total_events; i++ )
-        PRINT( quiet, "PAPI counterValue %12lld \t\t --> %s \n", values[i], EventName[i] );
+    for( i = 0; i < numEventsSuccessfullyAdded; i++ )
+        PRINT( quiet, "PAPI counterValue %12lld \t\t --> %s \n", values[i], eventsSuccessfullyAdded[i] );
 
     papi_errno = PAPI_cleanup_eventset( EventSet );
     if( papi_errno != PAPI_OK )  fprintf( stderr, "PAPI_cleanup_eventset failed\n" );
@@ -360,7 +415,19 @@ int main( int argc, char **argv )
         // Shut down this GPU
         CHECK_CUDA_ERROR( cudaStreamDestroy( plan[i].stream ) );
     }
+
+    //Free allocated memory
+    for (i = 0; i < event_count; i++) {
+        free(eventsSuccessfullyAdded[i]);
+    }
+    free(eventsSuccessfullyAdded);
+
 #ifdef PAPI
+    // Output a note that a multiple pass event was provided on the command line
+    if (numMultipassEvents > 0) {
+        PRINT(quiet, "\033[0;33mNOTE: From the events provided on the command line, an event or events requiring multiple passes was detected and not added to the EventSet. Check your events with utils/papi_native_avail.\n\033[0m");
+    }
+
     if ( diff < 1e-5 )
         test_pass(__FILE__);
     else


### PR DESCRIPTION
## Pull Request Description
This PR updates the Cuda component tests to more gracefully handle multiple pass events if they are added on the command line. The current master branch behavior will see a test fail or skipped if a multiple pass event is provided. 

For the tests listed below:
 - `HelloWorld.cu`, `HelloWorld_noCuCtx.cu`, `simpleMultiGPU.cu`, `simpleMultiGPU_noCuCtx.cu`, `concurrent_profiling.cu`, `concurrent_profiling_noCuCtx.cu`, `pthreads.cu`, `pthreads_noCuCtx.cu`, `cudaOpenMP.cu`, `cudaOpenMP_noCuCtx.cu`, and `test_multi_read_and_reset.cu`

the updated behavior will see two scenarios, 

1. If you provide only multiple pass events we output the following message:
```
Events provided on the command line could not be added to an EventSet as they require multiple passes.
```
2. If you provide a multiple pass event with events that require a single pass we output the following message:
```
NOTE: From the events provided on the command line, an event or events requiring multiple passes was detected and not added to the EventSet. Check your events with papi_native_avail.
```

Two tests will not have the updated behvaior:

- `test_multipass_event_fail.cu` - As this test is designed to take a multiple pass event to make sure we correctly handle it internally. Note that, this test was updated in PR #348 to handle cases where a single pass event is provided.
- `test_2thr_1gpu_not_allowed.cu` - For this test to function properly, we need two single pass events. Therefore, if a multiple pass event is provided we will error, but give a more explicit error message now: 
```
"Event %s requires multiple passes and cannot be added to an EventSet. See papi_native_avail for more Cuda native events.
```
One last updated done for `test_2thr_1gpu_not_allowed.cu` is to check to make sure exactly 2 events have been provided on the command line. As from my testing, this is what is needed for the test to function properly. 

## Testing Changes

| Cuda Test | Cuda Toolkit Version Used| Devices on Machine | Testing Status |
| :-------------:| :-------------: | :-------------: | :-------------: |
| `HelloWorld.cu`  | 12.8 | 8 * A100s |  ✅   |
| `HelloWorld_noCuCtx.cu` | 12.8 | 8 * A100s |  ✅   |
| `simpleMultiGPU.cu` | 12.8 | 8 * A100s |  ✅   |
| `simpleMultiGPU_noCuCtx.cu` | 12.8 | 8 * A100s |  ✅   |
| `concurrent_profiling.cu` | 12.8 | 8 * A100s |  ✅  |
| `concurrent_profiling_noCuCtx.cu` | 12.8 | 8 * A100s |  ✅  |
| `pthreads.cu` | 12.8 | 8 * A100s | ✅ |
| `pthreads_noCuCtx.cu` | 12.8 | 8 * A100s |  ✅  |
| `cudaOpenMP.cu` | 12.8 | 8 * A100s | ✅  |
| `cudaOpenMP_noCuCtx.cu` | 12.8 | 8 * A100s | ✅ |
| `test_multi_read_and_reset.cu` | 12.8 | 8 * A100s | ✅ |
| `test_2thr_1gpu_not_allowed.cu` | 12.8 | 8 * A100s | ✅ |

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
