### PR TITLE
2025.07.07 rocm_smi command line

### DIFF
--- a/src/components/rocm_smi/tests/Makefile
+++ b/src/components/rocm_smi/tests/Makefile
@@ -24,7 +24,7 @@ LDFLAGS = -ldl -g -pthread
 	@echo "CFLAGS=" $(CFLAGS)
 	g++ $(CFLAGS) $(OPTFLAGS) $(INCLUDE) -c -o $@ $<
 
-TESTS = rocm_command_line rocm_smi_all power_monitor_rocm rocm_smi_writeTests
+TESTS = rocm_smi_command_line rocm_smi_all power_monitor_rocm rocm_smi_writeTests
 TESTS_LONG = rocmsmi_example
 
 rocm_smi_tests: $(TESTS)
@@ -33,10 +33,10 @@ rocm_smi_tests_long: $(TESTS_LONG)
 # Note: We compile .o separately from the executable link; some versions of hipcc
 #       have trouble managing libraries if we try to do both in a single step.
 
-rocm_command_line.o: rocm_command_line.cpp $(UTILOBJS) $(PAPILIB)
+rocm_smi_command_line.o: rocm_smi_command_line.cpp $(UTILOBJS) $(PAPILIB)
 	$(HIPCC) $(CFLAGS) $(INCLUDE) -c $< -o $@ 
 
-rocm_command_line: rocm_command_line.o $(UTILOBJS) $(PAPILIB)
+rocm_smi_command_line: rocm_smi_command_line.o $(UTILOBJS) $(PAPILIB)
 	$(HIPCC) $(CFLAGS) $(INCLUDE) -o $@ $< $(UTILOBJS) $(PAPILIB) $(LDFLAGS) 
 
 rocm_smi_all.o: rocm_smi_all.cpp $(UTILOBJS) $(PAPILIB)

--- a/src/components/rocm_smi/tests/rocm_command_line.cpp
+++ b/src/components/rocm_smi/tests/rocm_command_line.cpp
@@ -161,6 +161,13 @@ main( int argc, char **argv )
     printf( "\nThis utility lets you add events from the command line "
         "interface to see if they work.\n\n" );
 
+    if ( argc < 2 ) {
+        printf("No events specified!\n");
+        printf("Specify events like rocm_smi:::device=0:mem_usage_VRAM rocm_smi:::device=0:pci_throughput_sent\n");
+        printf("Use papi/src/utils/papi_native_avail for a list of all events; search for 'rocm_smi:::'.\n");
+        exit(-1);
+    }
+
     retval = PAPI_library_init( PAPI_VER_CURRENT );
     if (retval != PAPI_VER_CURRENT ) {
         fprintf(stderr,"Error! PAPI_library_init\n");
@@ -239,14 +246,6 @@ main( int argc, char **argv )
                 printf( "Successfully added: %s\n", argv[i] );
             }
         }
-    }
-
-    /* Automatically pass if no events, for run_tests.sh */
-    if ( num_events == 0 ) {
-        printf("No events specified!\n");
-        printf("Specify events like rocm_smi:::device=0:mem_usage_VRAM rocm_smi:::device=0:pci_throughput_sent\n");
-        printf("Use papi/src/utils/papi_native_avail for a list of all events; search for 'rocm_smi:::'.\n");
-        return 0;
     }
 
    // ROCM Activity.

--- a/src/components/rocm_smi/tests/rocm_smi_command_line.cpp
+++ b/src/components/rocm_smi/tests/rocm_smi_command_line.cpp
@@ -1,6 +1,6 @@
 #define __HIP_PLATFORM_HCC__
 
-/* file rocm_command_line.c
+/* file rocm_smi_command_line.c
  * Nearly identical to "papi/src/utils/papi_command_line.c". 
  * This simply tries to add the events listed on the command line,
  * all into a single event set. It will then conduct a test using


### PR DESCRIPTION
## Pull Request Description

- Places the check (for whether or not command-line arguments were given) earlier in the code to avoid a core dump.

- Changes the name of the component test 'rocm_command_line' to 'rocm_smi_command_line' to align with the name of the component being 'rocm_smi'.

These changes have been tested on the Frontier supercomputer, which contains the AMD MI250X architecture, using ROCm version 6.4.0.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
