### PR TITLE
Get perl from env instead of hard-coded path

### DIFF
--- a/src/maint/genpapifdef.pl
+++ b/src/maint/genpapifdef.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 ##
 ## Copyright (C) by Innovative Computing Laboratory


### PR DESCRIPTION
## Pull Request Description

Changes how perl in found on the system for the genpapifdef.pl script (shebang) to allow for other locations than `/usr/bin/perl`.

## Author Checklist

- [x] **Description**

After #5, installing papi requires perl to be installed at `/usr/bin/perl`. However, this is not always the case.
In particular, I was running into "no such file or directory" while trying to install papi in Spack CI context (in a centos 7 container). See https://github.com/spack/spack-packages/pull/869
The minimal fix consisted in 2 things: 
- Add perl as a build dependency for papi. (necessary but not sufficient).
- Change the script shebang to allow for another location.

- [x] **Commits**

_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution

- [ ] **Tests**

The PR needs to pass all the tests
