### PR TITLE
rocp_sdk: In the tests Makefile account for CPU agents on amd64

### DIFF
--- a/src/components/rocp_sdk/tests/Makefile
+++ b/src/components/rocp_sdk/tests/Makefile
@@ -10,7 +10,7 @@ CFLAGS    = $(OPTFLAGS)
 CPPFLAGS += $(INCLUDE) $(ROCP_SDK_INCL)
 LDFLAGS  += $(PAPILIB) $(TESTLIB) $(UTILOBJS)
 
-GPUARCH = $(shell rocm_agent_enumerator 2>/dev/null | head -1)
+GPUARCH = $(shell rocm_agent_enumerator 2>/dev/null | grep -v "gfx000" | head -1)
 ifneq ($(GPUARCH),)
     ARCHFLAG=--offload-arch=$(GPUARCH)
 endif


### PR DESCRIPTION
## Pull Request Description
When configuring PAPI with the `rocp_sdk` component on the following machine (Pinwheel at Oregon):
    - CPU: AMD EPYC 7513 32-Core Processor
    - GPUs: 2 * AMD MI210s
    - OS: Debian 12
    - Kernel: 6.12.12+bpo-amd64

Upon running `make` the following error occurs:
```
+ make -C components/rocp_sdk/tests
make[2]: Entering directory '/storage/users/tburgess/papi_fork/papi/src/components/rocp_sdk/tests'
gcc -I. -I../../.. -I../../../testlib -I../../../validation_tests -I/home/users/tburgess/papi_fork/papi/src/test-install/include -I/opt/rocm-6.4.0/include -I/opt/rocm-6.4.0/include/hsa -I/opt/rocm-6.4.0/hsa/include -O2 -O2 -D__HIP_PLATFORM_AMD__ -c -o simple.o simple.c
amdclang++ -D__HIP_ROCclr__=1 -O2 -g -DNDEBUG --offload-arch=gfx000 -W -Wall -Wextra -Wshadow -o kernel.o -x hip -c kernel.cpp
gcc -DPAPI_NUM_COMP=4 -O2  -o papi_xml_event_info papi_xml_event_info.o ../libpapi.a -lstdc++ -pthread  
clang++: error: invalid target ID 'gfx000'; format is a processor name followed by an optional colon-delimited list of features followed by an enable/disable sign (e.g., 'gfx908:sramecc+:xnack-')
make[2]: *** [Makefile:26: kernel.o] Error 1
make[2]: Leaving directory '/storage/users/tburgess/papi_fork/papi/src/components/rocp_sdk/tests'
make[1]: *** [Makefile.inc:266: comp_tests] Error 2
```

`gfx000` corresponds to the CPU agent as mentioned [here](https://rocm.docs.amd.com/projects/rocminfo/en/latest/how-to/use-rocm-agent-enumerator.html) by AMD. Looking into this issue more, there is a mention of similar behavior [here](https://bugs.gentoo.org/936865). In the post they mention `amd64` which is the kernel for `Pinwheel`.

This PR updates the `GPUARCH` assignment in `rocp_sdk/tests/Makefile` to ignore the CPU agent:
```
GPUARCH = $(shell rocm_agent_enumerator 2>/dev/null | grep -v "gfx000" | head -1)
```

Testing: 
 - On the machine Pinwheel, I am now able to fully build PAPI with the `rocp_sdk` component. 
    - Note, when I tried to run the utility `papi_component_avail` it states: `Disabled: hsa_init() failed. Possibly no AMD GPUs present` for the `rocp_sdk` component. This does not appear to be a PAPI issue as a standalone reproducer of `hsa_init()` encountered the same issue.
 - On Gilgamesh at Oregon (AMD EPYC 7413 24-Core Processor, 2 * MI210s) using ROCm 6.4.0:
     - PAPI utilities were successful
     - `rocp_sdk` tests were successful

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
