### PR TITLE
ROCm component: Bug fix for typo in rocm_verify_no_repeated_qualifiers

### DIFF
--- a/src/components/rocm/roc_profiler.c
+++ b/src/components/rocm/roc_profiler.c
@@ -834,7 +834,7 @@ rocm_verify_no_repeated_qualifiers(const char *eventName)
         if (strncmp(token, "device", 6) == 0) {
             numDeviceQualifiers++;
         }
-        else if (strncmp(token, "stat", 4) == 0){
+        else if (strncmp(token, "instance", 8) == 0){
             numStatsQualifiers++;
         }
 


### PR DESCRIPTION
## Pull Request Description
This PR fixes a typo in `rocm_verify_no_repeated_qualifiers`. In ROCm we should be checking for a `device` and `instance` qualifier. PR #362 introduced a typo that saw us checking for a `stat` qualifier instead of an `instance` qualifier. 

This PR resolves the typo and now correctly errors if more than two instance qualifiers are provided:
```
[ICL:histamine2 bin]$ ./papi_command_line rocm:::TCC_EA1_WRREQ:instance=0:device=0:instance=0

This utility lets you add events from the command line interface to see if they work.

Failed adding: rocm:::TCC_EA1_WRREQ:instance=0:device=0:instance=0
because: Event does not exist
No events specified!
Try running something like: ./papi_command_line PAPI_TOT_CYC
```

Tested this fix on a Vega 20 with ROCm 6.3.2.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
