### PR TITLE
papi_internal: Change strcasecmp to strcmp

### DIFF
--- a/src/papi_internal.c
+++ b/src/papi_internal.c
@@ -2810,7 +2810,7 @@ _papi_hwi_native_name_to_code( const char *in, int *out )
 				retval = _papi_hwd[cidx]->ntv_code_to_name(i, name, sizeof(name));
 				/* printf("%#x\nname =|%s|\ninput=|%s|\n", i, name, in); */
 				if ( retval == PAPI_OK && in != NULL) {
-					if ( strcasecmp( name, in ) == 0 ) {
+					if ( strcmp( name, in ) == 0 ) {
 						*out = _papi_hwi_native_to_eventcode(cidx, i, -1, name);
 						free (full_event_name);
 						INTDBG("EXIT: PAPI_OK, event: %s, code: %#x\n", in, *out);


### PR DESCRIPTION
## Pull Request Description
**BACKGROUND**:
Currently in the master branch, an event name will be converted to an event code internally by either calling the function `ntv_name_to_code` if the component supports it or using the workaround if it does not:
```c
do { 
    // save event code so components can get it with call to: _papi_hwi_get_papi_event_code()
     _papi_hwi_set_papi_event_code(i, 0);
     retval = _papi_hwd[cidx]->ntv_code_to_name(i, name, sizeof(name));
     /* printf("%#x\nname =|%s|\ninput=|%s|\n", i, name, in); */
     if ( retval == PAPI_OK && in != NULL) {
         if ( strcasecmp( name, in ) == 0 ) {
             *out = _papi_hwi_native_to_eventcode(cidx, i, -1, name);
             free (full_event_name);
             INTDBG("EXIT: PAPI_OK, event: %s, code: %#x\n", in, *out);
             return PAPI_OK;
         }    
         retval = PAPI_ENOEVNT;
      } else {
          *out = 0; 
          retval = PAPI_ENOEVNT;
          break;
     }    
} while ( ( _papi_hwd[cidx]->ntv_enum_events( &i, PAPI_ENUM_EVENTS ) == PAPI_OK ) ); 
```

**ISSUE**:
When configuring PAPI as follows: `./configure --prefix=$PWD/test-install --with-components="io appio"`, many of the`appio` component tests will fail:
```
[ICL:methane tests]$ ./appio_test_seek
This program will do a strided read /etc/group and write it to stdout
Error adding READ_BYTES to event set
```

This is because the event `READ_BYTES` exists for both `io` and `appio` and the workaround shown above uses `strcasecmp`:

- `io:::read_bytes`
- `appio:::READ_BYTES`

`strcasecmp` ignores the difference in cases. Therefore, if `appio` is configured after `io`, the component tests find `READ_BYTES` as a native event in `io`. This leads to the `appio` component tests failing.

This PR replaces `strcasecmp` with `strcmp` as the latter is case sensitive.

## Testing
Testing was done on Methane at ICL, machine info is as follows:
- CPU: Intel Xeon Gold 6140
- GPU: 1 * A100
- OS: Rocky Linux 9.5

Using the following configure: `./configure --prefix=$PWD/test-install --with-components="io appio"`.

PAPI Utilities:
 - `papi_component_avail`: ✅ 
 - `papi_native_avail`: ✅ 
 - `papi_command_line`: ✅ 

Component Tests:
- `io`: ✅ 
- `appio`: ✅ 

I did some final testing with the following configure: `./configure --prefix=$PWD/test-install --with-components="coretemp io appio stealtime"`.

PAPI Utilities:
 - `papi_component_avail`: ✅ 
 - `papi_native_avail`: ✅ 
 - `papi_command_line`: ✅ 
 
Component Tests:
- `perf_event`: ✅ 
- `perf_event_uncore`: No events defined for architecture in component tests
- `coretemp`: ✅ 
- `io`: ✅ 
- `appio`: ✅ 
- `stealtime`: ✅ 


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
