### PR TITLE
net: Update the test net_values_by_name.c to successfully run and not use hard coded events

### DIFF
--- a/src/components/net/tests/net_values_by_name.c
+++ b/src/components/net/tests/net_values_by_name.c
@@ -3,12 +3,9 @@
 /****************************/
 
 /**
- * @author  Jose Pedro Oliveira
- *
- * test case for the linux-net component
- *
  * @brief
- *   Prints the values of several net events specified by names
+ *   For each net event that is available add it to an EventSet by its name 
+ *   e.g. net:::lo:rx:byte. Then run through a start - stop workflow.
  */
 
 #include <stdio.h>
@@ -18,67 +15,80 @@
 #include "papi.h"
 #include "papi_test.h"
 
-/*
-#define IFNAME     "eth0"
-*/
-#define IFNAME     "lo"
 #define PINGADDR   "127.0.0.1"
-
-#define NUM_EVENTS 4
 
 int main (int argc, char **argv)
 {
-    int i, retval;
-    int EventSet = PAPI_NULL;
-    char *event_name[NUM_EVENTS] = {
-        IFNAME ":rx:bytes",
-        IFNAME ":rx:packets",
-        IFNAME ":tx:bytes",
-        IFNAME ":tx:packets",
-    };
-    int event_code[NUM_EVENTS] = { 0, 0, 0, 0};
-    long long event_value[NUM_EVENTS];
-    int total_events=0;
-
     /* Set TESTS_QUIET variable */
     tests_quiet( argc, argv );
 
     /* PAPI Initialization */
-    retval = PAPI_library_init( PAPI_VER_CURRENT );
+    int retval = PAPI_library_init( PAPI_VER_CURRENT );
     if ( retval != PAPI_VER_CURRENT ) {
-        test_fail(__FILE__, __LINE__,"PAPI_library_init failed\n",retval);
+        test_fail(__FILE__, __LINE__, "PAPI_library_init", retval);
     }
 
-    if (!TESTS_QUIET) {
-        printf("Net events by name\n");
+    const char *componentName = "net";
+    int cmpIdx = PAPI_get_component_index(componentName);
+    if (cmpIdx < 0) {
+        test_fail(__FILE__, __LINE__,"PAPI_get_component_index", cmpIdx);
     }
 
-    /* Map names to codes */
-    for ( i=0; i<NUM_EVENTS; i++ ) {
-        retval = PAPI_event_name_to_code( event_name[i], &event_code[i]);
-        if ( retval != PAPI_OK ) {
-            test_fail( __FILE__, __LINE__, "PAPI_event_name_to_code", retval );
+    int eventCode = 0 | PAPI_NATIVE_MASK;
+    int modifier = PAPI_ENUM_FIRST;
+    retval = PAPI_enum_cmp_event(&eventCode, modifier, cmpIdx);
+    if (retval != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_enum_cmp_event", retval);
+    }
+
+    int EventSet = PAPI_NULL;
+    retval = PAPI_create_eventset(&EventSet);
+    if (retval != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_create_eventset", retval);
+    }  
+
+    int numEventsAdded = 0;
+    char **eventNames = NULL;
+    modifier = PAPI_ENUM_EVENTS;
+    do {
+        // Get an events info to use the symbol member variable
+        PAPI_event_info_t evtInfo;
+        retval = PAPI_get_event_info(eventCode, &evtInfo);
+        if (retval != PAPI_OK) {
+            test_fail(__FILE__, __LINE__, "PAPI_get_event_info", retval);
         }
 
-        total_events++;
-    }
+        retval = PAPI_add_named_event(EventSet, evtInfo.symbol);
+        if (retval != PAPI_OK) {
+            test_fail(__FILE__, __LINE__, "PAPI_add_named_event", retval);
+        }
 
-    /* Create and populate the EventSet */
-    EventSet = PAPI_NULL;
+        // Allocate necessary memory to store successfully added events
+        eventNames = (char **) realloc(eventNames, (numEventsAdded + 1) * sizeof(char *));
+        if (eventNames == NULL) {
+            fprintf(stderr, "Failed to allocate memory for the array eventNames.\n");
+            exit(1);
+        }
+        eventNames[numEventsAdded] = (char *) malloc(PAPI_MAX_STR_LEN * sizeof(char));
+        if (eventNames[numEventsAdded] == NULL) {
+            fprintf(stderr, "Failed to allocate memory for index %d of array eventNames.\n", numEventsAdded);
+            exit(1);
+        }
 
-    retval = PAPI_create_eventset( &EventSet );
-    if (retval != PAPI_OK) {
-        test_fail(__FILE__, __LINE__, "PAPI_create_eventset()", retval);
-    }
+        // Store successfully added events to be output after start - stop workflow
+        int strLen = snprintf(eventNames[numEventsAdded], PAPI_MAX_STR_LEN, "%s", evtInfo.symbol);
+        if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+            fprintf(stderr, "Failed to fully write the event %s to index %d.\n", evtInfo.symbol, numEventsAdded);
+            exit(1);
+        }
 
-    retval = PAPI_add_events( EventSet, event_code, NUM_EVENTS);
-    if (retval != PAPI_OK) {
-        test_fail(__FILE__, __LINE__, "PAPI_add_events()", retval);
-    }
+        // Incremenent total number of events successfully added
+        numEventsAdded++;
+    } while(PAPI_enum_cmp_event(&eventCode, modifier, cmpIdx) == PAPI_OK);
 
     retval = PAPI_start( EventSet );
     if (retval != PAPI_OK) {
-        test_fail(__FILE__, __LINE__, "PAPI_start()", retval);
+        test_fail(__FILE__, __LINE__, "PAPI_start", retval);
     }
 
     /* generate some traffic
@@ -86,30 +96,45 @@ int main (int argc, char **argv)
      * to guarantee that the network counters are updated */
     retval = system("ping -c 4 " PINGADDR " > /dev/null");
     if (retval < 0) {
-		test_fail(__FILE__, __LINE__, "Unable to start ping", retval);
+        fprintf(stderr, "Unable to start ping.\n");
+        exit(1);
 	}
 
-    retval = PAPI_stop( EventSet, event_value );
-    if (retval != PAPI_OK) {
-        test_fail(__FILE__, __LINE__, "PAPI_start()", retval);
+    long long *counterValues = (long long *) malloc(numEventsAdded * sizeof(long long));
+    if (counterValues == NULL) {
+        fprintf(stderr, "Failed to allocate memory for array counterValues.\n");
+        exit(1);
     }
 
+    retval = PAPI_stop( EventSet, counterValues );
+    if (retval != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_stop", retval);
+    }
+
+    int i;
     if (!TESTS_QUIET) {
-        for ( i=0; i<NUM_EVENTS; i++ ) {
-            printf("%#x %-24s = %lld\n",
-                event_code[i], event_name[i], event_value[i]);
+        printf("Net events by name:\n");
+        for (i = 0; i < numEventsAdded; i++) {
+            printf("%s has a counter value of %d\n", eventNames[i], counterValues[i]);
         }
     }
 
     retval = PAPI_cleanup_eventset( EventSet );
     if (retval != PAPI_OK) {
-        test_fail(__FILE__, __LINE__, "PAPI_cleanup_eventset()", retval);
+        test_fail(__FILE__, __LINE__, "PAPI_cleanup_eventset", retval);
     }
 
     retval = PAPI_destroy_eventset( &EventSet );
     if (retval != PAPI_OK) {
-        test_fail(__FILE__, __LINE__, "PAPI_destroy_eventset()", retval);
+        test_fail(__FILE__, __LINE__, "PAPI_destroy_eventset", retval);
     }
+
+    // Free allocated memory
+    for (i = 0; i < numEventsAdded; i++) {
+        free(eventNames[i]);
+    }
+    free(eventNames);
+    free(counterValues);
 
     test_pass( __FILE__ );
 


### PR DESCRIPTION
## Pull Request Description
Currently in the master branch if you try to run the `net` component test `net_values_by_name.c` it will not successfully run:
```
Net events by name
FAILED!!!
Line # 60 Error in PAPI_event_name_to_code: Not supported by component
Some tests require special hardware, permissions, OS, compilers
or library versions. PAPI may still function perfectly on your 
system without the particular feature being tested here.  
```

This PR updates the `net_values_by_name.c` by:

- Not hard coding the net native event names and instead enumerating through the available net events.
- Actually using `PAPI_add_named_event` instead of `PAPI_add_events`. As the test name indicates we will get the net values by name.

Testing of this PR was done on an Intel Xeon Gold 6430 with RHEL 8.10. Snippet of output for `net_values_by_name.c` is below:
```
.
.
.
net:::docker0:tx:error has a counter value of 0
net:::docker0:tx:droppe has a counter value of 0
net:::docker0:tx:fif has a counter value of 0
net:::docker0:tx:coll has a counter value of 0
net:::docker0:tx:carrie has a counter value of 0
net:::docker0:tx:compresse has a counter value of 0
PASSED
```

The utilities `papi_component_avail`,  `papi_native_avail`, and `papi_command_line` work as expected as well. Along with that the other `net` component tests still function as expected.


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
