### PR TITLE
rocm_smi/rocp_sdk: Restructure init_private functions to avoid setting initialized equal to 1 even when initialization fails

### DIFF
--- a/src/components/rocm_smi/linux-rocm-smi.c
+++ b/src/components/rocm_smi/linux-rocm-smi.c
@@ -114,12 +114,16 @@ _rocm_smi_init_private(void)
 
     int count = 0;
     papi_errno = evt_get_count(&count);
+    if (papi_errno != PAPI_OK) {
+        goto fn_fail;
+    }
     _rocm_smi_vector.cmp_info.num_native_events = count;
     _rocm_smi_vector.cmp_info.num_cntrs = count;
     _rocm_smi_vector.cmp_info.num_mpx_cntrs = count;
 
-  fn_exit:
     _rocm_smi_vector.cmp_info.initialized = 1;
+
+  fn_exit:
     _rocm_smi_vector.cmp_info.disabled = papi_errno;
     PAPI_unlock(COMPONENT_LOCK);
     return papi_errno;

--- a/src/components/rocp_sdk/rocp_sdk.c
+++ b/src/components/rocp_sdk/rocp_sdk.c
@@ -222,12 +222,16 @@ rocp_sdk_init_private(void)
 
     int count = 0;
     papi_errno = evt_get_count(&count);
+    if (papi_errno != PAPI_OK) {
+        goto fn_fail;
+    }
     _rocp_sdk_vector.cmp_info.num_native_events = count;
     _rocp_sdk_vector.cmp_info.num_cntrs = count;
     _rocp_sdk_vector.cmp_info.num_mpx_cntrs = count;
 
-  fn_exit:
     _rocp_sdk_vector.cmp_info.initialized = 1;
+
+  fn_exit:
     _rocp_sdk_vector.cmp_info.disabled = papi_errno;
     _papi_hwi_unlock(COMPONENT_LOCK);
     return papi_errno;

--- a/src/components/template/template.c
+++ b/src/components/template/template.c
@@ -167,11 +167,15 @@ templ_init_private(void)
 
     int count = 0;
     papi_errno = evt_get_count(&count);
+    if (papi_errno != PAPI_OK) {
+        goto fn_fail;
+    }
     _template_vector.cmp_info.num_native_events = count;
     _template_vector.cmp_info.num_cntrs = count;
 
-  fn_exit:
     _template_vector.cmp_info.initialized = 1;
+
+  fn_exit:
     _template_vector.cmp_info.disabled = papi_errno;
     _papi_hwi_unlock(COMPONENT_LOCK);
     return papi_errno;


### PR DESCRIPTION
## Pull Request Description
As stands both `rocm_smi` and `rocp_sdk` have the following `fn_exit`/`fn_fail` structure:
```
fn_exit:
    _component_vector.cmp_info.initialized = 1;
fn_fail:
    goto fn_exit;
```

Therefore, if either component fails to initialize at any point in their respective `init_private` functions we would goto `fn_fail` and then `fn_exit` which would result in `initialized` being set to 1 which would not be true. 

This PR resolves this behavior and correctly will have `initialized` set to 0 if either fail at any point inside their respective `init_private` functions.

Testing was done on Intel Xeon Gold 6140 with an NVIDIA A100 (no AMD Devices on the machine).  As a note, I tested on a machine without AMD devices to trigger a failure at the `init_private` functions.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
