### PR TITLE
ROCM_SMI: Added -pthread flag in tests/Makefile.

### DIFF
--- a/src/components/rocm_smi/tests/Makefile
+++ b/src/components/rocm_smi/tests/Makefile
@@ -13,7 +13,7 @@ INCLUDE += -I$(PAPI_ROCM_ROOT)/include/hip
 INCLUDE += -I$(PAPI_ROCM_ROOT)/include/hsa
 INCLUDE += -I$(PAPI_ROCM_ROOT)/include/rocprofiler
 INCLUDE += -I$(PAPI_ROCM_ROOT)/include/rocblas
-LDFLAGS = -ldl -g -L$(PAPI_ROCM_ROOT)/lib/rocblas -lrocblas
+LDFLAGS = -ldl -g -L$(PAPI_ROCM_ROOT)/lib/rocblas -lrocblas -pthread
 
 %.o:%.c
 	@echo "INCLUDE=" $(INCLUDE)


### PR DESCRIPTION
## Pull Request Description

The Makefile in the tests directory of the rocm_smi component overwrites the LDFLAGS variable, so it won't inherit the "-pthread" flag even when necessary.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
