### PR TITLE
intel_gpu: Remove -DDEBUG from Rules.intel_gpu

### DIFF
--- a/src/components/intel_gpu/Rules.intel_gpu
+++ b/src/components/intel_gpu/Rules.intel_gpu
@@ -14,7 +14,7 @@ COMPSRCS += $(GPUSRCS) $(GPULIBSRCS)
 GPUOBJS = GPUMetricInterface.o GPUMetricHandler.o linux_intel_gpu_metrics.o
 COMPOBJS += $(GPUOBJS)
 
-CFLAGS += $(LDL) -g -DDEBUG  -I$(GPU_INTERNAL) -I$(GPU_INTERNAL)/inc -D_GLIBCXX_USE_CXX11_ABI=1
+CFLAGS += $(LDL) -g -I$(GPU_INTERNAL) -I$(GPU_INTERNAL)/inc -D_GLIBCXX_USE_CXX11_ABI=1
 LDFLAGS += -ldl
 
 GPUMetricInterface.o:  $(GPU_INTERNAL)/src/GPUMetricInterface.cpp $(GPUHEADER)


### PR DESCRIPTION
## Pull Request Description
In the file `Rules.intel_gpu`, `DEBUG` will be defined as a macro with definition 1. This macro is normally only defined when a user adds `--with-debug={yes, memory}` when configuring PAPI.  Defining the macro `DEBUG` in `Rules.intel_gpu` will cause a users build to act as if they did provide `--with-debug={yes, memory}` when configuring.

For example, in `PAPI_num_events`, the following block of code wrapped in an `ifdef` and `endif` will be triggered when configured with the `intel_gpu` component:
```
int
PAPI_num_events( int EventSet )
{
        APIDBG( "Entry: EventSet: %d\n", EventSet);
        EventSetInfo_t *ESI;

        ESI = _papi_hwi_lookup_EventSet( EventSet );
        if ( !ESI )
                papi_return( PAPI_ENOEVST );

#ifdef DEBUG
        /* Not necessary */
        if ( ESI->NumberOfEvents == 0 )
                papi_return( PAPI_EINVAL );
#endif

        return ( ESI->NumberOfEvents );
}
```

This PR resolves this bug by removing `-DDEBUG` from `Rules.intel_gpu`.

I tested this PR on a machine with an AMD Ryzen 9 7590X and an Intel Arc A770:
    - The above `#ifdef` and `#endif` now does not trigger when configured with the `intel_gpu` component
    - We still are able to trigger the `SUBDBG` messages in the source file `linux_intel_gpu_metrics.c` as `LIBCFLAGS` is already provided in `Rules.intel_gpu`
    - `papi_component_avail`, `papi_native_avail`, and `papi_command_line` work as expected with the `intel_gpu` component

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
