### PR TITLE
rocp_sdk: Restructure cleanup process

### DIFF
--- a/src/components/rocp_sdk/rocp_sdk.c
+++ b/src/components/rocp_sdk/rocp_sdk.c
@@ -242,10 +242,8 @@ rocp_sdk_init_private(void)
 int
 rocp_sdk_shutdown_component(void)
 {
+    unload_hsa_sym();
     _rocp_sdk_vector.cmp_info.initialized = 0;
-    if (rocm_dlp != NULL) {
-        dlclose(rocm_dlp);
-    }
     return rocprofiler_sdk_shutdown();
 }
 
@@ -488,9 +486,6 @@ check_for_available_devices(char *err_msg)
         return PAPI_EMISC;
     }
 
-    if( unload_hsa_sym() )
-        return PAPI_EMISC;
-
     return PAPI_OK;
 }
 
@@ -572,6 +567,8 @@ unload_hsa_sym( void )
     hsa_shut_downPtr      = NULL;
     hsa_iterate_agentsPtr = NULL;
     hsa_agent_get_infoPtr = NULL;
+
+    dlclose(rocm_dlp);
 
     return hsa_is_enabled();
 }


### PR DESCRIPTION
## Pull Request Description
Currently configuring the `rocm` component with the `rocp_sdk` component will result in the `rocm` component failing to initialize when using it in application code. Specifically the failure stems from the `hsa_init` call in `roc_common.c` which returns the error code `HSA_STATUS_ERROR_OUT_OF_RESOURCES`.

 After looking into the issue with Anthony, the error occurred due to the cleanup process in `rocp_sdk`, specifically when/where `unload_hsa_sym` and `dlclose(rocm_dlp)` were called.

This PR restructures the aforementioned calls in `rocp_sdk` to allow for the `rocm` component to successfully run in application code.

I tested this PR on an MI300A with ROCm 6.4.0 with the below application code:
```c
#include "papi.h"

#include <stdio.h>
#include <stdlib.h>

int main() {
    int retval = PAPI_library_init(PAPI_VER_CURRENT);
    if (retval != PAPI_VER_CURRENT) {
        printf("Failed call to PAPI_library_init: %d\n", retval);
        return PAPI_ENOINIT;
    }   
    int i;
    int cmpIdx = 2; // My rocm cmp idx
    i = 0 | PAPI_NATIVE_MASK;
    retval = PAPI_enum_cmp_event( &i, PAPI_ENUM_FIRST, cmpIdx);
    if (retval != PAPI_OK) {
       printf("Failed call to PAPI_enum_cmp_event: %d\n", retval);
       return retval;
    }   

    retval = PAPI_num_cmp_hwctrs(cmpIdx);
    if (retval < PAPI_OK) {
        printf("Failed call to PAPI_num_cmp_hwctrs: %d\n", retval);
        return retval;
    }   
    printf("Component hw ctrs: %d\n", retval);

    PAPI_event_info_t info;
    retval = PAPI_get_event_info(i, &info);
    if (retval != PAPI_OK) {
       printf("Failed call to PAPI_get_event_info: %d\n", retval);
       return retval;
    }   

    printf("Event Code: %u\n", info.event_code);
    printf("Symbol: %s\n", info.symbol);
    printf("Short Descr: %s\n", info.short_descr);
    printf("Long Descr: %s\n", info.long_descr);
    printf("Component Index: %d\n", info.component_index);
    printf("Units: %s\n", info.units);
    printf("Location: %d\n", info.location);
    printf("Data Type: %d\n", info.data_type);
    printf("Value Type: %d\n", info.value_type);
    printf("Time Scope: %d\n", info.timescope);
    printf("Update Type: %d\n", info.update_type);
    printf("Update Freq: %d\n", info.update_freq);
    printf("Count: %u\n", info.count);
    printf("Event Type: %u\n", info.event_type);
    printf("Derived: %s\n", info.derived);
    printf("Postfix: %s\n", info.postfix);
    for (int i = 0; i < 12; i++) {
        printf("Code: %u\n", info.code[i] );
        printf("Name: %s\n", info.name[i]);
    }   
    printf("Note: %s\n", info.note);

    PAPI_shutdown();

    return 0;
}

```


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
