### PR TITLE
rocm/rocm_smi: Allow users to optionally set HIPCC

### DIFF
--- a/src/components/rocm/tests/Makefile
+++ b/src/components/rocm/tests/Makefile
@@ -2,7 +2,7 @@ NAME = rocm
 include ../../Makefile_comp_tests.target
 PAPI_ROCM_ROOT ?= /opt/rocm
 
-HIPCC    = $(shell find $(PAPI_ROCM_ROOT) -iname hipcc | grep bin | head -n 1)
+HIPCC    ?= $(shell find $(PAPI_ROCM_ROOT) -iname hipcc | grep bin | head -n 1)
 CC       = $(HIPCC)
 CXX      = $(HIPCC)
 CPPFLAGS+= -I$(PAPI_ROCM_ROOT)/include          \

--- a/src/components/rocm_smi/tests/Makefile
+++ b/src/components/rocm_smi/tests/Makefile
@@ -4,16 +4,16 @@
 NAME=rocm_smi
 include ../../Makefile_comp_tests.target
 PAPI_ROCM_ROOT ?= /opt/rocm
-HIP_PATH= ${PAPI_ROCM_ROOT}
-HIPCC=$(HIP_PATH)/bin/hipcc
+HIPCC ?= $(PAPI_ROCM_ROOT)/bin/hipcc
 
+INCLUDE += -I$(PAPI_ROCMSMI_ROOT)/include
 INCLUDE += -I$(PAPI_ROCM_ROOT)/include
 INCLUDE += -I$(PAPI_ROCM_ROOT)/include/rocm_smi
 INCLUDE += -I$(PAPI_ROCM_ROOT)/include/hip
 INCLUDE += -I$(PAPI_ROCM_ROOT)/include/hsa
 INCLUDE += -I$(PAPI_ROCM_ROOT)/include/rocprofiler
 INCLUDE += -I$(PAPI_ROCM_ROOT)/include/rocblas
-LDFLAGS = -ldl -g -L$(PAPI_ROCM_ROOT)/lib/rocblas -lrocblas -pthread
+LDFLAGS = -ldl -g -pthread
 
 %.o:%.c
 	@echo "INCLUDE=" $(INCLUDE)
@@ -24,9 +24,11 @@ LDFLAGS = -ldl -g -L$(PAPI_ROCM_ROOT)/lib/rocblas -lrocblas -pthread
 	@echo "CFLAGS=" $(CFLAGS)
 	g++ $(CFLAGS) $(OPTFLAGS) $(INCLUDE) -c -o $@ $<
 
-TESTS = rocm_command_line rocm_smi_all power_monitor_rocm rocmsmi_example rocm_smi_writeTests
+TESTS = rocm_command_line rocm_smi_all power_monitor_rocm rocm_smi_writeTests
+TESTS_LONG = rocmsmi_example
 
 rocm_smi_tests: $(TESTS)
+rocm_smi_tests_long: $(TESTS_LONG)
 
 # Note: We compile .o separately from the executable link; some versions of hipcc
 #       have trouble managing libraries if we try to do both in a single step.
@@ -53,7 +55,7 @@ rocmsmi_example.o: rocmsmi_example.cpp $(UTILOBJS) $(PAPILIB)
 	$(HIPCC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 rocmsmi_example: rocmsmi_example.o $(UTILOBJS) $(PAPILIB)
-	$(HIPCC) $(CFLAGS) $(INCLUDE) -o $@ $< $(UTILOBJS) $(PAPILIB) $(LDFLAGS) -lpthread
+	$(HIPCC) $(CFLAGS) $(INCLUDE) -o $@ $< $(UTILOBJS) $(PAPILIB) $(LDFLAGS) -L$(PAPI_ROCM_ROOT)/lib/rocblas -lrocblas
 
 rocm_smi_writeTests.o: rocm_smi_writeTests.cpp $(UTILOBJS) $(PAPILIB)
 	$(HIPCC) $(CFLAGS) $(INCLUDE) -c $< -o $@
@@ -62,7 +64,7 @@ rocm_smi_writeTests: rocm_smi_writeTests.o $(UTILOBJS) $(PAPILIB)
 	$(HIPCC) $(CFLAGS) $(INCLUDE) -o $@ $< $(UTILOBJS) $(PAPILIB) $(LDFLAGS)
 
 clean:
-	rm -f $(TESTS) *.o
+	rm -f $(TESTS) $(TESTS_LONG) *.o
 
 checkpath: 
 	echo PAPI_ROCM_ROOT = $(PAPI_ROCM_ROOT)


### PR DESCRIPTION
## Pull Request Description
This PR addresses the following two items:

1. For both `rocm` and `rocm_smi` this PR allows users to optionally set `HIPCC` for `tests/Makefile` if it is not found in the path designed by the environment variable `PAPI_ROCM_ROOT`.
2. For `rocm_smi`, the test `rocmsmi_example.cpp` becomes an optional test. This is being done as the test requires `rocblas` which is one of the longest to build packages in spack. For more information, please see Geri's comment [here](https://github.com/icl-utk-edu/papi/pull/388#issuecomment-2917126368).

I tested both of these changes on Gilgamesh at Oregon (2 * Instinct MI210s) with ROCm 6.1.3, results are below:

- For item **1.**, I was able to optionally set `HIPCC` for both `rocm/tests/Makefile` and `rocm_smi/tests/Makefile`.
- For item **2.**,  `rocmsmi_example.cpp` was not compiled unless `make rocmsmi_example` or `make rocm_smi_tests_long` were ran on the command line. 
- For both components, `papi_component_avail`, `papi_native_avail`, and `papi_command_line` all ran successfully. 

Thanks to Gerald Ragghianti for these changes. 

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
