### PR TITLE
sde: Remove dependency of -lpfm

### DIFF
--- a/src/components/sde/tests/Makefile
+++ b/src/components/sde/tests/Makefile
@@ -24,7 +24,7 @@ ifeq ($(BUILD_LIBSDE_STATIC),yes)
 endif
 
 ifeq ($(BUILD_LIBSDE_SHARED),yes)
-	sdeLDFLAGS = $(LDFLAGS) -Llib -L$(datadir) -L$(datadir)/libpfm4/lib -lpapi -lpfm -lsde
+	sdeLDFLAGS = $(LDFLAGS) -Llib -L$(datadir) -lpapi -lsde
 	LIBSDE=yes
 else
 	sdeLDFLAGS = $(LD_STATIC_FLAGS)


### PR DESCRIPTION
## Pull Request Description
This PR resolves the below encountered compilation error with the sde component.

Configuring PAPI with the `sde` component and the option `--disable-cpu` will result in a compilation error (first encountered by @djwoun  [here](https://github.com/icl-utk-edu/papi/pull/450#issuecomment-3197444987)):
```
+ for comp in sde
+ make -C components/sde/tests
make[1]: Entering directory '/storage/users/tburgess/papi_clean_installs/papi_dir/src/components/sde/tests'
gcc Minimal/Minimal_Test.c -o Minimal_Test -I. -I../../.. -I../../../testlib -I../../../validation_tests -I/home/users/tburgess/papi_clean_installs/papi_dir/src/test-install/include -I../../../sde_lib -I.. -DPAPI_NUM_COMP=1 -g ../../../testlib/libtestlib.a -lrt -ldl -Llib -L../../.. -L../../../libpfm4/lib -lpapi -lpfm -lsde
/opt/cray/pe/cce/18.0.0/binutils/x86_64/x86_64-pc-linux-gnu/bin/ld: cannot find -lpfm: No such file or directory
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:55: Minimal_Test] Error 1
make[1]: Leaving directory '/storage/users/tburgess/papi_clean_installs/papi_dir/src/components/sde/tests'
```

After looking more into this, when `--disable-cpu` is set at configure, `libpfm4.so` is not created inside `libpfm4/lib`. Which is what causes the compilation warning.

Per a discussion, the sde component does not need libpfm4; however, during this discussion it was mentioned there could be a possible edge case which was resolved by specifically adding `-lfpm` in the file `sde/tests/Makefile`. Testing for this edge case was done by adding the option `--with-static-lib=no`, but no error was encountered with `-lpfm` removed.

## Testing
Testing was done on a machine with an AMD EPYC 7763 and OS of RHEL 8.10 using the following two configures:
```
./configure --prefix=$PWD/test-install --with-components="sde"
./configure --prefix=$PWD/test-install --with-components="sde" --disable-cpu
```

In both cases, the `sde` component was active and the component tests all passed.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
