### PR TITLE
papi_avail.c: Move print statement for final format line to output even if only the default components are configured

### DIFF
--- a/src/utils/papi_avail.c
+++ b/src/utils/papi_avail.c
@@ -788,9 +788,6 @@ main( int argc, char **argv )
               }
             }
           } while (PAPI_enum_event( &event_code, print_avail_only ) == PAPI_OK);
-
-        printf( "================================================================================\n" );
-
     }
 
 
@@ -798,6 +795,7 @@ main( int argc, char **argv )
   }
       }
 
+    printf( "================================================================================\n" );
     if ( !print_event_info ) {
         if ( print_avail_only == PAPI_PRESET_ENUM_CPU_AVAIL || print_avail_only == PAPI_PRESET_ENUM_AVAIL ) {
             printf( "Of %d available events, %d ", avail_count, deriv_count );


### PR DESCRIPTION
## Pull Request Description
Currently in the master branch if PAPI is configured as follows: `./configure --prefix=$PWD/test-install`. `papi_avail` will have the following output:
```
.
.
.
PAPI_VEC_SP  0x80000069  Yes   Yes  Single precision vector/SIMD instructions
PAPI_VEC_DP  0x8000006a  Yes   Yes  Double precision vector/SIMD instructions
PAPI_REF_CYC 0x8000006b  Yes   No   Reference clock cycles
Of 108 possible events, 59 are available, of which 18 are derived.
```

This PR updates `papi_avail.c` to print the final format line even in the case that PAPI is only configured with the default components.

## Testing
Testing was done on a machine with an Intel Xeon Gold 6140 with 1 * A100 using Cuda Toolkit 12.6.

`./papi_avail` with `./configure --prefix=$PWD/test-install`:
```
.
.
.
PAPI_VEC_SP  0x80000069  Yes   Yes  Single precision vector/SIMD instructions
PAPI_VEC_DP  0x8000006a  Yes   Yes  Double precision vector/SIMD instructions
PAPI_REF_CYC 0x8000006b  Yes   No   Reference clock cycles
================================================================================
Of 108 possible events, 59 are available, of which 18 are derived.
```

`./papi_avail` with `./configure --prefix=$PWD/test-install --with-components="cuda"`:
```
.
.
.
--------------------------------------------------------------------------------
PAPI_CUDA_FP64_FMA 0x80000083  Yes   No   CUDA Double precision (FP64) FMA instructions
    :stat=sum
        Mandatory stat qualifier [avg, max, min, sum]
    :device=0
        Mandatory device qualifier [0]
--------------------------------------------------------------------------------
PAPI_CUDA_FP_FMA   0x80000084  Yes   Yes  CUDA floating-point FMA instructions
    :stat=sum
        Mandatory stat qualifier [avg, max, min, sum]
    :device=0
        Mandatory device qualifier [0]
--------------------------------------------------------------------------------
PAPI_CUDA_FP8_OPS  0x80000085  No    No   CUDA 8-bit precision floating-point operations
================================================================================
Of 114 possible events, 64 are available, of which 19 are derived.
```


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
