### PR TITLE
framework: correct PAPI_PRESET_ENUM_AVAIL behavior

### DIFF
--- a/src/papi.c
+++ b/src/papi.c
@@ -1811,15 +1811,18 @@ PAPI_enum_event( int *EventCode, int modifier )
         /* Iterate over all or all available presets. */
         if ( modifier == PAPI_ENUM_EVENTS || modifier == PAPI_PRESET_ENUM_AVAIL ) {
 
-            if ( _papi_hwd[cidx]->cmp_info.disabled == PAPI_EDELAY_INIT ) {
-                int junk;
-                _papi_hwd[cidx]->ntv_enum_events(&junk, PAPI_ENUM_FIRST);
-            }
-
             /* NULL pointer used to terminate the list. However, now we have
              * more presets that exist beyond the bounds of the original
              * array, so skip over the NULL entries. */
             do {
+                cidx = _papi_hwi_component_index( (int)(i | PAPI_PRESET_MASK) );
+                if (cidx < 0) return PAPI_ENOCMP;
+                if ( _papi_hwd[cidx]->cmp_info.disabled == PAPI_EDELAY_INIT ) {
+                    fprintf(stdout, "Having to run check again.\n");
+                    int junk;
+                    _papi_hwd[cidx]->ntv_enum_events(&junk, PAPI_ENUM_FIRST);
+                }
+
                 if ( ++i >= num_all_presets ) {
                     return ( PAPI_EINVAL );
                 }


### PR DESCRIPTION
## Pull Request Description

Commit 60065f5 introduced changes to address improper PAPI_EDELAY_INIT behavior. However, this causes improper behavior of the PAPI_PRESET_ENUM_AVAIL modifier in certain cases. These changes correct this behavior.

These changes were tested on the NVIDIA GH200 480GB device.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
