### PR TITLE
cuda/rocm components: Restructure update_native_events to not call realloc on a size of 0

### DIFF
--- a/src/components/cuda/linux-cuda.c
+++ b/src/components/cuda/linux-cuda.c
@@ -459,14 +459,19 @@ int update_native_events(cuda_control_t *ctl, NativeInfo_t *ntv_info,
     struct event_map_item sorted_events[PAPI_CUDA_MAX_COUNTERS];
 
     if (ntv_count != ctl->num_events) {
-        ctl->events_id = realloc(ctl->events_id,
-                                      ntv_count * sizeof(*ctl->events_id));
-        if (ctl->events_id == NULL) {
-            papi_errno = PAPI_ENOMEM;
-            goto fn_fail;
-        }
-
         ctl->num_events = ntv_count;
+        if (ntv_count == 0) {
+            free(ctl->events_id);
+            ctl->events_id = NULL;
+            goto fn_exit;
+        }
+        else {
+            ctl->events_id = realloc(ctl->events_id, ntv_count * sizeof(*ctl->events_id));
+            if (ctl->events_id == NULL) {
+                papi_errno = PAPI_ENOMEM;
+                goto fn_fail;
+            }
+        }
     }
 
     int i;

--- a/src/components/rocm/rocm.c
+++ b/src/components/rocm/rocm.c
@@ -403,14 +403,19 @@ update_native_events(rocm_control_t *ctl, NativeInfo_t *ntv_info,
     struct event_map_item sorted_events[PAPI_ROCM_MAX_COUNTERS];
 
     if (ntv_count != ctl->num_events) {
-        ctl->events_id = papi_realloc(ctl->events_id,
-                                      ntv_count * sizeof(*ctl->events_id));
-        if (ctl->events_id == NULL) {
-            papi_errno = PAPI_ENOMEM;
-            goto fn_fail;
-        }
-
         ctl->num_events = ntv_count;
+        if (ntv_count == 0) {
+            papi_free(ctl->events_id);
+            ctl->events_id = NULL;
+            goto fn_exit;
+        }
+        else {
+            ctl->events_id = papi_realloc(ctl->events_id, ntv_count * sizeof(*ctl->events_id));
+            if (ctl->events_id == NULL) {
+                papi_errno = PAPI_ENOMEM;
+                goto fn_fail;
+            }
+        }
     }
 
     int i;

--- a/src/components/template/template.c
+++ b/src/components/template/template.c
@@ -239,12 +239,19 @@ update_native_events(templ_control_t *ctl, NativeInfo_t *ntv_info, int ntv_count
     int papi_errno = PAPI_OK;
 
     if (ntv_count != ctl->num_events) {
-        ctl->events_id = papi_realloc(ctl->events_id, ntv_count * sizeof(*ctl->events_id));
-        if (NULL == ctl->events_id) {
-            papi_errno = PAPI_ENOMEM;
-            goto fn_fail;
-        }
         ctl->num_events = ntv_count;
+        if (ntv_count == 0) {
+            papi_free(ctl->events_id);
+            ctl->events_id = NULL;
+            goto fn_exit;
+        }
+        else {
+            ctl->events_id = papi_realloc(ctl->events_id, ntv_count * sizeof(*ctl->events_id));
+            if (ctl->events_id == NULL) {
+                papi_errno = PAPI_ENOMEM;
+                goto fn_fail;
+            }
+        }
     }
 
     int i;


### PR DESCRIPTION
## Pull Request Description
This PR updates the function `update_native_events` in the `rocm` and `cuda` components such that `realloc` is not called on a size of 0. As when `realloc` is called on a size of 0 the behavior is implementation defined.

This edge case can occur in the following workflow: 
```
#include "papi.h"

#include <stdio.h>
#include <stdlib.h>

int main() {
    int retval = PAPI_library_init(PAPI_VER_CURRENT);
    if (retval != PAPI_VER_CURRENT) {
        printf("Call to PAPI_library_init: %d\n", PAPI_ENOINIT);
        exit(1);
    }   

    retval = PAPI_get_component_index("rocm");
    if (retval < PAPI_OK) {
        printf("Call to PAPI_get_component_index failed: %d\n", retval);
        exit(1);
    }   

    int cmpIdx = 2;
    int i = 0 | PAPI_NATIVE_MASK;
    retval = PAPI_enum_cmp_event( &i, PAPI_ENUM_FIRST, cmpIdx);
    if (retval != PAPI_OK) {
       printf("Call to PAPI_enum_cmp_event failed: %d\n", retval);
       exit(1);
    }   

    int EventSet = PAPI_NULL;
    retval = PAPI_create_eventset(&EventSet);
    if (retval != PAPI_OK) {
        printf("Call to PAPI_create_eventset failed: %d\n", retval);
        exit(1);
    }   

    retval = PAPI_add_event(EventSet, i); 
    if (retval != PAPI_OK) {
        printf("Call to PAPI_add_event failed (1): %d\n", retval);
        exit(1);
    }   

    retval = PAPI_num_events(EventSet);
    if (retval < PAPI_OK) {
        printf("Call to PAPI_num_events failed (1): %d\n", retval);
        exit(1);
    }   
    printf("First call to PAPI_num_events: %d\n", retval);

    retval = PAPI_remove_event(EventSet, i); // In the master branch this call will fail in the Rocm component
    if (retval != PAPI_OK) {
        printf("Call to PAPI_remove_event failed: %d\n", retval);
        exit(1);
    }   

    retval = PAPI_num_events(EventSet);
    if (retval < PAPI_OK) {
        printf("Call to PAPI_num_events failed (2): %d\n", retval);
        exit(1);
    }   
    printf("Second call to PAPI_num_events: %d\n", retval);


    retval = PAPI_add_event(EventSet, i); 
    if (retval != PAPI_OK) {
        printf("Call to PAPI_add_event failed (2): %d\n", retval);
        exit(1);
    }   

    retval = PAPI_num_events(EventSet);
    if (retval < PAPI_OK) {
        printf("Call to PAPI_num_events failed (3): %d\n", retval);
        exit(1);
    }   
    printf("Final call to PAPI_num_events: %d\n", retval);

    PAPI_shutdown();

    return 0;
}
```

Note: I was unable to trigger the same failure at `PAPI_remove_event` for the Cuda component as I did for the ROCm component in the above workflow. However, I chose to update the Cuda component still.

This PR was tested on a machine with an AMD EPYC 7413 24-Core Processor with 1 * NVIDIA H100 (Cuda Toolkit 12.6.3) and 2 * AMD MI210s (ROCm 6.4.0).

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
