### PR TITLE
PAPI_list_events: Update functions documentation to match the function prototype

### DIFF
--- a/src/papi.c
+++ b/src/papi.c
@@ -6652,7 +6652,7 @@ PAPI_remove_events( int EventSet, int *Events, int number )
  *
  * @par C Interface
  * \#include <papi.h> @n
- * int PAPI_list_events(int *EventSet, int *Events, int *number );
+ * int PAPI_list_events(int EventSet, int *Events, int *number);
 *
  *	@param[in] EventSet
  *		An integer handle for a PAPI event set as created by PAPI_create_eventset 


### PR DESCRIPTION
## Pull Request Description
This PR updates the documentation for `PAPI_list_events` in `papi.c` as follows:
```
from:
int PAPI_list_events(int *EventSet, int *Events, int *number );

to:
int PAPI_list_events(int EventSet, int *Events, int *number);
```

This is such that we match the actual function prototype.

I have verified that this updated documentation shows when running `doxygen Doxyfile-html` and `doxygen Doxyfile-man3`, see below.

man3 documentation for `PAPI_list_events`:
```
#include <\fBpapi\&.h\fP> 
.br
int PAPI_list_events(int EventSet, int *Events, int *number);
.RE
```

Generated html page:
```
C Interface
    #include <papi.h>
    int PAPI_list_events(int EventSet, int *Events, int *number);
```

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
