### PR TITLE
Various Components: Avoid Mixed Memory Allocation

### DIFF
--- a/src/components/coretemp/linux-coretemp.c
+++ b/src/components/coretemp/linux-coretemp.c
@@ -72,7 +72,7 @@ insert_in_list(char *name, char *units,
 		   /* Because this is a function, it is possible */
 		   /* we are called with root!=NULL but no last  */
 		   /* so add this to keep coverity happy         */
-		   free(temp);
+		   papi_free(temp);
 		   PAPIERROR("This shouldn't be possible\n");
 
 		   return PAPI_ECMP;

--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -460,7 +460,7 @@ static int get_counter_availability(cuptip_gpu_state_t *gpu_ctl)
 
     // Allocate the necessary memory for data
     gpu_ctl->counterAvailabilityImage.size = getCounterAvailabilityParams.counterAvailabilityImageSize;
-    gpu_ctl->counterAvailabilityImage.data = (uint8_t *) papi_malloc(gpu_ctl->counterAvailabilityImage.size);
+    gpu_ctl->counterAvailabilityImage.data = (uint8_t *) malloc(gpu_ctl->counterAvailabilityImage.size);
     if (gpu_ctl->counterAvailabilityImage.data == NULL) {
         ERRDBG("Failed to allocate memory for counterAvailabilityImage.data.\n");
         return PAPI_ENOMEM;
@@ -484,23 +484,23 @@ void free_and_reset_configuration_images(cuptip_gpu_state_t *gpu_ctl)
     COMPDBG("Entering.\n");
     // Note that you can find the memory allocation for the below variables
     // in cuptip_ctx_start as of April 21st, 2025
-    papi_free(gpu_ctl->configImage.data);
+    free(gpu_ctl->configImage.data);
     gpu_ctl->configImage.data = NULL;
     gpu_ctl->configImage.size = 0;
 
-    papi_free(gpu_ctl->counterDataPrefixImage.data);
+    free(gpu_ctl->counterDataPrefixImage.data);
     gpu_ctl->counterDataPrefixImage.data = NULL;
     gpu_ctl->counterDataPrefixImage.size = 0;
 
-    papi_free(gpu_ctl->counterDataScratchBuffer.data);
+    free(gpu_ctl->counterDataScratchBuffer.data);
     gpu_ctl->counterDataScratchBuffer.data = NULL;
     gpu_ctl->counterDataScratchBuffer.size = 0;
 
-    papi_free(gpu_ctl->counterDataImage.data);
+    free(gpu_ctl->counterDataImage.data);
     gpu_ctl->counterDataImage.data = NULL;
     gpu_ctl->counterDataImage.size = 0; 
     
-    papi_free(gpu_ctl->counterAvailabilityImage.data);
+    free(gpu_ctl->counterAvailabilityImage.data);
     gpu_ctl->counterAvailabilityImage.data = NULL;
     gpu_ctl->counterAvailabilityImage.size = 0;
 }
@@ -534,7 +534,7 @@ static int init_main_htable(void)
         val *= base;
     }    
    
-    cuptiu_table_p = (cuptiu_event_table_t *) papi_malloc(sizeof(cuptiu_event_table_t));
+    cuptiu_table_p = (cuptiu_event_table_t *) malloc(sizeof(cuptiu_event_table_t));
     if (cuptiu_table_p == NULL) {
         ERRDBG("Failed to allocate memory for cuptiu_table_p.\n");
         return PAPI_ENOMEM;
@@ -543,19 +543,19 @@ static int init_main_htable(void)
     cuptiu_table_p->count = 0;
     cuptiu_table_p->event_stats_count = 0;
 
-    cuptiu_table_p->events = (cuptiu_event_t *) papi_calloc(val, sizeof(cuptiu_event_t));
+    cuptiu_table_p->events = (cuptiu_event_t *) calloc(val, sizeof(cuptiu_event_t));
     if (cuptiu_table_p->events == NULL) {
         ERRDBG("Failed to allocate memory for cuptiu_table_p->events.\n");
         return PAPI_ENOMEM;
     }
 
-    cuptiu_table_p->event_stats = (StringVector *) papi_calloc(val, sizeof(StringVector));
+    cuptiu_table_p->event_stats = (StringVector *) calloc(val, sizeof(StringVector));
     if (cuptiu_table_p->event_stats == NULL) {
         ERRDBG("Failed to allocate memory for cuptiu_table_p->event_stats.\n");
         return PAPI_ENOMEM;
     }
 
-    cuptiu_table_p->avail_gpu_info = (gpu_record_t *) papi_calloc(numDevicesOnMachine, sizeof(gpu_record_t));
+    cuptiu_table_p->avail_gpu_info = (gpu_record_t *) calloc(numDevicesOnMachine, sizeof(gpu_record_t));
     if (cuptiu_table_p->avail_gpu_info == NULL) {
         ERRDBG("Failed to allocate memory for cuptiu_table_p->avail_gpu_info.\n");
         return PAPI_ENOMEM;
@@ -732,19 +732,19 @@ int cuptip_ctx_create(cuptic_info_t thr_info, cuptip_control_t *pstate, uint32_t
 {
     COMPDBG("Entering.\n");
 
-    cuptip_control_t state = (cuptip_control_t) papi_calloc (1, sizeof(struct cuptip_control_s));
+    cuptip_control_t state = (cuptip_control_t) calloc (1, sizeof(struct cuptip_control_s));
     if (state == NULL) {
         SUBDBG("Failed to allocate memory for state.\n");
         return PAPI_ENOMEM;
     }
 
-    state->gpu_ctl = (cuptip_gpu_state_t *) papi_calloc(numDevicesOnMachine, sizeof(cuptip_gpu_state_t));
+    state->gpu_ctl = (cuptip_gpu_state_t *) calloc(numDevicesOnMachine, sizeof(cuptip_gpu_state_t));
     if (state->gpu_ctl == NULL) {
         SUBDBG("Failed to allocate memory for state->gpu_ctl.\n"); 
         return PAPI_ENOMEM;
     }
 
-    long long *counters = (long long *) papi_malloc(num_events * sizeof(*counters));
+    long long *counters = (long long *) malloc(num_events * sizeof(*counters));
     if (counters == NULL) {
         SUBDBG("Failed to allocate memory for counters.\n");
         return PAPI_ENOMEM;
@@ -1034,7 +1034,7 @@ int cuptip_ctx_read(cuptip_control_t state, long long **counters)
                 }
             }
         }
-        papi_free(metricValues);
+        free(metricValues);
         *counters = counter_vals;
 
         papi_errno = begin_pass();
@@ -1165,15 +1165,15 @@ int cuptip_ctx_destroy(cuptip_control_t *pstate)
         // Free the created rawMetricRequests from cuptip_ctx_start
         int j;
         for (j = 0; j < state->gpu_ctl[i].numberOfRawMetricRequests; j++) {
-            papi_free((void *) state->gpu_ctl[i].rawMetricRequests[j].pMetricName);
+            free((void *) state->gpu_ctl[i].rawMetricRequests[j].pMetricName);
         }
-        papi_free(state->gpu_ctl[i].rawMetricRequests);
+        free(state->gpu_ctl[i].rawMetricRequests);
     }
 
     // Free the allocated memory from cuptip_ctx_create
-    papi_free(state->counters);
-    papi_free(state->gpu_ctl);
-    papi_free(state);
+    free(state->counters);
+    free(state->gpu_ctl);
+    free(state);
     *pstate = NULL;
 
     return PAPI_OK;
@@ -1522,13 +1522,13 @@ static void shutdown_event_table(void)
 {
     cuptiu_table_p->count = 0;
 
-    papi_free(cuptiu_table_p->avail_gpu_info);
+    free(cuptiu_table_p->avail_gpu_info);
     cuptiu_table_p->avail_gpu_info = NULL;
 
-    papi_free(cuptiu_table_p->events);
+    free(cuptiu_table_p->events);
     cuptiu_table_p->events = NULL;
 
-    papi_free(cuptiu_table_p);
+    free(cuptiu_table_p);
     cuptiu_table_p = NULL;
 }
 
@@ -1545,7 +1545,7 @@ static void shutdown_event_stats_table(void)
     
     cuptiu_table_p->event_stats_count = 0;
 
-    papi_free(cuptiu_table_p->event_stats);
+    free(cuptiu_table_p->event_stats);
 }
 
 /** @class cuptip_evt_enum

--- a/src/components/cuda/cupti_utils.c
+++ b/src/components/cuda/cupti_utils.c
@@ -16,7 +16,7 @@
 
 int cuptiu_event_table_create_init_capacity(int capacity, int sizeof_rec, cuptiu_event_table_t **pevt_table)
 {
-    cuptiu_event_table_t *evt_table = (cuptiu_event_table_t *) papi_malloc(sizeof(cuptiu_event_table_t));
+    cuptiu_event_table_t *evt_table = (cuptiu_event_table_t *) malloc(sizeof(cuptiu_event_table_t));
     if (evt_table == NULL) {
         goto fn_fail;
     }
@@ -48,7 +48,7 @@ void cuptiu_event_table_destroy(cuptiu_event_table_t **pevt_table)
         evt_table->htable = NULL;
     }
 
-    papi_free(evt_table);
+    free(evt_table);
     *pevt_table = NULL;
 }
 

--- a/src/components/cuda/htable.h
+++ b/src/components/cuda/htable.h
@@ -121,7 +121,7 @@ htable_insert(void *handle, const char *key, void *in)
     return htable_errno;
   fn_fail:
     if (entry) {
-        papi_free(entry);
+        free(entry);
     }
     goto fn_exit;
 }
@@ -196,13 +196,13 @@ create_table(uint64_t size, struct hash_table **table)
 {
     int htable_errno = HTABLE_SUCCESS;
 
-    *table = papi_calloc(1, sizeof(**table));
+    *table = calloc(1, sizeof(**table));
     if (table == NULL) {
         htable_errno = HTABLE_ENOMEM;
         goto fn_exit;
     }
 
-    (*table)->buckets = papi_calloc(size, sizeof(*(*table)->buckets));
+    (*table)->buckets = calloc(size, sizeof(*(*table)->buckets));
     if ((*table)->buckets == NULL) {
         htable_errno = HTABLE_ENOMEM;
         goto fn_exit;
@@ -220,11 +220,11 @@ destroy_table(struct hash_table *table)
     int htable_errno = HTABLE_SUCCESS;
 
     if (table && table->buckets) {
-        papi_free(table->buckets);
+        free(table->buckets);
     }
 
     if (table) {
-        papi_free(table);
+        free(table);
     }
 
     return htable_errno;
@@ -258,7 +258,7 @@ move_table(struct hash_table *new_table, struct hash_table *old_table)
     old_table->size = new_table->size;
     old_table->buckets = new_table->buckets;
     new_table->buckets = NULL;
-    papi_free(old_buckets);
+    free(old_buckets);
 
     return htable_errno;
 }
@@ -322,7 +322,7 @@ create_table_entry(const char *key, void *val, struct hash_table_entry **entry)
 {
     int htable_errno = HTABLE_SUCCESS;
 
-    *entry = papi_calloc(1, sizeof(**entry));
+    *entry = calloc(1, sizeof(**entry));
     if (*entry == NULL) {
         return HTABLE_ENOMEM;
     }
@@ -337,8 +337,8 @@ int
 destroy_table_entry(struct hash_table_entry *entry)
 {
     int htable_errno = HTABLE_SUCCESS;
-    papi_free(entry->key);
-    papi_free(entry);
+    free(entry->key);
+    free(entry);
     return htable_errno;
 }
 

--- a/src/components/cuda/linux-cuda.c
+++ b/src/components/cuda/linux-cuda.c
@@ -449,7 +449,7 @@ int update_native_events(cuda_control_t *ctl, NativeInfo_t *ntv_info,
     struct event_map_item sorted_events[PAPI_CUDA_MAX_COUNTERS];
 
     if (ntv_count != ctl->num_events) {
-        ctl->events_id = papi_realloc(ctl->events_id,
+        ctl->events_id = realloc(ctl->events_id,
                                       ntv_count * sizeof(*ctl->events_id));
         if (ctl->events_id == NULL) {
             papi_errno = PAPI_ENOMEM;
@@ -642,7 +642,7 @@ static int cuda_cleanup_eventset(hwd_control_state_t *ctl)
     }
 
     /* free int array of event id's and reset number of events */
-    papi_free(cuda_ctl->events_id);
+    free(cuda_ctl->events_id);
     cuda_ctl->events_id = NULL;
     cuda_ctl->num_events = 0;
 

--- a/src/components/cuda/papi_cupti_common.c
+++ b/src/components/cuda/papi_cupti_common.c
@@ -761,7 +761,7 @@ int cuptic_ctxarr_create(cuptic_info_t *pinfo)
     }
   
     /* allocate memory */ 
-    *pinfo = (cuptic_info_t) papi_calloc (total_gpus, sizeof(*pinfo));
+    *pinfo = (cuptic_info_t) calloc (total_gpus, sizeof(*pinfo));
     if (*pinfo == NULL) {
         return PAPI_ENOMEM;
     }
@@ -837,7 +837,7 @@ int cuptic_ctxarr_get_ctx(cuptic_info_t info, int gpu_idx, CUcontext *ctx)
 
 int cuptic_ctxarr_destroy(cuptic_info_t *pinfo)
 {
-    papi_free(*pinfo);
+    free(*pinfo);
     *pinfo = NULL;
     return PAPI_OK;
 }

--- a/src/components/infiniband/linux-infiniband.c
+++ b/src/components/infiniband/linux-infiniband.c
@@ -303,11 +303,12 @@ add_ib_device(const char* name, int port)
         return (0);
     }
 
-    new_dev->dev_name = strdup(name);
+    new_dev->dev_name = papi_strdup(name);
     new_dev->dev_port = port;
     if (new_dev->dev_name==0)
     {
         PAPIERROR("cannot allocate memory for device internal fields");
+        papi_free(new_dev->dev_name);
         papi_free(new_dev);
         return (0);
     }
@@ -328,8 +329,8 @@ add_ib_counter(const char* name, const char* file_name, int extended, ib_device_
         return (0);
     }
 
-    new_cnt->ev_name = strdup(name);
-    new_cnt->ev_file_name = strdup(file_name);
+    new_cnt->ev_name = papi_strdup(name);
+    new_cnt->ev_file_name = papi_strdup(file_name);
     new_cnt->extended = extended;
     new_cnt->ev_device = device;
     if (new_cnt->ev_name==0 || new_cnt->ev_file_name==0)
@@ -599,9 +600,9 @@ deallocate_infiniband_resources()
     {
         for (i=0 ; i<num_events ; ++i) {
             if (infiniband_native_events[i].name)
-                free(infiniband_native_events[i].name);
+                papi_free(infiniband_native_events[i].name);
             if (infiniband_native_events[i].file_name)
-                free(infiniband_native_events[i].file_name);
+                papi_free(infiniband_native_events[i].file_name);
             if (infiniband_native_events[i].description)
                 papi_free(infiniband_native_events[i].description);
         }
@@ -612,7 +613,7 @@ deallocate_infiniband_resources()
     while (iter != 0) 
     {
         if (iter->dev_name)
-            free(iter->dev_name);
+            papi_free(iter->dev_name);
 
         ib_device_t *tmp = iter;
         iter = iter->next;

--- a/src/components/net/linux-net.c
+++ b/src/components/net/linux-net.c
@@ -173,7 +173,7 @@ generateNetEventList( void )
             } else if (last) {
                 last->next = temp;
             } else {
-                free(temp);
+                papi_free(temp);
                 fclose(fin);
                 PAPIERROR("This shouldn't be possible\n");
                 snprintf(_net_vector.cmp_info.disabled_reason, PAPI_MAX_STR_LEN-2,

--- a/src/components/rocm/htable.h
+++ b/src/components/rocm/htable.h
@@ -325,7 +325,7 @@ create_table_entry(const char *key, void *val, struct hash_table_entry **entry)
     if (*entry == NULL) {
         return HTABLE_ENOMEM;
     }
-    (*entry)->key = strdup(key);
+    (*entry)->key = papi_strdup(key);
     (*entry)->val = val;
     (*entry)->next = NULL;
 

--- a/src/components/rocm_smi/htable.h
+++ b/src/components/rocm_smi/htable.h
@@ -325,7 +325,7 @@ create_table_entry(const char *key, void *val, struct hash_table_entry **entry)
     if (*entry == NULL) {
         return HTABLE_ENOMEM;
     }
-    (*entry)->key = strdup(key);
+    (*entry)->key = papi_strdup(key);
     (*entry)->val = val;
     (*entry)->next = NULL;
 

--- a/src/components/rocm_smi/rocs.c
+++ b/src/components/rocm_smi/rocs.c
@@ -997,13 +997,13 @@ init_device_table(void)
     int i, j;
     rsmi_status_t status;
 
-    freq_table = calloc(device_count * ROCS_GPU_CLK_FREQ_VARIANT__NUM, sizeof(rsmi_frequencies_t));
+    freq_table = papi_calloc(device_count * ROCS_GPU_CLK_FREQ_VARIANT__NUM, sizeof(rsmi_frequencies_t));
     if (freq_table == NULL) {
         papi_errno = PAPI_ENOMEM;
         goto fn_fail;
     }
 
-    pcie_table = calloc(device_count, sizeof(rsmi_pcie_bandwidth_t));
+    pcie_table = papi_calloc(device_count, sizeof(rsmi_pcie_bandwidth_t));
     if (pcie_table == NULL) {
         papi_errno = PAPI_ENOMEM;
         goto fn_fail;
@@ -1862,11 +1862,11 @@ get_event_name(const char *name, int32_t dev, int64_t variant, int64_t subvarian
     char event_name_str[PAPI_MAX_STR_LEN] = { 0 };
 
     if (strcmp(name, "rsmi_dev_count") == 0) {
-        return strdup("NUMDevices");
+        return papi_strdup("NUMDevices");
     } else if (strcmp(name, "rsmi_lib_version") == 0) {
-        return strdup("rsmi_version");
+        return papi_strdup("rsmi_version");
     } else if (strcmp(name, "rsmi_dev_driver_version_str_get") == 0) {
-        return strdup("driver_version_str");
+        return papi_strdup("driver_version_str");
     } else if (strcmp(name, "rsmi_dev_id_get") == 0) {
         sprintf(event_name_str, "device_id:device=%i", dev);
     } else if (strcmp(name, "rsmi_dev_subsystem_vendor_id_get") == 0) {
@@ -2362,7 +2362,7 @@ get_event_name(const char *name, int32_t dev, int64_t variant, int64_t subvarian
         return NULL;
     }
 
-    return strdup(event_name_str);
+    return papi_strdup(event_name_str);
 }
 
 char *
@@ -2371,25 +2371,25 @@ get_event_descr(const char *name, int64_t variant, int64_t subvariant)
     char event_descr_str[PAPI_MAX_STR_LEN] = { 0 };
 
     if (strcmp(name, "rsmi_dev_count") == 0) {
-        return strdup("Number of Devices which have monitors, accessible by rocm_smi.");
+        return papi_strdup("Number of Devices which have monitors, accessible by rocm_smi.");
     } else if (strcmp(name, "rsmi_lib_version") == 0) {
-        return strdup("Version of RSMI lib; 0x0000MMMMmmmmpppp Major, Minor, Patch.");
+        return papi_strdup("Version of RSMI lib; 0x0000MMMMmmmmpppp Major, Minor, Patch.");
     } else if (strcmp(name, "rsmi_dev_driver_version_str_get") == 0) {
-        return strdup("Returns char* to z-terminated driver version string; do not free().");
+        return papi_strdup("Returns char* to z-terminated driver version string; do not free().");
     } else if (strcmp(name, "rsmi_dev_id_get") == 0) {
-        return strdup("Vendor supplied device id number. May be shared by same model devices; see pci_id for a unique identifier.");
+        return papi_strdup("Vendor supplied device id number. May be shared by same model devices; see pci_id for a unique identifier.");
     } else if (strcmp(name, "rsmi_dev_subsystem_vendor_id_get") == 0) {
-        return strdup("System vendor id number.");
+        return papi_strdup("System vendor id number.");
     } else if (strcmp(name, "rsmi_dev_vendor_id_get") == 0) {
-        return strdup("Vendor id number.");
+        return papi_strdup("Vendor id number.");
     } else if (strcmp(name, "rsmi_dev_unique_id_get") == 0) {
-        return strdup("Unique id for device.");
+        return papi_strdup("Unique id for device.");
     } else if (strcmp(name, "rsmi_dev_subsystem_id_get") == 0) {
-        return strdup("Subsystem id number.");
+        return papi_strdup("Subsystem id number.");
     } else if (strcmp(name, "rsmi_dev_drm_render_minor_get") == 0) {
-        return strdup("DRM Minor Number associated with this device.");
+        return papi_strdup("DRM Minor Number associated with this device.");
     } else if (strcmp(name, "rsmi_dev_overdrive_level_get") == 0) {
-        return strdup("Overdriver Level \% for device, 0 to 20, max overclocked permitted. Read Only.");
+        return papi_strdup("Overdriver Level \% for device, 0 to 20, max overclocked permitted. Read Only.");
     } else if (strcmp(name, "rsmi_dev_perf_level_get") == 0) {
         sprintf(event_descr_str, "PowerPlay Performance Level; Read Only, enum rsmi_dev_perf_level_t [0-%i], see ROCm_SMI_Manual for details.",
                 RSMI_DEV_PERF_LEVEL_LAST);
@@ -2425,139 +2425,139 @@ get_event_descr(const char *name, int64_t variant, int64_t subvariant)
                 return NULL;
         }
     } else if (strcmp(name, "rsmi_dev_busy_percent_get") == 0) {
-        return strdup("Percentage of time the device was busy doing any processing.");
+        return papi_strdup("Percentage of time the device was busy doing any processing.");
     } else if (strcmp(name, "rsmi_dev_memory_busy_percent_get") == 0) {
-        return strdup("Percentage_of time any device memory is being used.");
+        return papi_strdup("Percentage_of time any device memory is being used.");
     } else if (strcmp(name, "rsmi_dev_pci_id_get") == 0) {
-        return strdup("BDF (Bus/Device/Function) ID, unique per device.");
+        return papi_strdup("BDF (Bus/Device/Function) ID, unique per device.");
     } else if (strcmp(name, "rsmi_dev_pci_replay_counter_get") == 0) {
-        return strdup("Sum of the number of NAK's received by the GPU and the NAK's generated by the GPU.");
+        return papi_strdup("Sum of the number of NAK's received by the GPU and the NAK's generated by the GPU.");
     } else if (strcmp(name, "rsmi_dev_pci_throughput_get") == 0) {
         switch (variant) {
             case ROCS_PCI_THROUGHPUT_VARIANT__SENT:
-                return strdup("Throughput on PCIe traffic, bytes/second sent.");
+                return papi_strdup("Throughput on PCIe traffic, bytes/second sent.");
             case ROCS_PCI_THROUGHPUT_VARIANT__RECEIVED:
-                return strdup("Throughput on PCIe traffic, bytes/second received.");
+                return papi_strdup("Throughput on PCIe traffic, bytes/second received.");
             case ROCS_PCI_THROUGHPUT_VARIANT__MAX_PACKET_SIZE:
-                return strdup("Maximum PCIe packet size.");
+                return papi_strdup("Maximum PCIe packet size.");
             default:
                 return NULL;
         }
     } else if (strcmp(name, "rsmi_dev_power_profile_presets_get") == 0) {
         switch (variant) {
             case ROCS_POWER_PRESETS_VARIANT__COUNT:
-                return strdup("Number of power profile presets available. See ROCM_SMI Manual for details.");
+                return papi_strdup("Number of power profile presets available. See ROCM_SMI Manual for details.");
             case ROCS_POWER_PRESETS_VARIANT__AVAIL_PROFILES:
-                return strdup("Bit mask for available power profile presets. See ROCM_SMI Manual for details.");
+                return papi_strdup("Bit mask for available power profile presets. See ROCM_SMI Manual for details.");
             case ROCS_POWER_PRESETS_VARIANT__CURRENT:
-                return strdup("Bit mask for current power profile preset. Read/Write. See ROCM_SMI Manual for details.");
+                return papi_strdup("Bit mask for current power profile preset. Read/Write. See ROCM_SMI Manual for details.");
             default:
                 return NULL;
         }
     } else if (strcmp(name, "rsmi_dev_power_profile_set") == 0) {
-        return strdup("Write Only, set the power profile to one of the available masks. See ROCM_SMI Manual for details.");
+        return papi_strdup("Write Only, set the power profile to one of the available masks. See ROCM_SMI Manual for details.");
     } else if (strcmp(name, "rsmi_dev_fan_reset") == 0) {
-        return strdup("Fan Reset. Write Only, data value is ignored.");
+        return papi_strdup("Fan Reset. Write Only, data value is ignored.");
     } else if (strcmp(name, "rsmi_dev_fan_rpms_get") == 0) {
-        return strdup("Current fan speed in RPMs (Rotations Per Minute).");
+        return papi_strdup("Current fan speed in RPMs (Rotations Per Minute).");
     } else if (strcmp(name, "rsmi_dev_fan_speed_max_get") == 0) {
-        return strdup("Maximum possible fan speed in RPMs (Rotations Per Minute).");
+        return papi_strdup("Maximum possible fan speed in RPMs (Rotations Per Minute).");
     } else if (strcmp(name, "rsmi_dev_fan_speed_get") == 0) {
-        return strdup("Current fan speed in RPMs (Rotations Per Minute), Read Only, result [0-255].");
+        return papi_strdup("Current fan speed in RPMs (Rotations Per Minute), Read Only, result [0-255].");
     } else if (strcmp(name, "rsmi_dev_fan_speed_set") == 0) {
-        return strdup("Current fan speed in RPMs (Rotations Per Minute), Read/Write, Write must be <= MAX (see fan_speed_max event), arg in [0-255].");
+        return papi_strdup("Current fan speed in RPMs (Rotations Per Minute), Read/Write, Write must be <= MAX (see fan_speed_max event), arg in [0-255].");
     } else if (strcmp(name, "rsmi_dev_power_ave_get") == 0) {
-        return strdup("Current Average Power consumption in microwatts. Requires root privileges.");
+        return papi_strdup("Current Average Power consumption in microwatts. Requires root privileges.");
     } else if (strcmp(name, "rsmi_dev_power_cap_get") == 0) {
-        return strdup("Power cap in microwatts. Read Only. Between min/max (see power_cap_range_min/max). May require root privileges.");
+        return papi_strdup("Power cap in microwatts. Read Only. Between min/max (see power_cap_range_min/max). May require root privileges.");
     } else if (strcmp(name, "rsmi_dev_power_cap_set") == 0) {
-        return strdup("Power cap in microwatts. Read/Write. Between min/max (see power_cap_range_min/max). May require root privileges.");
+        return papi_strdup("Power cap in microwatts. Read/Write. Between min/max (see power_cap_range_min/max). May require root privileges.");
     } else if (strcmp(name, "rsmi_dev_power_cap_range_get") == 0) {
         switch (variant) {
             case ROCS_POWER_CAP_RANGE_VARIANT__MIN:
-                return strdup("Power cap Minimum settable value, in microwatts.");
+                return papi_strdup("Power cap Minimum settable value, in microwatts.");
             case ROCS_POWER_CAP_RANGE_VARIANT__MAX:
-                return strdup("Power cap Maximim settable value, in microwatts.");
+                return papi_strdup("Power cap Maximim settable value, in microwatts.");
             default:
                 return NULL;
         }
     } else if (strcmp(name, "rsmi_dev_temp_metric_get") == 0) {
         switch (variant) {
             case RSMI_TEMP_CURRENT:
-                return strdup("Temperature current value, millidegrees Celsius.");
+                return papi_strdup("Temperature current value, millidegrees Celsius.");
             case RSMI_TEMP_MAX:
-                return strdup("Temperature maximum value, millidegrees Celsius.");
+                return papi_strdup("Temperature maximum value, millidegrees Celsius.");
             case RSMI_TEMP_MIN:
-                return strdup("Temperature minimum value, millidegrees Celsius.");
+                return papi_strdup("Temperature minimum value, millidegrees Celsius.");
             case RSMI_TEMP_MAX_HYST:
-                return strdup("Temperature hysteresis value for max limit, millidegrees Celsius.");
+                return papi_strdup("Temperature hysteresis value for max limit, millidegrees Celsius.");
             case RSMI_TEMP_MIN_HYST:
-                return strdup("Temperature hysteresis value for min limit, millidegrees Celsius.");
+                return papi_strdup("Temperature hysteresis value for min limit, millidegrees Celsius.");
             case RSMI_TEMP_CRITICAL:
-                return strdup("Temperature critical max value, typical > temp_max, millidegrees Celsius.");
+                return papi_strdup("Temperature critical max value, typical > temp_max, millidegrees Celsius.");
             case RSMI_TEMP_CRITICAL_HYST:
-                return strdup("Temperature hysteresis value for critical limit, millidegrees Celsius.");
+                return papi_strdup("Temperature hysteresis value for critical limit, millidegrees Celsius.");
             case RSMI_TEMP_EMERGENCY:
-                return strdup("Temperature emergency max for chips supporting more than two upper temp limits, millidegrees Celsius.");
+                return papi_strdup("Temperature emergency max for chips supporting more than two upper temp limits, millidegrees Celsius.");
             case RSMI_TEMP_EMERGENCY_HYST:
-                return strdup("Temperature hysteresis value for emergency limit, millidegrees Celsius.");
+                return papi_strdup("Temperature hysteresis value for emergency limit, millidegrees Celsius.");
             case RSMI_TEMP_CRIT_MIN:
-                return strdup("Temperature critical min value, typical < temp_min, millidegrees Celsius.");
+                return papi_strdup("Temperature critical min value, typical < temp_min, millidegrees Celsius.");
             case RSMI_TEMP_CRIT_MIN_HYST:
-                return strdup("Temperature hysteresis value for critical min limit, millidegrees Celsius.");
+                return papi_strdup("Temperature hysteresis value for critical min limit, millidegrees Celsius.");
             case RSMI_TEMP_OFFSET:
-                return strdup("Temperature offset added to temp reading by the chip, millidegrees Celsius.");
+                return papi_strdup("Temperature offset added to temp reading by the chip, millidegrees Celsius.");
             case RSMI_TEMP_LOWEST:
-                return strdup("Temperature historical minimum, millidegrees Celsius.");
+                return papi_strdup("Temperature historical minimum, millidegrees Celsius.");
             case RSMI_TEMP_HIGHEST:
-                return strdup("Temperature historical maximum, millidegrees Celsius.");
+                return papi_strdup("Temperature historical maximum, millidegrees Celsius.");
             default:
                 return NULL;
         }
     } else if (strcmp(name, "rsmi_dev_firmware_version_get") == 0) {
         switch (variant) {
             case RSMI_FW_BLOCK_ASD:
-                return strdup("Firmware Version Block ASD.");
+                return papi_strdup("Firmware Version Block ASD.");
             case RSMI_FW_BLOCK_CE:
-                return strdup("Firmware Version Block CE.");
+                return papi_strdup("Firmware Version Block CE.");
             case RSMI_FW_BLOCK_DMCU:
-                return strdup("Firmware Version Block DMCU.");
+                return papi_strdup("Firmware Version Block DMCU.");
             case RSMI_FW_BLOCK_MC:
-                return strdup("Firmware Version Block MC.");
+                return papi_strdup("Firmware Version Block MC.");
             case RSMI_FW_BLOCK_ME:
-                return strdup("Firmware Version Block ME.");
+                return papi_strdup("Firmware Version Block ME.");
             case RSMI_FW_BLOCK_MEC:
-                return strdup("Firmware Version Block MEC.");
+                return papi_strdup("Firmware Version Block MEC.");
             case RSMI_FW_BLOCK_MEC2:
-                return strdup("Firmware Version Block MEC2.");
+                return papi_strdup("Firmware Version Block MEC2.");
             case RSMI_FW_BLOCK_PFP:
-                return strdup("Firmware Version Block PFP.");
+                return papi_strdup("Firmware Version Block PFP.");
             case RSMI_FW_BLOCK_RLC:
-                return strdup("Firmware Version Block RLC.");
+                return papi_strdup("Firmware Version Block RLC.");
             case RSMI_FW_BLOCK_RLC_SRLC:
-                return strdup("Firmware Version Block SRLC.");
+                return papi_strdup("Firmware Version Block SRLC.");
             case RSMI_FW_BLOCK_RLC_SRLG:
-                return strdup("Firmware Version Block SRLG.");
+                return papi_strdup("Firmware Version Block SRLG.");
             case RSMI_FW_BLOCK_RLC_SRLS:
-                return strdup("Firmware Version Block SRLS.");
+                return papi_strdup("Firmware Version Block SRLS.");
             case RSMI_FW_BLOCK_SDMA:
-                return strdup("Firmware Version Block SDMA.");
+                return papi_strdup("Firmware Version Block SDMA.");
             case RSMI_FW_BLOCK_SDMA2:
-                return strdup("Firmware Version Block SDMA2.");
+                return papi_strdup("Firmware Version Block SDMA2.");
             case RSMI_FW_BLOCK_SMC:
-                return strdup("Firmware Version Block SMC.");
+                return papi_strdup("Firmware Version Block SMC.");
             case RSMI_FW_BLOCK_SOS:
-                return strdup("Firmware Version Block SOS.");
+                return papi_strdup("Firmware Version Block SOS.");
             case RSMI_FW_BLOCK_TA_RAS:
-                return strdup("Firmware Version Block RAS.");
+                return papi_strdup("Firmware Version Block RAS.");
             case RSMI_FW_BLOCK_TA_XGMI:
-                return strdup("Firmware Version Block XGMI.");
+                return papi_strdup("Firmware Version Block XGMI.");
             case RSMI_FW_BLOCK_UVD:
-                return strdup("Firmware Version Block UVD.");
+                return papi_strdup("Firmware Version Block UVD.");
             case RSMI_FW_BLOCK_VCE:
-                return strdup("Firmware Version Block VCE.");
+                return papi_strdup("Firmware Version Block VCE.");
             case RSMI_FW_BLOCK_VCN:
-                return strdup("Firmware Version Block VCN.");
+                return papi_strdup("Firmware Version Block VCN.");
             default:
                 return NULL;
         }
@@ -2621,37 +2621,37 @@ get_event_descr(const char *name, int64_t variant, int64_t subvariant)
                 return NULL;
         }
     } else if (strcmp(name, "rsmi_dev_ecc_enabled_get") == 0) {
-        return strdup("Bit mask of GPU blocks with ecc error counting enabled.");
+        return papi_strdup("Bit mask of GPU blocks with ecc error counting enabled.");
     } else if (strcmp(name, "rsmi_dev_ecc_status_get") == 0) {
         switch (variant) {
             case RSMI_GPU_BLOCK_UMC:
-                return strdup("ECC Error Status for the GPU Block UMC.");
+                return papi_strdup("ECC Error Status for the GPU Block UMC.");
             case RSMI_GPU_BLOCK_SDMA:
-                return strdup("ECC Error Status for the GPU Block SDMA.");
+                return papi_strdup("ECC Error Status for the GPU Block SDMA.");
             case RSMI_GPU_BLOCK_GFX:
-                return strdup("ECC Error Status for the GPU Block GFX.");
+                return papi_strdup("ECC Error Status for the GPU Block GFX.");
             case RSMI_GPU_BLOCK_MMHUB:
-                return strdup("ECC Error Status for the GPU Block MMHUB.");
+                return papi_strdup("ECC Error Status for the GPU Block MMHUB.");
             case RSMI_GPU_BLOCK_ATHUB:
-                return strdup("ECC Error Status for the GPU Block ATHUB.");
+                return papi_strdup("ECC Error Status for the GPU Block ATHUB.");
             case RSMI_GPU_BLOCK_PCIE_BIF:
-                return strdup("ECC Error Status for the GPU Block BIF.");
+                return papi_strdup("ECC Error Status for the GPU Block BIF.");
             case RSMI_GPU_BLOCK_HDP:
-                return strdup("ECC Error Status for the GPU Block HDP.");
+                return papi_strdup("ECC Error Status for the GPU Block HDP.");
             case RSMI_GPU_BLOCK_XGMI_WAFL:
-                return strdup("ECC Error Status for the GPU Block WAFL.");
+                return papi_strdup("ECC Error Status for the GPU Block WAFL.");
             case RSMI_GPU_BLOCK_DF:
-                return strdup("ECC Error Status for the GPU Block DF.");
+                return papi_strdup("ECC Error Status for the GPU Block DF.");
             case RSMI_GPU_BLOCK_SMN:
-                return strdup("ECC Error Status for the GPU Block SMN.");
+                return papi_strdup("ECC Error Status for the GPU Block SMN.");
             case RSMI_GPU_BLOCK_SEM:
-                return strdup("ECC Error Status for the GPU Block SEM.");
+                return papi_strdup("ECC Error Status for the GPU Block SEM.");
             case RSMI_GPU_BLOCK_MP0:
-                return strdup("ECC Error Status for the GPU Block MP0.");
+                return papi_strdup("ECC Error Status for the GPU Block MP0.");
             case RSMI_GPU_BLOCK_MP1:
-                return strdup("ECC Error Status for the GPU Block MP1.");
+                return papi_strdup("ECC Error Status for the GPU Block MP1.");
             case RSMI_GPU_BLOCK_FUSE:
-                return strdup("ECC Error Status for the GPU Block FUSE.");
+                return papi_strdup("ECC Error Status for the GPU Block FUSE.");
             default:
                 return NULL;
         }
@@ -2680,9 +2680,9 @@ get_event_descr(const char *name, int64_t variant, int64_t subvariant)
         int idx;
         switch (subvariant) {
             case ROCS_GPU_CLK_FREQ_SUBVARIANT__COUNT:
-                return strdup("Number of frequencies available.");
+                return papi_strdup("Number of frequencies available.");
             case ROCS_GPU_CLK_FREQ_SUBVARIANT__CURRENT:
-                return strdup("Current operating frequency.");
+                return papi_strdup("Current operating frequency.");
             default:
                 idx = subvariant - ROCS_GPU_CLK_FREQ_SUBVARIANT__NUM;
         }
@@ -2714,9 +2714,9 @@ get_event_descr(const char *name, int64_t variant, int64_t subvariant)
     } else if (strcmp(name, "rsmi_dev_pci_bandwidth_get") == 0) {
         switch (variant) {
             case ROCS_PCI_BW_VARIANT__COUNT:
-                return strdup("Number of PCI transfers rates available.");
+                return papi_strdup("Number of PCI transfers rates available.");
             case ROCS_PCI_BW_VARIANT__CURRENT:
-                return strdup("Current PCI transfer rate.");
+                return papi_strdup("Current PCI transfer rate.");
             case ROCS_PCI_BW_VARIANT__RATE_IDX:
                 sprintf(event_descr_str, "Returns PCI bandwidth rate value from supported_table[%i].", (int) subvariant);
                 break;
@@ -2727,19 +2727,19 @@ get_event_descr(const char *name, int64_t variant, int64_t subvariant)
                 return NULL;
         }
     } else if (strcmp(name, "rsmi_dev_pci_bandwidth_set") == 0) {
-        return strdup("Write Only. Sets bit mask, 1's for PCI transfer rates in supported_table permitted. All 0 mask prohibited");
+        return papi_strdup("Write Only. Sets bit mask, 1's for PCI transfer rates in supported_table permitted. All 0 mask prohibited");
     } else if (strcmp(name, "rsmi_dev_brand_get") == 0) {
-        return strdup("Returns char* to z-terminated brand string; do not free().");
+        return papi_strdup("Returns char* to z-terminated brand string; do not free().");
     } else if (strcmp(name, "rsmi_dev_name_get") == 0) {
-        return strdup("Returns char* to z-terminated name string; do not free().");
+        return papi_strdup("Returns char* to z-terminated name string; do not free().");
     } else if (strcmp(name, "rsmi_dev_serial_number_get") == 0) {
-        return strdup("Returns char* to z-terminated serial number string; do not free().");
+        return papi_strdup("Returns char* to z-terminated serial number string; do not free().");
     } else if (strcmp(name, "rsmi_dev_subsystem_name_get") == 0) {
-        return strdup("Returns char* to z-terminated subsystem name string; do not free().");
+        return papi_strdup("Returns char* to z-terminated subsystem name string; do not free().");
     } else if (strcmp(name, "rsmi_dev_vbios_version_get") == 0) {
-        return strdup("Returns char* to z-terminated vbios version string; do not free().");
+        return papi_strdup("Returns char* to z-terminated vbios version string; do not free().");
     } else if (strcmp(name, "rsmi_dev_vendor_name_get") == 0) {
-        return strdup("Returns char* to z-terminated vendor name string; do not free().");
+        return papi_strdup("Returns char* to z-terminated vendor name string; do not free().");
     } else if (strcmp(name, "rsmi_dev_xgmi_evt_get") == 0) {
         const char *variant_str = NULL;
         switch (variant) {
@@ -2804,7 +2804,7 @@ get_event_descr(const char *name, int64_t variant, int64_t subvariant)
         return NULL;
     }
 
-    return strdup(event_descr_str);
+    return papi_strdup(event_descr_str);
 }
 
 rocs_access_mode_e


### PR DESCRIPTION
## Pull Request Description
This PR addresses components mixing C memory allocation and PAPI memory allocation. This becomes an issue when you add the flag `--with-debug=memory` as:

1. PAPI memory allocation creates extra metadata
2. Trying to `papi_free` a variable that was allocated with just `malloc`, `calloc`, or `realloc` will result in a segmentation fault

Below are Components that have changes done to them:
|Component | Memory Allocation Used Before Changes | Memory Allocation Used After Changes | Tests Ran | Hardware Tested On | Kernel Versioning |
| ------------- | -------------| ------------- | ------------- | ------------- | ------------- |
|  `rocm_smi` | Mixed  | PAPI | *`papi_component_avail` - ✅ <br> *`papi_native_avail` - ✅ <br> *`papi_command_line` - ✅  <br> *Application Code with `PAPI_shutdown` - ✅  |  2 * MI210s  | ROCm 6.4.0  |
| `rocm` | Mixed  | PAPI  | *`papi_component_avail` - ✅ <br> *`papi_native_avail` - ✅ <br> *`papi_command_line` - ✅  <br> *Application Code with `PAPI_shutdown` - ✅  | 2 * MI210s | ROCm 6.4.0 |
| `coretemp` | Mixed | PAPI | *`papi_component_avail` - ✅ <br> *`papi_native_avail` - ✅ <br> *`papi_command_line` - ✅  <br> *Application Code with `PAPI_shutdown` - ✅  | AMD EPYC 7413  | 4.18.0-553.16.1.el8_10.x86_64 |
| `cuda` | Mixed | C  | *`papi_component_avail` - ✅ <br> *`papi_native_avail` - ✅ <br> *`papi_command_line` - ✅  <br> *Application Code with `PAPI_shutdown` - ✅    | 1 * H100 | Cuda Toolkit 12.6.3  |
| `infiniband` | Mixed | PAPI  | *`papi_component_avail` - ✅ <br> *`papi_native_avail` - ✅ <br> *`papi_command_line` - ✅  <br> *Application Code with `PAPI_shutdown` - ✅   | Intel Xeon Gold 6140 | 6.1.129-1.el9.elrepo.x86_64  |

Note that the Cuda component did not change to PAPI memory allocation as when testing the runtime was extremely long in `--with-debug=memory` to the point the utilities looked like they hang. 


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
