### PR TITLE
utils/print_header.c: Move for loop counter declaration out of for loop header.

### DIFF
--- a/src/utils/print_header.c
+++ b/src/utils/print_header.c
@@ -75,8 +75,8 @@ papi_print_header( char *prompt, const PAPI_hw_info_t ** hwinfo )
 	mpx = PAPI_get_opt( PAPI_MAX_MPX_CTRS, NULL );
   
   int numcmp = PAPI_num_components(  );
-  int perf_event = 0;
-	for (int cid = 0; cid < numcmp; cid++ ) {
+  int perf_event = 0, cid;
+	for ( cid = 0; cid < numcmp; cid++ ) {
 	  const PAPI_component_info_t* cmpinfo = PAPI_get_component_info( cid );
 	  if (cmpinfo->disabled) continue;
     if (strcmp(cmpinfo->name, "perf_event")== 0) perf_event = 1;


### PR DESCRIPTION
## Pull Request Description
On a machine with a Power 9 using GCC version 4.8.5 if you run `make` after you `configure` (e.g. `./configure --prefix=$PWD/test-install`) the following error occurs:

```
print_header.c: In function ‘papi_print_header’:
print_header.c:79:2: error: ‘for’ loop initial declarations are only allowed in C99 mode
  for (int cid = 0; cid < numcmp; cid++ ) {
  ^
print_header.c:79:2: note: use option -std=c99 or -std=gnu99 to compile your code
```

This PR resolves this by moving the for loop counter declaration outside of the for loop header in `print_header.c`.

Tested on a Power 9 with GCC version 4.8.5 and built successfully with the utilities: `papi_component_avail`, `papi_native_avail`, and `papi_command_line` running as expected.

As a sanity check, I also tested on an AMD EPYC 7413 with GCC version 8.5.0 and built successfully with the utilties: `papi_component_avail`, `papi_native_avail`, and `papi_command_line` running as expected.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
