### PR TITLE
io: Add stricter component name check for io_basic.c

### DIFF
--- a/src/components/io/tests/io_basic.c
+++ b/src/components/io/tests/io_basic.c
@@ -69,9 +69,9 @@ int main (int argc, char **argv)
                     cmpinfo->num_native_events,
                     cmpinfo->name);
         }
-        if (strstr(cmpinfo->name,"io")) {
+        if (strncmp(cmpinfo->name, "io", strlen("io")) == 0) {
             /* FOUND! */
-            example_cid=cid;
+            example_cid = cid;
         }
     }
 


### PR DESCRIPTION
## Pull Request Description
Currently if you configure PAPI as follows: `./configure --prefix=$PWD/test-install --with-components="io appio"` and subsequently run the `io` component test `io_basic.c`. You will see `appio` native event names output rather than `io` native event names.

```
Listing all events in this component:
	Event 0x4000002f: appio:::READ_BYTES -- Bytes read
	Event 0x40000030: appio:::READ_CALLS -- Number of read calls
	Event 0x40000031: appio:::READ_ERR -- Number of read calls that resulted in an error
	Event 0x40000032: appio:::READ_INTERRUPTED -- Number of read calls that timed out or were interruped
.
.
.
```

Further, if you configure PAPI with `./configure --prefix=$PWD/test-install --with-components="appio"` and then run `io_basic.c`, `appio` native events will still output.

This PR resolves these two bug cases by making the conditional check stricter.

## Testing
Testing was done on the machine Jupiter at Oregon with:
- CPU: Intel Xeon Gold 6348H
- Ubuntu 22.04.5

With the stricter conditional check, `io` native event names now output when configured with `io` and then `appio`:
```
Listing all events in this component:
	Event 0x4000002f: io:::rchar -- Characters read.
	Event 0x40000030: io:::wchar -- Characters written.
	Event 0x40000031: io:::syscr -- Characters read by system calls.
	Event 0x40000032: io:::syscw -- Characters written by system calls.
	Event 0x40000033: io:::read_bytes -- Binary bytes read.
	Event 0x40000034: io:::write_bytes -- Binary bytes written.
	Event 0x40000035: io:::cancelled_write_bytes -- Binary write bytes cancelled.
```

And when solely configured with `appio` the `io_basic.c` component test is skipped:
```
Testing I/O component with PAPI 7.2.1
	Component 0 - 176 events - perf_event
	Component 1 - 3350 events - perf_event_uncore
	Component 2 - 45 events - appio
	Component 3 - 0 events - sysdetect
SKIPPED
``` 


## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
