### PR TITLE
rocm_smi: Remove rocm_smi.h from rocm_smi_writeTests as it is an unneeded dependency

### DIFF
--- a/src/components/rocm_smi/tests/rocm_smi_writeTests.cpp
+++ b/src/components/rocm_smi/tests/rocm_smi_writeTests.cpp
@@ -10,7 +10,6 @@
 #include <stdbool.h>
 #include "papi.h"
 #include <hip/hip_runtime.h>
-#include "rocm_smi.h"
 #include "force_init.h"
 
 // Helper Function


### PR DESCRIPTION
## Pull Request Description
Currently in the master branch if configuring PAPI with`./configure --prefix=$PWD/test-install --with-components="rocm_smi"` and using ROCm 6.3.2 a compilation error can occur if `/usr/include/libdrm` does not exist:
```
In file included from rocm_smi_writeTests.cpp:13:
In file included from /opt/rocm/include/rocm_smi/rocm_smi.h:57:
/opt/rocm/include/rocm_smi/kfd_ioctl.h:26:10: fatal error: 'libdrm/drm.h' file not found
   26 | #include <libdrm/drm.h>
      |          ^~~~~~~~~~~~~~
1 error generated when compiling for gfx906.
```

This PR removes `#include "rocm_smi.h"` from the list of includes in `rocm_smi_writeTests.cpp` as this is an unneeded dependency.

## Testing
Testing was done on Histamine3 at ICL, which has the following setup:
- OS: Rocky Linux 9.6
- GPU: 2 * Radeon VII
- CPU: AMD EPYC 7302 16-Core Processor
- ROCm Version: 6.3.2

With this change, the compilation error does not occur. As well as the utilities `./papi_component_avail`, `./papi_native_avail`, and `./papi_command_line` all are successful.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
