### PR TITLE
intel_gpu: update environment variable name

### DIFF
--- a/src/components/intel_gpu/README.md
+++ b/src/components/intel_gpu/README.md
@@ -34,7 +34,7 @@ It is requred to build with Intel oneAPI Level Zero header files. The directory 
 
 * To enable metrics query on an kernel
 	```sh 
-    ZET_ENABLE_API_TRACING_EXP=1
+    ZE_ENABLE_TRACING_LAYER=1
 	```
 
 ## Metric collection mode:
@@ -42,7 +42,7 @@ It is requred to build with Intel oneAPI Level Zero header files. The directory 
 Two metrics collection modes are supported.
 
 * Time based sampling. In this mode, data collection and app can run in separate processes. 
-* Metrics query on a kernel. In this mode,  the PAPI_start() and PAPI_stop must be called before kernel launch and after kernel execution completes. When setting ZET_ENABLE_API_TRACING_EXP=1,  the collection will switch to metrics query mode.
+* Metrics query on a kernel. In this mode,  the PAPI_start() and PAPI_stop must be called before kernel launch and after kernel execution completes. When setting ZE_ENABLE_TRACING_LAYER=1,  the collection will switch to metrics query mode.
 
 ## Metrics:
 


### PR DESCRIPTION
## Pull Request Description
On a system containing the Intel Arc A770 device, I am met with the following warning:

ZET_ENABLE_API_TRACING_EXP is deprecated. Use ZE_ENABLE_TRACING_LAYER instead.

The current README states to set ZET_ENABLE_API_TRACING_EXP; however, ZE_ENABLE_TRACING_LAYER is the correct variable to set. Setting ZE_ENABLE_TRACING_LAYER prevents the above warning.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
