### PR TITLE
rocp_sdk: Remove assignment of info->event_code and info->component_index in rocp_sdk as it is already done in papi_internal.c

### DIFF
--- a/src/components/rocp_sdk/rocp_sdk.c
+++ b/src/components/rocp_sdk/rocp_sdk.c
@@ -436,9 +436,6 @@ rocp_sdk_ntv_code_to_info(unsigned int event_code, PAPI_event_info_t *info)
         return papi_errno;
     }
 
-    info->event_code = event_code;
-    info->component_index = _rocp_sdk_vector.cmp_info.CmpIdx;
-
     return rocprofiler_sdk_evt_code_to_info(event_code, info);
 }
 


### PR DESCRIPTION
## Pull Request Description
This PR removes the assignments of `info->event_code` and `info->component_index` in `rocp_sdk` specifically in the function titled `rocp_sdk_ntv_code_to_info` in the source file `rocp_sdk.c`.

This is being done as in `papi_internal.c` the function titled `_papi_hwi_get_native_event_info` already assigns both of the variables a value. 

Specifically for the case of `info->event_code` this would lead to an incorrect `event_code` assignment which can be seen from `PAPI_get_event_info` output:
```
Event Code: 0 // incorrect
Symbol: rocp_sdk:::cache_lines_per_tag
Short Descr: Constant value cache_lines_per_tag from agent properties
Long Descr: Constant value cache_lines_per_tag from agent properties
Component Index: 2
```

This PR resolves the above issue with `info->event_code`:
```
Event Code: 1073741856
Symbol: rocp_sdk:::cache_lines_per_tag
Short Descr: Constant value cache_lines_per_tag from agent properties
Long Descr: Constant value cache_lines_per_tag from agent properties
Component Index: 2
```

Testing was done on an MI300A (Odyssey at Oregon) with ROCm 6.4.0.


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
