### PR TITLE
sysdetect: Add newline characters to the SUBDBG messages.

### DIFF
--- a/src/components/sysdetect/sysdetect.c
+++ b/src/components/sysdetect/sysdetect.c
@@ -80,7 +80,7 @@ static int
 _sysdetect_init_component( int cidx )
 {
 
-    SUBDBG( "_sysdetect_init_component..." );
+    SUBDBG( "_sysdetect_init_component...\n" );
 
     /* Export the component id */
     _sysdetect_vector.cmp_info.CmpIdx = cidx;
@@ -99,7 +99,7 @@ static int
 _sysdetect_shutdown_component( void )
 {
 
-    SUBDBG( "_sysdetect_shutdown_component..." );
+    SUBDBG( "_sysdetect_shutdown_component...\n" );
 
     cleanup_dev_info( );
 


### PR DESCRIPTION
## Pull Request Description
Currently, if PAPI is configured with `--with-debug=yes` and `PAPI_DEBUG` is set to `SUBSTRATE` then the `sysdetect` component will output `SUBDBG` messages that do not have newline characters for both init and shutdown: 

```
SUBSTRATE:components/sysdetect/sysdetect.c:_sysdetect_init_component:83:190767 _sysdetect_init_component...SUBSTRATE:components/perf_event/perf_event.c:perf_event_dump_attr:342:190767

SUBSTRATE:components/sysdetect/sysdetect.c:_sysdetect_shutdown_component:102:190767 _sysdetect_shutdown_component...Component hw ctrs: 10

```

This PR adds newline characters to the `SUBDBG` messages in `sysdetect` and the output will now appear as:
```
SUBSTRATE:components/sysdetect/sysdetect.c:_sysdetect_init_component:83:242768 _sysdetect_init_component...

SUBSTRATE:components/sysdetect/sysdetect.c:_sysdetect_shutdown_component:102:242768 _sysdetect_shutdown_component...
```

This PR was tested on a machine with an Intel Xeon Gold 6140 CPU.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
