### PR TITLE
Sysdetect/Topdown/Infiniband/NVML Components: Resolves Cases Where `Error! PAPI_library_init` Occurs with `--with-debug=memory`

### DIFF
--- a/src/components/infiniband/linux-infiniband.c
+++ b/src/components/infiniband/linux-infiniband.c
@@ -983,7 +983,7 @@ papi_vector_t _infiniband_vector = {
         .context = sizeof (infiniband_context_t),
         .control_state = sizeof (infiniband_control_state_t),
         .reg_value = sizeof (infiniband_register_t),
-        /* .reg_alloc = sizeof (infiniband_reg_alloc_t), */
+        .reg_alloc = 1 /* unused */
     },
     /* function pointers in this component */
     .init_thread =          _infiniband_init_thread,

--- a/src/components/nvml/linux-nvml.c
+++ b/src/components/nvml/linux-nvml.c
@@ -1893,7 +1893,7 @@ papi_vector_t _nvml_vector = {
         .context = sizeof(nvml_context_t),
         .control_state = sizeof(nvml_control_state_t),
         .reg_value = sizeof(nvml_register_t),
-        // .reg_alloc = sizeof ( nvml_reg_alloc_t ),
+        .reg_alloc = 1, /* unused */
     },
 
     /* function pointers */

--- a/src/components/sysdetect/sysdetect.c
+++ b/src/components/sysdetect/sysdetect.c
@@ -475,6 +475,14 @@ papi_vector_t _sysdetect_vector = {
                  .kernel_version = "n/a",
                 },
 
+    /* Sizes of framework-opaque component-private structures */
+    .size = {
+        .context = 1, /* unused */
+        .control_state = 1, /* unused */
+        .reg_value = 1, /* unused */
+        .reg_alloc = 1, /* unused */
+    },
+
     /* Used for general PAPI interactions */
     .init_component = _sysdetect_init_component,
     .init_thread = _sysdetect_init_thread,

--- a/src/components/topdown/topdown.c
+++ b/src/components/topdown/topdown.c
@@ -909,6 +909,8 @@ papi_vector_t _topdown_vector = {
 	.size = {
 		.context = sizeof(_topdown_context_t),
 		.control_state = sizeof(_topdown_control_state_t),
+		.reg_value = 1, /* unused */
+		.reg_alloc = 1, /* unused */
 	},
 
 	/* Used for general PAPI interactions */

--- a/src/components/topdown/topdown.h
+++ b/src/components/topdown/topdown.h
@@ -74,7 +74,9 @@ typedef struct topdown_control_state
 #define TOPDOWN_METRIC_IDX_FETCH_LAT        6
 #define TOPDOWN_METRIC_IDX_MEM_BOUND        7
 
-/** Holds per thread information */
+/* Holds per thread information; however, we do not use this structure,
+   but the framework still needs its size */
 typedef struct topdown_context
 {
+    int junk;
 } _topdown_context_t;


### PR DESCRIPTION
## Pull Request Description
This PR resolves Issue #366. 

The following components saw updates to `.size` in their component vectors:
| Component  | Update done | Status of `papi_component_avail` and `papi_native_avail` after updates |
| ------------- | ------------- | ------------- |
| `sysdetect`  | Added `.size` with default values |   * `papi_component_avail` - ✅  <br> * `papi_native_avail` - ✅   |
| `topdown`  | Added a junk int to `_topdown_context_t` | * `papi_component_avail` - ✅  <br> * `papi_native_avail` - ✅  |
| `infiniband`  | Set `.reg_alloc` to have a value of 1  | * `papi_component_avail` - ✅  <br> * `papi_native_avail` - ✅  |
| `nvml`  | Set `.reg_alloc` to have a value of 1  | * `papi_component_avail` - ✅  <br> * `papi_native_avail` - ✅ |


## Testing
The following components were tested and did not have `Error PAPI_library_init` occur:
 - `perf_event` - Verified using an Intel Xeon Gold 6140 and an OS of Rocky Linux 9.4
 - `perf_event_uncore` - Verified using an Intel Xeon Gold 6140 and an OS of Rocky Linux 9.4
 - `appio` - Verified using an Intel Xeon Gold 6140 and an OS of Rocky Linux 9.4
 - `coretemp` - Verified using an Intel Xeon Gold 6140 and an OS of Rocky Linux 9.4
 - `cuda` - Verified using Cuda Toolkit 12.6.0 with one A100 and an OS of Rocky Linux 9.4
 - `example` - Verified using an Intel Xeon Gold 6140 and an OS of Rocky Linux 9.4
 - `infiniband` - Verified using an Intel Xeon Gold 6140 and an OS of Rocky Linux 9.4
 - `io` - Verified using an Intel Xeon Gold 6140 and an OS of Rocky Linux 9.4
 - `intel_gpu` - Verified using an Intel Arc 770 and an OS of Rocky Linux 9.4
 - `lmsensors` - Verified using an Intel Xeon Gold 6140 and an OS of Rocky Linux 9.4
 - `net` - Verified using an Intel Xeon Gold 6140 and an OS of Rocky Linux 9.4
 - `nvml` - Verified using Cuda Toolkit 12.6.0 with one A100 and an OS of Rocky Linux 9.4
 - `pcp` - Verified using Power 10 and an OS of Red Hat Enterprise Linux 8.10
 - `powercap` - Verified using an Intel Xeon Gold 6140 and an OS of Rocky Linux 9.4
 - `powercap_ppc` - Verified using Power 9 and an OS of Red Hat Enterprise Linux  7.6
 - `rapl` - Verified using an AMD Ryzen 9 and an OS of Rocky Linux 9.4
 - `rocm` - Verified using a Vega 20 with ROCm 6.3.2
 - `rocp_sdk` - Verified using a Vega 20 with ROCm 6.3.2
 - `rocm_smi` - Verified using a Vega 20 with ROCm 6.3.2
     - Note a segmentation fault occurs, but this will be resolved in PR #382
 - `sde` - Verified using an Intel Xeon Gold 6140 and an OS of Rocky Linux 9.4
 - `sensors_ppc` - Verified using Power 9 and an OS of Red Hat Enterprise Linux  7.6 
 - `stealtime` - Verified using an Intel Xeon Gold 6140 and an OS of Rocky Linux 9.4
 
The following components were unable to be tested, but I did check to verify that `.size` was set properly:
- `bgpm`
- `coretemp_freebsd`
- `emon`
- `host_micpower`
- `lustre`
- `micpower`
- `mx`
- `perfmon2`
- `perfmon_ia64`
- `perfnec`
- `vmware`
- `libmsr`


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
