### PR TITLE
cuda: For the disabled reason in cuda_init_private check the snprintf return value with PAPI_HUGE_STR_LEN instead of PAPI_MAX_STR_LEN

### DIFF
--- a/src/components/cuda/linux-cuda.c
+++ b/src/components/cuda/linux-cuda.c
@@ -204,7 +204,7 @@ static int cuda_init_private(void)
         // Cuda component is disabled
         else {
             strLen = snprintf(_cuda_vector.cmp_info.disabled_reason, PAPI_HUGE_STR_LEN, "%s", err_string);
-            if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+            if (strLen < 0 || strLen >= PAPI_HUGE_STR_LEN) {
                 SUBDBG("Failed to fully write the disabled reason.\n");
             }
             goto fn_fail;


### PR DESCRIPTION
## Pull Request Description
Issue/Background:
Currently in the master branch, writing the disabled reason in `cuda_init_private` can result in the reason being truncated. This is due to the following block of code:
```
strLen = snprintf(_cuda_vector.cmp_info.disabled_reason, PAPI_HUGE_STR_LEN, "%s", err_string);
if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
    SUBDBG("Failed to fully write the disabled reason.\n");
}
```

`snprintf` can write up to a maximum of `PAPI_HUGE_STR_LEN`; however, the check just below it uses `PAPI_MAX_STR_LEN`. 

Resolution:
This PR resolves this issue by changing `PAPI_MAX_STR_LEN` to `PAPI_HUGE_STR_LEN`.


## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
