### PR TITLE
cuda: Add newline for SUBDBG message in cuda_stop

### DIFF
--- a/src/components/cuda/linux-cuda.c
+++ b/src/components/cuda/linux-cuda.c
@@ -610,7 +610,7 @@ int cuda_stop(hwd_context_t *ctx, hwd_control_state_t *ctl)
     cuda_control_t *cuda_ctl = (cuda_control_t *) ctl;
 
     if (cuda_ctx->state == CUDA_EVENTS_STOPPED) {
-        SUBDBG("Error! Cannot PAPI_stop counters for an eventset that has not been PAPI_start'ed.");
+        SUBDBG("Error! Cannot PAPI_stop counters for an eventset that has not been PAPI_start'ed.\n");
         papi_errno = PAPI_EMISC;
         goto fn_fail;
     }


### PR DESCRIPTION
## Pull Request Description
In PAPI master the `cuda_stop` `SUBDBG` message `"Error! Cannot PAPI_stop counters for an eventset that has not been PAPI_start'ed."` lacks a newline and results in the following output when `PAPI_DEBUG` is exported to be equal to `SUBSTRATE`
```
SUBSTRATE:components/cuda/linux-cuda.c:cuda_stop:614:262800 Error! Cannot PAPI_stop counters for an eventset that has not been PAPI_start'ed.SUBSTRATE:components/cuda/linux-cuda.c:cuda_stop:635:262800 EXIT: Unknown error code
```

This PR adds a newline to the end of this `SUBDBG` message.

# Testing
Testing was done on Voltar at Oregon, the machine details are as follows:
```
CPU: Intel Xeon Gold 6226R
GPUs: 1 * P100, 1 * V100, 1 * A100
OS: RHEL 8.10
CUDA Toolkit: 12.6.3
```

Now when exporting `PAPI_DEBUG` to be equal to `SUBSTRATE` the output shows as:
```
SUBSTRATE:components/cuda/linux-cuda.c:cuda_stop:614:264066 Error! Cannot PAPI_stop counters for an eventset that has not been PAPI_start'ed.
SUBSTRATE:components/cuda/linux-cuda.c:cuda_stop:635:264066 EXIT: Unknown error code
```

NOTE: For testing to successfully trigger the below conditional I set `cuda_ctx->state = CUDA_EVENTS_STOPPED` directly before it:
```
if (cuda_ctx->state == CUDA_EVENTS_STOPPED) {
    SUBDBG("Error! Cannot PAPI_stop counters for an eventset that has not been PAPI_start'ed.\n");
    papi_errno = PAPI_EMISC;
    goto fn_fail;
}
```

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
