### PR TITLE
PAPI CI: Add `rocp_sdk` jobs, improve robustness of checking for expected active components, and add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/papi_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/papi_feature_request.yml
@@ -1,0 +1,22 @@
+name: PAPI Feature Request
+description: Request additional functionality or suggest a new approach to existing functionality
+title: "[Feature Request]: "
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for taking the time to make a feature request!
+  - type: textarea
+    id: feature-request
+    attributes:
+      label: Description of Feature Request
+      description: Describe the feature that you would like to see in PAPI.
+    validations:
+      required: True
+  - type: input
+    id: component
+    attributes:
+      label: Component
+      description: If this is for a specific PAPI component, please mention it here (optional). 
+      placeholder: e.g. Cuda
+    validations:
+      required: False

--- a/.github/ISSUE_TEMPLATE/papi_issue_report.yml
+++ b/.github/ISSUE_TEMPLATE/papi_issue_report.yml
@@ -1,0 +1,76 @@
+name: PAPI Issue Report
+description: Create a report for a PAPI related issues on Linux
+title: "[Issue]: "
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for taking the time to fill out this issue report!
+  - type: textarea
+    id: issue-description
+    attributes:
+      label: Issue Description
+      description: What is the issue that you are encountering?
+    validations:
+      required: True
+  - type: input
+    id: operating-system
+    attributes:
+      label: Operating System
+      description: What is your machines operating system? Include name and version number.<br>(`cat /etc/os-release | grep -E "^(NAME=|VERSION=)"`)
+      placeholder: e.g. Rocky Linux Version 9.5
+    validations:
+      required: True
+  - type: input
+    id: architecture
+    attributes:
+      label: Architecture
+      description: What is your machines architecture?<br>(`uname -m`)
+      placeholder: e.g. x86_64
+    validations:
+      required: True
+  - type: input
+    id: cpu-architecture
+    attributes:
+      label: CPU Architecture
+      description: What CPU architecture are you using?<br>(`cat /proc/cpuinfo | grep "name" | head -n 1`)
+      placeholder: e.g. Intel Xeon Gold 6140 CPU
+    validations:
+      required: True
+  - type: input
+    id: compiler
+    attributes:
+      label: Compiler
+      description: What is your compiler and compiler version?<br>(`gcc --version` or `clang --version`)
+      placeholder: e.g. GCC 11.5.0
+    validations:
+      required: True
+  - type: input
+    id: papi-version
+    attributes:
+      label: PAPI Version
+      description: What version of PAPI are you using (optional)?<br>(`(cd path_to_your_papi_install/bin && ./papi_version)`)
+      placeholder: e.g. master or PAPI 7.2.0
+    validations:
+      required: False
+  - type: input
+    id: component
+    attributes:
+      label: Component
+      description: What component does this issue pertain to (optional)?<br>(`(cd path_to_your_papi_install/bin && ./papi_component_avail)`) 
+      placeholder: e.g. Cuda
+    validations:
+      required: False
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Provide steps to reproduce this issue (optional).
+    validations:
+      required: False
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional Information
+      description: Is there any additional information that is relevant to your issue? This could be node parallelization used or is the program ran directly on your system or a batch system.
+    validations:
+      required: False

--- a/.github/workflows/ci_individual_component.sh
+++ b/.github/workflows/ci_individual_component.sh
@@ -17,53 +17,75 @@ module load $COMPILER
 
 cd src
 
-# lmsensors environment variables
+# --- Set Necessary Environment Variables ---
+## Set the lmsensors component environment variables
 if [ "$COMPONENT" = "lmsensors" ]; then
-  wget https://github.com/groeck/lm-sensors/archive/V3-4-0.tar.gz
-  tar -zxf V3-4-0.tar.gz 
-  cd lm-sensors-3-4-0
-  make install PREFIX=../lm ETCDIR=../lm/etc
-  cd ..
-  export PAPI_LMSENSORS_ROOT=lm
-  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PAPI_LMSENSORS_ROOT/lib
+    wget https://github.com/groeck/lm-sensors/archive/V3-4-0.tar.gz
+    tar -zxf V3-4-0.tar.gz
+    cd lm-sensors-3-4-0
+    make install PREFIX=../lm ETCDIR=../lm/etc
+    cd ..
+    export PAPI_LMSENSORS_ROOT=lm
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PAPI_LMSENSORS_ROOT/lib
 fi
 
-# rocm and rocm_smi environment variables
-if [ "$COMPONENT" = "rocm" ] || [ "$COMPONENT" = "rocm_smi" ]; then
-  export PAPI_ROCM_ROOT=/apps/rocm/rocm-5.5.3
-  export PAPI_ROCMSMI_ROOT=$PAPI_ROCM_ROOT/rocm_smi
+## Set the rocm component environment variable
+if [ "$COMPONENT" = "rocm" ]; then
+    module load rocm/6.3.2
+    export PAPI_ROCM_ROOT=$ROCM_PATH
 fi
 
-# set necessary environemnt variables for cuda and nvml
+## Set the rocm_smi component environment variable
+if [ "$COMPONENT" = "rocm_smi" ]; then
+    module load rocm/6.3.2
+    export PAPI_ROCMSMI_ROOT=$ROCM_PATH
+fi
+
+## Set the rocp_sdk component environment variable
+if [ "$COMPONENT" = "rocp_sdk" ]; then
+    module load rocm/6.3.2
+    export PAPI_ROCP_SDK_ROOT=$ROCM_PATH
+fi
+
+## Set the cuda component or the nvml component environment variable
 if [ "$COMPONENT" = "cuda" ] || [ "$COMPONENT" = "nvml" ]; then
-  module load cuda
-  export PAPI_CUDA_ROOT=$ICL_CUDA_ROOT
-  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PAPI_CUDA_ROOT/extras/CUPTI/lib64
+    export MODULEPATH=$MODULEPATH:/apps/spacks/cuda/share/spack/modules/linux-rocky9-skylake_avx512/
+    module load  cuda/12.8.0
+    export PAPI_CUDA_ROOT=$ICL_CUDA_ROOT
 fi
 
-# test linking with or without --with-shlib-tools 
+# --- Configure and Build PAPI ---
+## Configure without --with-shlib-tools
 if [ "$SHLIB" = "without" ]; then
     ./configure --with-debug=$DEBUG --enable-warnings --with-components="$COMPONENT" 
+## Configure with --with-shlib-tools
 else
     ./configure --with-debug=$DEBUG --enable-warnings --with-components="$COMPONENT" --with-shlib-tools
 fi
-
 make -j4
 
-# run PAPI utilities
+# --- Verify Components we Expect to Be Active are Active ---
+## For the PAPI build get the active components
 utils/papi_component_avail
+current_active_components=$(utils/papi_component_avail | grep -A1000 'Active components' | grep "Name:   " | awk '{printf "%s%s", sep, $2; sep=" "} END{print ""}')
 
-# active component check
-EXPECTED_ACTIVE_COMPONENTS=$(echo "perf_event perf_event_uncore sysdetect" | sed "s/perf_event_uncore/& $COMPONENT/") 
-CURRENT_ACTIVE_COMPONENTS=$(utils/papi_component_avail | grep -A1000 'Active components' | grep "Name:   " | awk '{printf "%s%s", sep, $2; sep=" "} END{print ""}')
-[ "$EXPECTED_ACTIVE_COMPONENTS" = "$CURRENT_ACTIVE_COMPONENTS" ]
+## Defining the components we expect to be active for the PAPI build
+declare -a expected_active_components
+expected_active_components=("perf_event" "perf_event_uncore" "sysdetect" "$COMPONENT")
 
-# without '--with-shlib-tools' in ./configure
+## Verify the expected active components are active for the PAPI build
+for cmp in "${expected_active_components[@]}"; do
+    grep -q $cmp <<< $current_active_components || \
+    { echo "The component $cmp is not active and should be active!"; exit 1; }
+done
+
+# --- Run Tests: Ctests, Ftests, Component Tests, etc. ---
+## Without '--with-shlib-tools' in ./configure
 if [ "$SHLIB" = "without" ]; then
-   echo "Running full test suite for active components"
-   ./run_tests.sh TESTS_QUIET --disable-cuda-events=yes
-# with '--with-shlib-tools' in ./configure
+    echo "Running full test suite for active components"
+    ./run_tests.sh TESTS_QUIET --disable-cuda-events=yes
+## With '--with-shlib-tools' in ./configure
 else
-   echo "Running single component test for active components"
-   ./run_tests_shlib.sh TESTS_QUIET
+    echo "Running single component test for active components"
+    ./run_tests_shlib.sh TESTS_QUIET
 fi

--- a/.github/workflows/papi_framework_workflow.yml
+++ b/.github/workflows/papi_framework_workflow.yml
@@ -12,49 +12,50 @@ on:
 
 jobs:
   # build PAPI with multiple components to simulate a users' workflow
-  # rocm, rocm_smi, powercap_ppc, rapl, sensors_ppc, infiniband, lustre, and mx should all
-  # be disabled upon the build finishing
   papi_components_comprehensive:
     strategy:
       matrix:
-        components: [cuda nvml rocm rocm_smi powercap powercap_ppc rapl sensors_ppc net appio io lustre stealtime coretemp lmsensors mx sde]
+        components: [cuda nvml rocp_sdk rocm_smi powercap powercap_ppc rapl infiniband sensors_ppc net appio io lustre stealtime coretemp lmsensors mx sde]
         debug: [yes, no]
         shlib: [with, without]
+        hardware: [gpu_nvidia_w_cpu_intel]
       fail-fast: false
     runs-on: [self-hosted, cpu_intel, gpu_nvidia]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: comprehensive component tests 
-        run: .github/workflows/ci_papi_framework.sh "${{matrix.components}}" ${{matrix.debug}} ${{matrix.shlib}}
-  # build PAPI only with the amd components, as they will not be active in the above comprehensive job
+        run: .github/workflows/ci_papi_framework.sh "${{matrix.components}}" ${{matrix.debug}} ${{matrix.shlib}} ${{matrix.hardware}}
+  # build PAPI only with rocm and rocm_smi components, as they will not be active in the above comprehensive job
   papi_components_amd:
     strategy:
       matrix:
-        components: [rocm rocm_smi]
+        components: [rocp_sdk rocm_smi]
         debug: [yes, no] 
         shlib: [with, without]
+        hardware: [gpu_amd]
       fail-fast: false
     runs-on: [self-hosted, gpu_amd]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
-      - name: rocm and rocm_smi component tests
-        run: .github/workflows/ci_papi_framework.sh "${{matrix.components}}" ${{matrix.debug}} ${{matrix.shlib}}
-  # build PAPI only with the infiniband component, as it will not be active in the above comprehensive job
+      - name: rocp_sdk and rocm_smi component tests
+        run: .github/workflows/ci_papi_framework.sh "${{matrix.components}}" ${{matrix.debug}} ${{matrix.shlib}} ${{matrix.hardware}}
+  # build PAPI only with the infiniband component, as it will not always be active in the above comrehensive job
   papi_component_infiniband:
     strategy:
       matrix:
         components: [infiniband]
         debug: [yes, no] 
         shlib: [with, without]
+        hardware: [infiniband]
       fail-fast: false
     runs-on: [self-hosted, infiniband]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: infiniband component tests
-        run: .github/workflows/ci_papi_framework.sh ${{matrix.components}} ${{matrix.debug}} ${{matrix.shlib}} 
+        run: .github/workflows/ci_papi_framework.sh ${{matrix.components}} ${{matrix.debug}} ${{matrix.shlib}} ${{matrix.hardware}}
   papi_spack:
     runs-on: cpu
     timeout-minutes: 60

--- a/.github/workflows/rocp_sdk_component_workflow.yml
+++ b/.github/workflows/rocp_sdk_component_workflow.yml
@@ -1,0 +1,24 @@
+name: rocp_sdk
+
+on:
+  pull_request:
+    # run CI only if rocp_sdk directory or rocp_sdk sub-directories receive updates
+    paths:
+      - 'src/components/rocp_sdk/**'
+  # allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  component_tests:
+    strategy:
+      matrix:
+        component: [rocp_sdk]
+        debug: [yes, no] 
+        shlib: [with, without]
+      fail-fast: false
+    runs-on: [self-hosted, gpu_amd]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - name: rocp_sdk component tests
+        run: .github/workflows/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/src/run_tests.sh
+++ b/src/run_tests.sh
@@ -61,6 +61,11 @@ fi
 
 # List of active components
 ACTIVE_COMPONENTS_PATTERN=$(utils/papi_component_avail | awk '/Active components:/{flag=1; next} flag' | grep "Name:" | sed 's/Name: //' | awk '{print $1}' | paste -sd'|' -)
+case "$ACTIVE_COMPONENTS_PATTERN" in
+    *"rocp_sdk"*)
+        rocp_sdk_exclude_tests="ctests/multiattach ctests/multiattach2 ctests/zero_attach"
+        ;;
+esac
 
 # Find the test files, filtering for only the active components
 COMPTESTS=$(find components/*/tests -perm -u+x -type f ! \( -name "*.[c|h]" -o -name "*.cu" -o -name "*.so" \) | grep -E "components/($ACTIVE_COMPONENTS_PATTERN)/")
@@ -70,7 +75,7 @@ INACTIVE_COMPTESTS=$(find components/*/tests -perm -u+x -type f ! \( -name "*.[c
 
 #EXCLUDE=`grep --regexp=^# --invert-match run_tests_exclude.txt`
 EXCLUDE_TXT=`grep -v -e '^#\|^$' run_tests_exclude.txt`
-EXCLUDE="$EXCLUDE_TXT $INACTIVE_COMPTESTS";
+EXCLUDE="$EXCLUDE_TXT $INACTIVE_COMPTESTS $rocp_sdk_exclude_tests";
 
 ALLTESTS="$VTESTS $CTESTS $FTESTS $COMPTESTS";
 


### PR DESCRIPTION
## Pull Request Description
This PR updates the PAPI GitHub CI:

1. Two new issue templates are being added.
    - The first template is specifically for PAPI bug related issues and will request more information from a user early on in regards to their machine (e.g. cpu, gpu, etc.).
    - The second template is a feature request template.

    Note that the blank issue will still persist with this change.
2. `rocp_sdk` jobs are now added.
3.  Increased robustness for checking expected active components.
    - Currently when checking expected active components the order of the components matters. With this PR this is no longer the case. 


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
