### PR TITLE
perf_event: Allow for the use of CAP_SYS_ADMIN and CAP_PERFMON

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -8595,7 +8595,8 @@ if test "$have_paranoid" = "yes"; then
 ***************************************************************************
 * Insufficient permissions for accessing any hardware counters.           *
 * Your current paranoid level is $paranoid_level.                                       *
-* Set /proc/sys/kernel/perf_event_paranoid to 2 (or less) or run as root. *
+* Set /proc/sys/kernel/perf_event_paranoid to 2 (or less), run as root,   *
+* or use CAP_PERFMON/CAP_SYS_ADMIN.                                       *
 *                                                                         *
 * Example:                                                                *
 * sudo sh -c \"echo 2 > /proc/sys/kernel/perf_event_paranoid\"              *

--- a/src/configure.in
+++ b/src/configure.in
@@ -2269,7 +2269,8 @@ if test "$have_paranoid" = "yes"; then
 ***************************************************************************
 * Insufficient permissions for accessing any hardware counters.           *
 * Your current paranoid level is $paranoid_level.                                       *
-* Set /proc/sys/kernel/perf_event_paranoid to 2 (or less) or run as root. *
+* Set /proc/sys/kernel/perf_event_paranoid to 2 (or less), run as root,   *
+* or use CAP_PERFMON/CAP_SYS_ADMIN.                                       *
 *                                                                         *
 * Example:                                                                *
 * sudo sh -c \"echo 2 > /proc/sys/kernel/perf_event_paranoid\"              *


### PR DESCRIPTION
## Pull Request Description
This PR adds:

- Updated message for `configure` if the `perf_event_paranoid` level is above 2
- Updated message for `perf_event` when using `papi_component_avail` if the component is disabled due to the `perf_event_paranoid` level being insufficient
- The ability to use `CAP_SYS_ADMIN` or `CAP_PERFMON` with the `perf_event` component

## Testing
Testing was done in a docker container on a machine with:
 - CPU: Intel Xeon Gold 6140
 - OS: Rocky Linux 9.5
 
1. If the `perf_event_paranoid` level was insufficient then in both cases `configure` and `papi_component_avail` would output the updated messages.

`configure`:
```
***************************************************************************
* Insufficient permissions for accessing any hardware counters.           *
* Your current paranoid level is 3.                                       *
* Set /proc/sys/kernel/perf_event_paranoid to 2 (or less), run as root,   *
* or use CAP_PERFMON/CAP_SYS_ADMIN.                                       *
*                                                                         *
* Example:                                                                *
* sudo sh -c "echo 2 > /proc/sys/kernel/perf_event_paranoid"              *
***************************************************************************
```

`papi_component_avail`:
```
Compiled-in components:
Name:   perf_event              Linux perf_event CPU counters
   \-> Disabled: Insufficient permissions for perf_event support with paranoid=3. Set /proc/sys/kernel/perf_event_paranoid to 2 or less, run as root, or use CAP_PERFMON/CAP_SYS_ADMIN.
```

2. Using `CAP_SYS_ADMIN` or `CAP_PERFMON` when the `perf_event_paranoid` level is above 2 allowed for use of the `perf_event` component. I verified this by using docker with the options `--cap-add SYS_ADMIN` and `--cap-add PERFMON`. In both cases, the PAPI utilities ran successfully and `perf_event` component tests passed.


As a note, the structure/code for this PR closely followed the implementation done in PR #201. 

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
