### PR TITLE
Allow test compilation with hipcc in spack

### DIFF
--- a/src/components/rocm/tests/Makefile
+++ b/src/components/rocm/tests/Makefile
@@ -2,7 +2,7 @@ NAME = rocm
 include ../../Makefile_comp_tests.target
 PAPI_ROCM_ROOT ?= /opt/rocm
 
-HIPCC    = $(shell find $(PAPI_ROCM_ROOT) -iname hipcc | grep bin | head -n 1)
+HIPCC    ?= $(shell find $(PAPI_ROCM_ROOT) -iname hipcc | grep bin | head -n 1)
 CC       = $(HIPCC)
 CXX      = $(HIPCC)
 CPPFLAGS+= -I$(PAPI_ROCM_ROOT)/include          \

--- a/src/components/rocm_smi/tests/Makefile
+++ b/src/components/rocm_smi/tests/Makefile
@@ -4,8 +4,7 @@
 NAME=rocm_smi
 include ../../Makefile_comp_tests.target
 PAPI_ROCM_ROOT ?= /opt/rocm
-HIP_PATH= ${PAPI_ROCM_ROOT}
-HIPCC=$(HIP_PATH)/bin/hipcc
+HIPCC ?= $(PAPI_ROCM_ROOT)/bin/hipcc
 
 INCLUDE += -I$(PAPI_ROCM_ROOT)/include
 INCLUDE += -I$(PAPI_ROCM_ROOT)/include/rocm_smi
@@ -66,7 +65,6 @@ clean:
 
 checkpath: 
 	echo PAPI_ROCM_ROOT = $(PAPI_ROCM_ROOT)
-	echo HIP_PATH = $(HIP_PATH)
 	echo HIPCC = $(HIPCC)
 	echo INCLUDE = $(INCLUDE)
 	echo LDFLAGS = $(LDFLAGS)


### PR DESCRIPTION
## Pull Request Description

The hipcc compiler is needed for tests compilation in the rocm, rocm_smi, and rocp_sdk components, but the hipcc compiler is not provided in the spack package that PAPI_ROCM_ROOT is pointed to. This change allows the user (spack) to optionally set HIPCC if it is located somewhere other than PAPI_ROCM_ROOT.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
