### PR TITLE
rocm: Update the component README.md to account for new limitations.

### DIFF
--- a/src/components/rocm/README.md
+++ b/src/components/rocm/README.md
@@ -75,6 +75,11 @@ setting the ROCP\_TOOL\_LIB to the PAPI library as follows:
 
 ## Known Limitations
 
+* The `rocm` component is deprecated starting at the AMD Instinct MI300A and will continue to be for any future AMD device releases.
+  Please instead use the [`rocp_sdk`](https://github.com/icl-utk-edu/papi/blob/master/src/components/rocp_sdk/README.md) component.
+
+* For AMD devices older than the AMD Instinct MI300A, PAPI should not be configured with both `rocm` and `rocp_sdk`.
+
 * PAPI may read zeros for many events if rocprofiler environment variables are
   not exported and HIP functions are executed by the user before the user
   executes PAPI\_library\_init().


### PR DESCRIPTION
## Pull Request Description
This PR updates the `rocm` component `README.md` with two new limitations which can be seen below:

1. The `rocm` component is deprecated starting at the AMD Instinct MI300A and will continue to be for any future AMD device releases. Please instead use the [`rocp_sdk`](https://github.com/icl-utk-edu/papi/blob/master/src/components/rocp_sdk/README.md) component.
2. For AMD devices older than the AMD Instinct MI300A, PAPI should not be configured with both `rocm` and `rocp_sdk`.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
