### PR TITLE
PAPI CI: Explicitly set path to `libcupti.so` and `libcudart.so` to avoid error while loading shared libraries

### DIFF
--- a/.github/workflows/ci_individual_component.sh
+++ b/.github/workflows/ci_individual_component.sh
@@ -49,9 +49,11 @@ fi
 
 ## Set the cuda component or the nvml component environment variable
 if [ "$COMPONENT" = "cuda" ] || [ "$COMPONENT" = "nvml" ]; then
+    module unload glibc
     export MODULEPATH=$MODULEPATH:/apps/spacks/cuda/share/spack/modules/linux-rocky9-skylake_avx512/
     module load  cuda/12.8.0
     export PAPI_CUDA_ROOT=$ICL_CUDA_ROOT
+    export LD_LIBRARY_PATH=$PAPI_CUDA_ROOT/lib64:$PAPI_CUDA_ROOT/extras/CUPTI/lib64:$LD_LIBRARY_PATH
 fi
 
 # --- Configure and Build PAPI ---

--- a/.github/workflows/ci_papi_framework.sh
+++ b/.github/workflows/ci_papi_framework.sh
@@ -48,6 +48,7 @@ case "$COMPONENTS" in
     export MODULEPATH=$MODULEPATH:/apps/spacks/cuda/share/spack/modules/linux-rocky9-skylake_avx512/
     module load cuda/12.8.0
     export PAPI_CUDA_ROOT=$ICL_CUDA_ROOT
+    export LD_LIBRARY_PATH=$PAPI_CUDA_ROOT/lib64:$PAPI_CUDA_ROOT/extras/CUPTI/lib64:$LD_LIBRARY_PATH
     ;;
 esac
 


### PR DESCRIPTION
## Pull Request Description
Some of the ICL systems, namely Guyot and Hexane have been updated to support Cuda Toolkit 13. Due to this change, these systems see their system-installed Cuda Toolkit versions' be 13. Therefore, we must tell the system at runtime where to find the library; otherwise, we run into the error `error while loading shared libraries: libcudart.so.12`.

This PR updates the Cuda component tests to now:

- Explicitly set the path to `libcudart.so` using `LD_LIBRARY_PATH`.
- Explicitly set the path to `libcupti.so` using `LD_LIBRARY_PATH` as a precautionary safety net. I do not encounter the error `error while loading shared libraries: libcupti.so.12` for the Cuda component tests, but I did encounter it with the sample codes in CUPTI.
- Use `module unload glibc`

Thank you to Geri for discussing the topic with me.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
