### PR TITLE
Update PAPI_derived_event_files(1) with PAPI environment variable info

### DIFF
--- a/src/utils/papi_avail.c
+++ b/src/utils/papi_avail.c
@@ -110,9 +110,31 @@
  *
  * <br>
  *    @subsection notes Notes:
- *        The PRESET command has traditionally been used in the PAPI provided preset definition file.
- *        The EVENT command is intended to be used in user defined event definition files.  The code treats them
- *        the same so they are interchangeable and they can both be used in either event definition file.<br>
+ *        The PRESET command has traditionally been used in the PAPI-provided preset event definition file titled papi_events.csv.
+ *        While the EVENT command is intended to be used in user-defined event definition files i.e. my_user_defined_event.csv.
+ *        An important note is that the code treats them the same so they are interchangeable and both can be used in either definition file.
+ *
+ *        To override the existing preset event definitions defined in papi_events.csv, you must export PAPI_CSV_EVENT_FILE to a .csv file
+ *        containing your list of preset event definitions. As an example:
+ *        @code
+ *        edit my_preset_events.csv
+ *        CPU,skx
+ *        PRESET,PAPI_TOT_CYC,NOT_DERIVED,CPU_CLK_THREAD_UNHALTED:THREAD_P
+ *        PRESET,PAPI_TOT_INS,NOT_DERIVED,INST_RETIRED:ANY_P
+ *        PRESET,PAPI_REF_CYC,NOT_DERIVED,UNHALTED_REFERENCE_CYCLES
+ *        close my_preset_events.csv
+ *        export PAPI_CSV_EVENT_FILE=$PWD/my_preset_events.csv
+ *        @endcode
+ *
+ *        To add your own user-defined event definitions, you must export PAPI_USER_EVENTS_FILE to a .csv file containing your list of event definitions.
+ *        As an example:
+ *        @code
+ *        edit my_user_defined_events.csv
+ *        CPU,skx
+ *        EVENT,USER_TOT_CYC,NOT_DERIVED,PAPI_TOT_CYC
+ *        close my_user_defined_events.csv
+ *        export PAPI_USER_EVENTS_FILE=$PWD/my_user_defined_events.csv
+ *        @endcode
  *
  * <br>
  *    @subsection types Derived Types:


### PR DESCRIPTION
## Pull Request Description

Dear papi library development team,

This PR updates the manual to include information on how to try out modified preset events and user-defined events.

---

**1. Files Changed**
*   PAPI_derived_event_files.1

**2. Details of Changes**
Currently, PAPI_derived_event_files(1) describes the syntax for defining preset events, but it lacks instructions on how to modify existing preset event settings at application runtime using an environment variable. Additionally, while user-defined events can be added, their configuration method is not documented. Therefore, this PR adds the necessary configuration details to the manual.

Please review and merge these patches

Best regards.
Yoshiteru Teranishi

## Testing
This PR updates PAPI_derived_event_files(1). It has been tested by displaying the manual using the man -l command and confirming that there are no issues.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
