### PR TITLE
Cuda component: Initialize count variable in function cuda_init_private

### DIFF
--- a/src/components/cuda/linux-cuda.c
+++ b/src/components/cuda/linux-cuda.c
@@ -213,7 +213,7 @@ static int cuda_init_private(void)
     }
 
     // Get the metric count found on a machine
-    int count;
+    int count = 0;
     papi_errno = cuda_get_evt_count(&count);
     if (papi_errno != PAPI_OK) {
         goto fn_fail;


### PR DESCRIPTION
## Pull Request Description
This PR initializes the `count` variable in the function`cuda_init_private` to be 0. Without `count` being initialized junk values will show when you run `./papi_component_avail` when configured with `--with-debug=memory`:

Note: My configure is as follows for tests shown below: `./configure --prefix=$PWD/test-install --with-sysdetect=no --with-components="cuda" --with-debug=memory`

```
Compiled-in components:
Name:   cuda                    CUDA profiling via NVIDIA CuPTI interfaces

Active components:
Name:   cuda                    CUDA profiling via NVIDIA CuPTI interfaces
                                Native: 94561, Preset: 6, Counters: 30

```

Setting `count=0`, will show the correct count (Tested on an H100 with Cuda Toolkit 12.6.3):
```
Compiled-in components:
Name:   cuda                    CUDA profiling via NVIDIA CuPTI interfaces

Active components:
Name:   cuda                    CUDA profiling via NVIDIA CuPTI interfaces
                                Native: 61794, Preset: 6, Counters: 30


--------------------------------------------------------------------------------
```

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
