### PR TITLE
configure.in: Remove flag --with-libpfm4 from cross compile sample comment

### DIFF
--- a/src/configure.in
+++ b/src/configure.in
@@ -2,7 +2,7 @@
 # File: configure.in
 
 # cross compile sample
-# ARCH=mips CC=scgcc ./configure --with-arch=mips --host=mips64el-gentoo-linux-gnu- --with-ffsll --with-libpfm4 --with-perf-events --with-virtualtimer=times --with-walltimer=gettimeofday --with-tls=__thread --with-CPU=mips
+# ARCH=mips CC=scgcc ./configure --with-arch=mips --host=mips64el-gentoo-linux-gnu- --with-ffsll --with-perf-events --with-virtualtimer=times --with-walltimer=gettimeofday --with-tls=__thread --with-CPU=mips
 # cross compiling should work differently...
 
 AC_PREREQ(2.59)


### PR DESCRIPTION
## Pull Request Description
This PR removes the flag `--with-libpfm4` mentioned in the cross compile sample comment in `configure.in` as this flag does not exist anymore.

If you run `./configure --prefix=$PWD/test-install --with-libpfm4`, you will get back a warning:
```
configure: WARNING: unrecognized options: --with-libpfm4
```

Tested on an Intel Xeon Gold 6140 with the following configure: `./configure --prefix=$PWD/test-install`. The utilities: `papi_avail`, `papi_component_avail`, `papi_native_avail`, and `papi_command_line` all work as expected.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
