### PR TITLE
Remove perfctr documentation and leftover code from PR #191

### DIFF
--- a/src/components/README
+++ b/src/components/README
@@ -64,8 +64,6 @@ mx                            Myricom MX (Myrinet Express) statistics.
 net                           Linux network driver statistics
 nvml                          Requires its own configure; monitors NVIDIA hardware (power, temp, fan speed, etc).
 pcp                           Performance Co-Pilot interface.
-perfctr                       OLD, only used for Linux before 2.6.31.
-perfctr_ppc                   OLD, only used for Linux before 2.6.31.
 perf_event                    Linux perf_event CPU counters
 perf_event_uncore             Linux perf-event CPU uncore and Northbridge
 perfmon2                      OLD, only used for Linux before 2.6.31.


### PR DESCRIPTION
## Pull Request Description
PR #191 removed the `perfctr` and `perfctr_ppc` components. This PR removes leftover documentation in the `components` README.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
