### PR TITLE
lmsensors component: Replace fprintf with SUBDBG

### DIFF
--- a/src/components/lmsensors/linux-lmsensors.c
+++ b/src/components/lmsensors/linux-lmsensors.c
@@ -201,8 +201,7 @@ createNativeEvents( void )
 	      char *featurelabel;
 
 	      if ( !( featurelabel = sensors_get_labelPtr( chip_name, feature ))) {
-		 fprintf( stderr, "ERROR: Can't get label of feature %s!\n",
-						 feature->name );
+		 SUBDBG( "ERROR: Can't get label of feature %s!\n", feature->name );
 		 continue;
 	      }
 
@@ -260,8 +259,7 @@ getEventValue( unsigned event_id )
 							 subfeat_nr, &value );
 
 	if ( res < 0 ) {
-		fprintf( stderr, "libsensors(): Could not read event #%d!\n",
-				 event_id );
+		SUBDBG( "libsensors(): Could not read event #%d!\n", event_id );
 		return -1;
 	}
 


### PR DESCRIPTION
## Pull Request Description
Currently in the `lmsensors` component there are two `fprintf` calls. This can lead to error messages printing even when you do not set `PAPI_DEBUG`. As an example, on an AMD Epyc 7413 with `lmsensors` 3.4 the following will occur:
```
[tburgess@gilgamesh bin]$ ./papi_command_line lmsensors:::amdgpu-pci-e300.mem.temp3_crit

This utility lets you add events from the command line interface to see if they work.

libsensors(): Could not read event #26!
.
.
.
libsensors(): Could not read event #75!
Successfully added: lmsensors:::amdgpu-pci-e300.mem.temp3_crit

lmsensors:::amdgpu-pci-e300.mem.temp3_crit : 	94000 
```

This PR resolves this issue by replacing the `fprintf`'s with `SUBDBG`'s (Tested on an AMD Epyc 7413 with `lmsensors` 3.4).


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
