### PR TITLE
cuda: Add explicit check for the use of Cuda Toolkit's >= 13 with ccs < 7.5

### DIFF
--- a/src/components/cuda/papi_cupti_common.c
+++ b/src/components/cuda/papi_cupti_common.c
@@ -603,6 +603,14 @@ int cuptic_init(void)
         return papi_errno;
     }
 
+    // Verify that Cuda Toolkit's >= 13 are not being used with devices that have cc's < 7.5
+    int cudaRuntimeVersion;
+    cudaArtCheckErrors( cudaRuntimeGetVersionPtr(&cudaRuntimeVersion), return PAPI_EMISC );
+    if (cudaRuntimeVersion >= 13000 && system_ccs != sys_gpu_ccs_all_gt_70) {
+        cuptic_err_set_last("Cuda Toolkit's >= 13 do not support offline compilation for architectures prior to cc's < 7.5. On mixed cc machines utilize 'export CUDA_VISIBLE_DEVICES'.\n");
+        return PAPI_ECMP;
+    }
+
     // Get an array of the available devices on the system
     papi_errno = get_enabled_devices();
     if (papi_errno != PAPI_OK) {


### PR DESCRIPTION
## Pull Request Description
In Cuda Toolkit 13, support for offline compilation for architectures prior to cc's < 7.5 have been removed.

Currently the `cuda` component is able to be compiled using Cuda Toolkit 13 on a machine with cc's < 7.5. However, if a user ran `./papi_component_avail` they would be met with the `cuda` component being disabled with a message of:
```
Name:   cuda                    CUDA profiling via NVIDIA CuPTI interfaces
   \-> Disabled: Unable to initialize CUPTI profiler libraries.
```

This PR introduces a conditional check to make sure that a Cuda Toolkit version >= 13 is not being used on a machine with devices that have cc's < 7.5. If this conditional check is met then a more apt error message is now provided:
```
Name:   cuda                    CUDA profiling via NVIDIA CuPTI interfaces
   \-> Disabled: Cuda Toolkit's >= 13 do not support offline compilation for architectures prior to cc's < 7.5. On mixed cc machines utilize 'export CUDA_VISIBLE_DEVICES'.
```

## Testing

1. Using Cuda Toolkit 13 on a machine with mixed cc's (1 * V100 and 1 * H100) result in the proper error message being shown:
```
Name:   cuda                    CUDA profiling via NVIDIA CuPTI interfaces
   \-> Disabled: Cuda Toolkit's >= 13 do not support offline compilation for architectures prior to cc's < 7.5. On mixed cc machines utilize 'export CUDA_VISIBLE_DEVICES'
```

2. Using Cuda Toolkit 13 on a machine with mixed cc's (1 * V100 and 1 * H100) and using `export CUDA_VISIBLE_DEVICES=0` which corresponds to the H100 only being seen results in:

    - The `cuda` component being active
    - `papi_component_avail`, `papi_native_avail`, and `papi_command_line` all successfully working
    - The `cuda` component tests all passing
 
3. Using Cuda Toolkit 12.6 on a machine with mixed cc's (1 * V100 and 1 * H100) results in:

    - The `cuda` component being active
    - `papi_component_avail`, `papi_native_avail`, and `papi_command_line` all successfully working
    - The `cuda` component tests all passing

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
