### PR TITLE
rocp_sdk: Update component tests to enumerate through available events and add them if none of the desired events can be added

### DIFF
--- a/src/components/rocp_sdk/tests/Makefile
+++ b/src/components/rocp_sdk/tests/Makefile
@@ -34,17 +34,20 @@ template_tests: $(TESTS)
 kernel.o: kernel.cpp
 	$(AMDCXX) -D__HIP_ROCclr__=1 -O2 -g -DNDEBUG $(ARCHFLAG) -W -Wall -Wextra -Wshadow -o kernel.o -x hip -c kernel.cpp
 
-simple: simple.o kernel.o
-	$(AMDCXX) -O2 -g -DNDEBUG $(GPUFLAGS) simple.o kernel.o -o simple $(LDFLAGS)
+helper_rocp_sdk.o: helper_rocp_sdk.c
+	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $^
 
-advanced: advanced.o kernel.o
-	$(AMDCXX) -O2 -g -DNDEBUG $(GPUFLAGS) advanced.o kernel.o -o advanced $(LDFLAGS)
+simple: simple.o kernel.o helper_rocp_sdk.o
+	$(AMDCXX) -O2 -g -DNDEBUG $(GPUFLAGS) simple.o kernel.o helper_rocp_sdk.o -o simple $(LDFLAGS)
 
-two_eventsets: two_eventsets.o kernel.o
-	$(AMDCXX) -O2 -g -DNDEBUG $(GPUFLAGS) two_eventsets.o kernel.o -o two_eventsets $(LDFLAGS)
+advanced: advanced.o kernel.o helper_rocp_sdk.o
+	$(AMDCXX) -O2 -g -DNDEBUG $(GPUFLAGS) advanced.o kernel.o helper_rocp_sdk.o -o advanced $(LDFLAGS)
 
-simple_sampling: simple_sampling.o kernel.o
-	$(AMDCXX) -O2 -g -DNDEBUG $(GPUFLAGS) simple_sampling.o kernel.o -o simple_sampling $(LDFLAGS) -pthread
+two_eventsets: two_eventsets.o kernel.o helper_rocp_sdk.o
+	$(AMDCXX) -O2 -g -DNDEBUG $(GPUFLAGS) two_eventsets.o kernel.o helper_rocp_sdk.o -o two_eventsets $(LDFLAGS)
+
+simple_sampling: simple_sampling.o kernel.o helper_rocp_sdk.o
+	$(AMDCXX) -O2 -g -DNDEBUG $(GPUFLAGS) simple_sampling.o kernel.o helper_rocp_sdk.o -o simple_sampling $(LDFLAGS) -pthread
 
 clean:
 	rm -f $(TESTS) *.o

--- a/src/components/rocp_sdk/tests/helper_rocp_sdk.c
+++ b/src/components/rocp_sdk/tests/helper_rocp_sdk.c
@@ -1,0 +1,80 @@
+#include <papi.h>
+#include <papi_test.h>
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/*
+ * For the rocp_sdk component tests, take the desired events and attempt to add them.
+ */
+void add_desired_component_events(int eventSet, int maxNativeEventsToAdd, const char nativeEventsToAdd[][PAPI_MAX_STR_LEN], char nativeEventNamesAdded[][PAPI_MAX_STR_LEN], int *numNativeEventsAdded)
+{
+    int i;
+    int *numEventsAdded = numNativeEventsAdded;
+    for (i = 0; i < maxNativeEventsToAdd; i++) {
+        int papi_errno = PAPI_add_named_event(eventSet, nativeEventsToAdd[i]);
+        if (papi_errno == PAPI_ENOEVNT) {
+            continue;
+        }
+        else if (papi_errno != PAPI_OK){
+            test_fail(__FILE__, __LINE__, "PAPI_add_named_event", papi_errno);
+        }
+
+        int strLen = snprintf(nativeEventNamesAdded[(*numEventsAdded)], PAPI_MAX_STR_LEN, "%s", nativeEventsToAdd[i]);
+        if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+            fprintf(stderr, "Failed to fully write native event name into index: %d\n", i);
+            exit(1);
+        }
+        (*numEventsAdded)++;
+    }
+
+    return;
+}
+
+/*
+ * Enumerate through the rocp_sdk native events and attempt to add them.
+ * This function should only be called if none of the desired events were
+ * successfully added. 
+ */
+void enumerate_and_add_component_events(const char *componentName, int eventSet, int maxNativeEventsToAdd, char nativeEventNamesAdded[][PAPI_MAX_STR_LEN], int *numNativeEventsAdded)
+{
+
+    int componentIdx = PAPI_get_component_index(componentName);
+    if (componentIdx < 0) {
+        test_fail(__FILE__, __LINE__, "PAPI_get_component_index", componentIdx);
+    }  
+
+    int eventCode = 0 | PAPI_NATIVE_MASK, modifier = PAPI_ENUM_FIRST;
+    int papi_errno = PAPI_enum_cmp_event(&eventCode, modifier, componentIdx);
+    if (papi_errno != PAPI_OK) {
+        test_fail(__FILE__, __LINE__, "PAPI_enum_cmp_event", papi_errno);
+    }
+
+    int *numEventsAdded = numNativeEventsAdded;
+    modifier = PAPI_ENUM_EVENTS;
+    do {
+        char eventName[PAPI_MAX_STR_LEN];
+        papi_errno = PAPI_event_code_to_name(eventCode, eventName);
+        if (papi_errno != PAPI_OK) {
+            test_fail(__FILE__, __LINE__, "PAPI_event_code_to_name", papi_errno);
+        }
+
+        papi_errno = PAPI_add_named_event(eventSet, eventName);
+        if (papi_errno == PAPI_ENOEVNT) {
+            continue;
+        }
+        else if (papi_errno != PAPI_OK) {
+            test_fail(__FILE__, __LINE__, "PAPI_add_named_event", papi_errno);
+        }
+
+        int strLen = snprintf(nativeEventNamesAdded[(*numEventsAdded)], PAPI_MAX_STR_LEN, "%s", eventName);
+        if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+            fprintf(stderr, "Failed to fully write native event name into index: %d\n", (*numEventsAdded));
+            exit(1);
+        }
+        (*numEventsAdded)++;
+    } while(PAPI_enum_cmp_event(&eventCode, modifier, componentIdx) == PAPI_OK && (*numEventsAdded) < maxNativeEventsToAdd);
+
+    return;
+}


### PR DESCRIPTION
## Pull Request Description
This PR updates the `rocp_sdk` component tests to be able to enumerate through the available native events on a device if none of the desired events in the application test code exist.

# Testing for this PR

This PR was tested on two difference machines.

- First machine: 2 * MI50 using ROCm 6.4.0 
    - `advanced.c`: ✅ 
    - `simple.c`: ✅ 
    - `simple_sampling.c`: ✅ 
    - `two_eventsets.c`: ✅ 

Note: For this machine, the tests would run with random events.


- Second machine: 2 * MI210 using ROCm 6.4.0
    - `advanced.c`: ✅ 
    - `simple.c`: ✅ 
    - `simple_sampling.c`: ✅ 
    - `two_eventsets.c`: ✅ 

Note: For this machine, the tests would run with the desired events. Along with testing the desired events ran, I modified the helper functions to only collect two desired events. In this case the tests would only run with the two desired events which is expected behavior.



## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
