### PR TITLE
cuda: In tests/Makefile add a conditional check to append -Wno-deprecated-gpu-targets for Cuda Toolkit 12.8 and 12.9

### DIFF
--- a/src/components/cuda/tests/Makefile
+++ b/src/components/cuda/tests/Makefile
@@ -15,6 +15,16 @@ TESTS_NOCTX = concurrent_profiling_noCuCtx pthreads_noCuCtx \
 NVCC = $(PAPI_CUDA_ROOT)/bin/nvcc
 NVCC_VERSION := $(shell $(NVCC) --version | grep -oP '(?<=release )\d+\.\d+')
 
+PAPI_FLAG = -DPAPI    # Comment this line for tests to run without PAPI profiling
+NVCFLAGS = -g -ccbin='$(CC)' $(PAPI_FLAG)
+
+# Check to see if the Cuda Toolkit version is either 12.8 or 12.9 such that
+# we can add -Wno-deprecated-gpu-targets to avoid compilation warning
+CUDA_TOOLKIT_EQUAL_TO_12_8_OR_12_9 := $(shell echo "$(NVCC_VERSION)" | awk '{print ($$1 == 12.8 || $$1 == 12.9)}')
+ifeq ($(CUDA_TOOLKIT_EQUAL_TO_12_8_OR_12_9), 1)
+    NVCFLAGS += -Wno-deprecated-gpu-targets
+endif
+
 # Check to see if we are using a Cuda Toolkit version greater than or equal to 13
 # as the API call for cuCtxCreate changed at this version
 CUDA_TOOLKIT_GE_13 := $(shell echo "$(NVCC_VERSION) 13.0" | awk '{print $$1 >= $$2}')
@@ -23,8 +33,6 @@ ifeq ($(CUDA_TOOLKIT_GE_13), 1)
     CUDA_CPPFLAGS += -DCUDA_TOOLKIT_GE_13
 endif
 
-PAPI_FLAG = -DPAPI    # Comment this line for tests to run without PAPI profiling
-NVCFLAGS = -g -ccbin='$(CC)' $(PAPI_FLAG)
 ifeq ($(BUILD_SHARED_LIB),yes)
 	NVCFLAGS += -Xcompiler -fpic
 endif


### PR DESCRIPTION
## Pull Request Description
Issue/Background:
Starting at Cuda Toolkit 12.8 a compilation warning will occur for the `cuda` component tests:
```
nvcc warning : Support for offline compilation for architectures prior to '<compute/sm/lto>_75' will be removed in a future release (Use -Wno-deprecated-gpu-targets to suppress warning).
```

Note that:

- I do not have access to Cuda Toolkit 12.9; however, from looking more into the warning I have [seen](https://github.com/ggml-org/whisper.cpp/issues/3339#issue-3259498607) other users of Cuda Toolkit 12.9 experience the compilation warning
- This compilation warning stops at Cuda Toolkit 13 from my testing

Resolution:
This PR adds a conditional check in the `cuda/tests/Makefile` to append the flag `-Wno-deprecated-gpu-targets` if a user is using Cuda Toolkit 12.8 or Cuda Toolkit 12.9.

## Testing
Testing was done on Illyad at Oregon using Cuda Toolkit 12.6.3 and Cuda Toolkit 12.8.1. Illyad has the following setup:
 - CPU: AMD EPYC 7402
 - GPU: 1 * H100
 - OS: RHEL 8.10

| Cuda Toolkit Version  | PAPI Build Successful | PAPI Utilities * | Component Tests | 
| ------------- | ------------- | ------------- |  ------------- | 
| 12.6.3  | ✅   | ✅   | ✅   | 
| 12.8.1  | ✅   | ✅  |  ✅  | 
 
__*__ - Utilities ran include `papi_component_avail`, `papi_native_avail`, and `papi_command_line`


## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
