### PR TITLE
ROCM: PAPI_strerror() cannot be used at shutdown.

### DIFF
--- a/src/components/rocm/rocm.c
+++ b/src/components/rocm/rocm.c
@@ -261,7 +261,7 @@ rocm_shutdown_component(void)
     }
 
   fn_exit:
-    SUBDBG("EXIT: %s\n", PAPI_strerror(papi_errno));
+    SUBDBG("EXIT\n");
     return papi_errno;
   fn_fail:
     _rocm_vector.cmp_info.initialized = orig_state;


### PR DESCRIPTION
## Pull Request Description


## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
