### PR TITLE
framework: force init only if presets avail

### DIFF
--- a/src/papi_internal.c
+++ b/src/papi_internal.c
@@ -2228,15 +2228,16 @@ _papi_hwi_init_global_presets( void )
         }
 
         /* Force initialization of component if needed. */
-        if (_papi_hwd[i]->cmp_info.disabled == PAPI_EDELAY_INIT) {
+        if ( NULL != _papi_hwd[i]->init_comp_presets ) {
+          if ( _papi_hwd[i]->cmp_info.disabled == PAPI_EDELAY_INIT ) {
             int junk;
             _papi_hwd[i]->ntv_enum_events(&junk, PAPI_ENUM_FIRST);
-        }
+          }
 
-        if ( (NULL != _papi_hwd[i]->init_comp_presets) && !is_pe
-              && ( !_papi_hwd[i]->cmp_info.disabled ||
-                    _papi_hwd[i]->cmp_info.disabled == PAPI_EDELAY_INIT ) ) {
+          if ( !is_pe && ( !_papi_hwd[i]->cmp_info.disabled ||
+               _papi_hwd[i]->cmp_info.disabled == PAPI_EDELAY_INIT ) ) {
                 retval = _papi_hwd[i]->init_comp_presets();
+          }
         }
 
         _papi_hwi_start_idx[i] = num_all_presets;


### PR DESCRIPTION
## Pull Request Description

These changes force initialization of components that are configured-in only if they have preset definitions.

These changes have been tested on systems containing:
- the NVIDIA Hopper
- AMD Zen3 CPU and AMD MI250X GPU architectures (Frontier).

This pull request addresses Issue #385.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
