### PR TITLE
sysdetect: Allow for gfortran executable variants

### DIFF
--- a/src/components/sysdetect/tests/Makefile
+++ b/src/components/sysdetect/tests/Makefile
@@ -21,7 +21,8 @@ endif
 intel_compilers := ifort ifx
 cray_compilers := ftn crayftn
 
-ifeq ($(notdir $(F77)),gfortran)
+gfortran_variants := $(shell echo "$(F77)" | grep --ignore-case --fixed-strings --silent gfortran; echo $$?)
+ifeq ($(gfortran_variants), 0)
     FFLAGS +=-ffree-form -ffree-line-length-none
 else ifeq ($(patsubst %flang,,$(notdir $(F77))),)  # compiler name ends with flang
     FFLAGS +=-ffree-form


### PR DESCRIPTION
## Pull Request Description
This PR resolves Issue #473.

I chose to use a shell approach compared to using `findstring` as the former is case insensitive while the latter is case sensitive. 

## Testing

Testing was done on two machines.

First, llyad at Oregon with the following machine info:
- CPU: AMD EPYC 7402
- OS: RHEL 8.10 

| Name of Executable  | PAPI Build | Sysdetect Component Tests Build and Run |
| ------------- | ------------- | ------------- |
| `gfortran`  | ✅  | ✅  |
| `/home/users/tburgess/gfortran_executable/13.2.0/bin/gfortran-13`  | ✅  | ✅  |
| `/home/users/tburgess/gfortran_executable/13.2.0/bin/gfortran13`  | ✅  | ✅  |
|`/home/users/tburgess/gfortran_executable/13.2.0/bin/Gfortran13` | ✅  | ✅  |
|`/home/users/tburgess/gfortran_executable/13.2.0/bin/GFORTRAN13` | ✅  | ✅ |

Second, Pinwheel at Oregon with the following machine info:
- CPU: AMD EPYC 7513
- OS: Debian 12

| Name of Executable  | PAPI Build | Sysdetect Component Tests Build and Run |
| ------------- | ------------- | ------------- |
| `gfortran`  | ✅  | ✅ |
| `/home/users/tburgess/gfortran_executable/13.2.0/bin/GFoRTRAN13`  | ✅  | ✅ |


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
