### PR TITLE
Appio Component: Add a component description, as it is missing from `papi_component_avail`

### DIFF
--- a/src/components/appio/appio.c
+++ b/src/components/appio/appio.c
@@ -746,6 +746,7 @@ papi_vector_t _appio_vector = {
         .name                  = "appio",
         .short_name            = "appio",
         .version               = "1.1.2.4",
+        .description           = "Linux I/O system calls",
         .CmpIdx                = 0,              /* set by init_component */
         .num_mpx_cntrs         = APPIO_MAX_COUNTERS,
         .num_cntrs             = APPIO_MAX_COUNTERS,


### PR DESCRIPTION
## Pull Request Description
Currently if you run `./papi_component_avail` the `appio` component will not have a description shown:

```
Compiled-in components:
Name:   appio                   

Active components:
Name:   appio                   
                                Native: 45, Preset: 0, Counters: 45

--------------------------------------------------------------------------------
```

This PR addresses this by adding a description in the component vector of `appio`, now `./papi_component_avail` shows:
```
Compiled-in components:
Name:   appio                   Linux I/O system calls


Active components:
Name:   appio                   Linux I/O system calls
                                Native: 45, Preset: 0, Counters: 45

--------------------------------------------------------------------------------
```

Tested this change on a machine with an Intel Xeon Gold 6140.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
