### PR TITLE
framework: force init per existing policy

### DIFF
--- a/src/components/cuda/linux-cuda.c
+++ b/src/components/cuda/linux-cuda.c
@@ -118,7 +118,6 @@ papi_vector_t _cuda_vector = {
 
     .init_thread = cuda_init_thread,
     .shutdown_thread = cuda_shutdown_thread,
-    .init_comp_presets = cuda_init_comp_presets,
 
     .ntv_enum_events = cuda_ntv_enum_events,
     .ntv_code_to_name = cuda_ntv_code_to_name,
@@ -234,7 +233,18 @@ static int cuda_init_private(void)
 static int check_n_initialize(void)
 {
     if (!_cuda_vector.cmp_info.initialized) {
-        return cuda_init_private();
+        int papi_errno = cuda_init_private();
+        if( PAPI_OK != papi_errno ) {
+            return papi_errno;
+        }
+
+        // Setup the presets.
+        papi_errno = cuda_init_comp_presets();
+        if( PAPI_OK != papi_errno ) {
+            return papi_errno;
+        }
+
+        return papi_errno;
     }
     return _cuda_vector.cmp_info.disabled;
 }

--- a/src/papi.c
+++ b/src/papi.c
@@ -588,7 +588,7 @@ extern hwi_presets_t user_defined_events[PAPI_MAX_USER_EVENTS];
 extern int user_defined_events_count;
 extern int num_all_presets;
 extern int _papi_hwi_start_idx[PAPI_NUM_COMP];
-extern int first_comp_idx;
+extern int first_comp_with_presets;
 extern int first_comp_preset_idx;
 
 
@@ -1504,6 +1504,11 @@ PAPI_event_code_to_name( int EventCode, char *out )
         if( compIdx < 0 ) {
             return PAPI_ENOEVNT;
         }
+        if ( _papi_hwd[compIdx]->cmp_info.disabled == PAPI_EDELAY_INIT ) {
+            int junk;
+            _papi_hwd[compIdx]->ntv_enum_events(&junk, PAPI_ENUM_FIRST);
+        }
+
 
 		if (_papi_hwi_comp_presets[compIdx][preset_index].symbol == NULL )
 			papi_return( PAPI_ENOTPRESET );
@@ -1624,6 +1629,12 @@ PAPI_event_name_to_code( const char *in, int *out )
                if ( ( _papi_hwi_list[i].symbol )
                  && ( strcasecmp( _papi_hwi_list[i].symbol, evt_base_name ) == 0) ) {
                      *out = ( int ) ( (i + _papi_hwi_start_idx[cmpnt]) | PAPI_PRESET_MASK );
+
+                     if ( _papi_hwd[cmpnt]->cmp_info.disabled == PAPI_EDELAY_INIT ) {
+                         int junk;
+                         _papi_hwd[cmpnt]->ntv_enum_events(&junk, PAPI_ENUM_FIRST);
+                     }
+
                      preset_idx = i;
                      breakFlag = 1;
                      break;
@@ -1800,6 +1811,11 @@ PAPI_enum_event( int *EventCode, int modifier )
         /* Iterate over all or all available presets. */
         if ( modifier == PAPI_ENUM_EVENTS || modifier == PAPI_PRESET_ENUM_AVAIL ) {
 
+            if ( _papi_hwd[cidx]->cmp_info.disabled == PAPI_EDELAY_INIT ) {
+                int junk;
+                _papi_hwd[cidx]->ntv_enum_events(&junk, PAPI_ENUM_FIRST);
+            }
+
             /* NULL pointer used to terminate the list. However, now we have
              * more presets that exist beyond the bounds of the original
              * array, so skip over the NULL entries. */
@@ -1833,6 +1849,12 @@ PAPI_enum_event( int *EventCode, int modifier )
             if( preset_index < 0 ) {
                 return ( PAPI_ENOEVNT );
             }
+
+            if ( _papi_hwd[first_comp_with_presets]->cmp_info.disabled == PAPI_EDELAY_INIT ) {
+                int junk;
+                _papi_hwd[first_comp_with_presets]->ntv_enum_events(&junk, PAPI_ENUM_FIRST);
+            }
+
             *EventCode = ( int ) ( preset_index | PAPI_PRESET_MASK );
             APIDBG("EXIT: *EventCode: %#x\n", *EventCode);
             return ( PAPI_OK );
@@ -2044,6 +2066,11 @@ PAPI_enum_cmp_event( int *EventCode, int modifier, int cidx )
 	}
 
     if ( IS_PRESET(i) ) {
+
+        if ( _papi_hwd[cidx]->cmp_info.disabled == PAPI_EDELAY_INIT ) {
+            int junk;
+            _papi_hwd[cidx]->ntv_enum_events(&junk, PAPI_ENUM_FIRST);
+        }
 
         int preset_index;
         hwi_presets_t *_papi_hwi_list;

--- a/src/papi_preset.c
+++ b/src/papi_preset.c
@@ -26,8 +26,6 @@ extern hwi_presets_t user_defined_events[];
 extern int user_defined_events_count;
 extern int num_all_presets;
 extern int _papi_hwi_start_idx[PAPI_NUM_COMP];
-extern int first_comp_idx;
-extern int first_comp_preset_idx;
 
 static int papi_load_derived_events (char *pmu_str, int pmu_type, int cidx, int preset_flag);
 static int papi_load_derived_events_component (char *comp_str, char *arch_str, int cidx);

--- a/src/papi_vector.c
+++ b/src/papi_vector.c
@@ -144,9 +144,6 @@ _papi_hwi_innoculate_vector( papi_vector_t * v )
 		v->init_component = ( int ( * )( int ) ) vec_int_ok_dummy;
 	if ( !v->init_thread )
 		v->init_thread = ( int ( * )( hwd_context_t * ) ) vec_int_ok_dummy;
-	if ( !v->init_comp_presets ) {
-		v->init_comp_presets = ( int ( * )( void ) ) vec_int_ok_dummy;
-    }
 	if ( !v->init_control_state )
 		v->init_control_state =
 			( int ( * )( hwd_control_state_t * ptr ) ) vec_int_dummy;

--- a/src/papi_vector.h
+++ b/src/papi_vector.h
@@ -35,7 +35,6 @@ typedef struct papi_vectors {
     int		(*init_component)	(int);										/**< */
     int		(*init_thread)		 (hwd_context_t *);								/**< */
     int		(*init_control_state)	(hwd_control_state_t * ptr);			/**< */
-    int		(*init_comp_presets)     (void);                                /**< */
     int		(*update_control_state)	(hwd_control_state_t *, NativeInfo_t *, int, hwd_context_t *);	/**< */
     int		(*ctl)			(hwd_context_t *, int , _papi_int_option_t *);	/**< */
     int		(*set_overflow)		(EventSetInfo_t *, int, int);				/**< */


### PR DESCRIPTION
## Pull Request Description

PR #284 introduced code that always forced the initialization of all components. However, this defeats the purpose of having PAPI_EDELAY_INIT.

The changes in this pull request only force initialization of components when necessary.

These changes have been tested on systems containing:
- NVIDIA Hopper architecture
- AMD Zen3 CPU and AMD MI250X GPU architectures (Frontier).

This pull request addresses Issue #385.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
