### PR TITLE
RAPL Component: Add support in RAPL for Intel Emerald Rapids

### DIFF
--- a/src/components/rapl/linux-rapl.c
+++ b/src/components/rapl/linux-rapl.c
@@ -479,6 +479,7 @@ _rapl_init_component( int cidx )
 			break;
 			
 		case 143:      /* Sapphire Rapids-SP */
+		case 207:      /* Emerald Rapids */
 		        package_avail=1;
 			pp0_avail=0;
 			pp1_avail=0;


### PR DESCRIPTION
## Pull Request Description
This PR adds RAPL support for Intel Emerald Rapids CPUs.  For the RAPL case, I verified the model number (207) via a [post](https://www.redhat.com/en/blog/red-hat-enterprise-linux-performance-results-5th-gen-intel-xeon-scalable-processors) by Red Hat that shows the hardware configuration.

**Note at this time the PAPI team does not have access to a machine with an Intel Emerald Rapids CPU to verify this addition**.

As a sanity check, I configured and built PAPI as follows `./configure --prefix=$PWD/test-install --with-components="rapl"` on an Intel Xeon Gold 6430 (Sapphire Rapids - Family/Model/Stepping 6/143/8). The build was successful, with the utilities `papi_avail`, `papi_component_avail`, `papi_native_avail`, and `papi_command_line` working as expected (`rapl` was disabled as I lacked the necessary permissions).


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
