### PR TITLE
rocm_smi: Update tests/Makefile to properly link with existing LDFLAGS e.g. -lrt

### DIFF
--- a/src/components/rocm_smi/tests/Makefile
+++ b/src/components/rocm_smi/tests/Makefile
@@ -13,7 +13,7 @@ INCLUDE += -I$(PAPI_ROCM_ROOT)/include/hip
 INCLUDE += -I$(PAPI_ROCM_ROOT)/include/hsa
 INCLUDE += -I$(PAPI_ROCM_ROOT)/include/rocprofiler
 INCLUDE += -I$(PAPI_ROCM_ROOT)/include/rocblas
-LDFLAGS = -ldl -g -pthread
+ROCM_SMI_LDFLAGS := $(LDFLAGS) -ldl -g -pthread
 
 %.o:%.c
 	@echo "INCLUDE=" $(INCLUDE)
@@ -37,31 +37,31 @@ rocm_command_line.o: rocm_command_line.cpp $(UTILOBJS) $(PAPILIB)
 	$(HIPCC) $(CFLAGS) $(INCLUDE) -c $< -o $@ 
 
 rocm_command_line: rocm_command_line.o $(UTILOBJS) $(PAPILIB)
-	$(HIPCC) $(CFLAGS) $(INCLUDE) -o $@ $< $(UTILOBJS) $(PAPILIB) $(LDFLAGS) 
+	$(HIPCC) $(CFLAGS) $(INCLUDE) -o $@ $< $(UTILOBJS) $(PAPILIB) $(ROCM_SMI_LDFLAGS)
 
 rocm_smi_all.o: rocm_smi_all.cpp $(UTILOBJS) $(PAPILIB)
 	$(HIPCC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 rocm_smi_all: rocm_smi_all.o $(UTILOBJS) $(PAPILIB)
-	$(HIPCC) $(CFLAGS) $(INCLUDE) -o $@ $< $(UTILOBJS) $(PAPILIB) $(LDFLAGS) 
+	$(HIPCC) $(CFLAGS) $(INCLUDE) -o $@ $< $(UTILOBJS) $(PAPILIB) $(ROCM_SMI_LDFLAGS)
 
 power_monitor_rocm.o: power_monitor_rocm.cpp $(UTILOBJS) $(PAPILIB)
 	$(HIPCC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 power_monitor_rocm: power_monitor_rocm.o $(UTILOBJS) $(PAPILIB)
-	$(HIPCC) $(CFLAGS) $(INCLUDE) -o $@ $< $(UTILOBJS) $(PAPILIB) $(LDFLAGS) 
+	$(HIPCC) $(CFLAGS) $(INCLUDE) -o $@ $< $(UTILOBJS) $(PAPILIB) $(ROCM_SMI_LDFLAGS)
 
 rocmsmi_example.o: rocmsmi_example.cpp $(UTILOBJS) $(PAPILIB)
 	$(HIPCC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 rocmsmi_example: rocmsmi_example.o $(UTILOBJS) $(PAPILIB)
-	$(HIPCC) $(CFLAGS) $(INCLUDE) -o $@ $< $(UTILOBJS) $(PAPILIB) $(LDFLAGS) -L$(PAPI_ROCM_ROOT)/lib/rocblas -lrocblas
+	$(HIPCC) $(CFLAGS) $(INCLUDE) -o $@ $< $(UTILOBJS) $(PAPILIB) $(ROCM_SMI_LDFLAGS) -L$(PAPI_ROCM_ROOT)/lib/rocblas -lrocblas
 
 rocm_smi_writeTests.o: rocm_smi_writeTests.cpp $(UTILOBJS) $(PAPILIB)
 	$(HIPCC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 rocm_smi_writeTests: rocm_smi_writeTests.o $(UTILOBJS) $(PAPILIB)
-	$(HIPCC) $(CFLAGS) $(INCLUDE) -o $@ $< $(UTILOBJS) $(PAPILIB) $(LDFLAGS)
+	$(HIPCC) $(CFLAGS) $(INCLUDE) -o $@ $< $(UTILOBJS) $(PAPILIB) $(ROCM_SMI_LDFLAGS)
 
 clean:
 	rm -f $(TESTS) $(TESTS_LONG) *.o
@@ -71,6 +71,6 @@ checkpath:
 	echo HIP_PATH = $(HIP_PATH)
 	echo HIPCC = $(HIPCC)
 	echo INCLUDE = $(INCLUDE)
-	echo LDFLAGS = $(LDFLAGS)
+	echo ROCM_SMI_LDFLAGS = $(ROCM_SMI_LDFLAGS)
 	echo CFLAGS = $(CFLAGS)
 


### PR DESCRIPTION
## Pull Request Description
Currently in the master branch if you configure PAPI as follows: `./configure --prefix=$PWD/test-install --with-components="sde rocm_smi"` you will run into the below linker error:
```
ld.lld: error: undefined symbol: timer_create
>>> referenced by sde.c:729 (components/sde/sde.c:729)
>>>               sde.o:(do_set_timer_for_overflow) in archive ../../../libpapi.a

ld.lld: error: undefined symbol: timer_delete
>>> referenced by sde.c:688 (components/sde/sde.c:688)
>>>               sde.o:(_sde_set_overflow) in archive ../../../libpapi.a
>>> referenced by sde.c:846 (components/sde/sde.c:846)
>>>               sde.o:(_sde_dispatch_timer) in archive ../../../libpapi.a
>>> referenced by sde.c:288 (components/sde/sde.c:288)
>>>               sde.o:(_sde_stop) in archive ../../../libpapi.a
>>> referenced 2 more times

ld.lld: error: undefined symbol: timer_gettime
>>> referenced by sde.c:866 (components/sde/sde.c:866)
>>>               sde.o:(_sde_dispatch_timer) in archive ../../../libpapi.a

ld.lld: error: undefined symbol: timer_settime
>>> referenced by sde.c:895 (components/sde/sde.c:895)
>>>               sde.o:(_sde_dispatch_timer) in archive ../../../libpapi.a
>>> referenced by sde.c:844 (components/sde/sde.c:844)
>>>               sde.o:(_sde_dispatch_timer) in archive ../../../libpapi.a
>>> referenced by sde.c:286 (components/sde/sde.c:286)
>>>               sde.o:(_sde_stop) in archive ../../../libpapi.a
>>> referenced 2 more times
```

This PR resolves this behavior. 

## Testing
Testing was done on Illyad at Oregon:

- AMD EPYC 7402 24-Core Processor
- 2 * AMD Instinct MI210's
- GCC Version 8.5.0
- ROCm Version 6.4.0

Compilation now completes with the PR change and the PAPI utilities: `papi_component_avail`, `papi_native_avail`, and `papi_command_line` run as expected.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
