### PR TITLE
topdown: Add return type for TOPDOWN_MEM_BOUND_PERC

### DIFF
--- a/src/components/topdown/topdown.c
+++ b/src/components/topdown/topdown.c
@@ -486,6 +486,7 @@ _topdown_init_component(int cidx)
 		i++;
 		strcpy(topdown_native_events[i].name, "TOPDOWN_MEM_BOUND_PERC");
 		strcpy(topdown_native_events[i].description, "The percentage of pipeline slots that were stalled due to demand load/store instructions");
+		strcpy(topdown_native_events[i].units, "%");
 		topdown_native_events[i].return_type = PAPI_DATATYPE_FP64;
 		topdown_native_events[i].metric_idx = TOPDOWN_METRIC_IDX_MEM_BOUND;
 		topdown_native_events[i].selector = i + 1;


### PR DESCRIPTION
## Pull Request Description
This pull request resolves Issue #499 - `TOPDOWN_MEM_BOUND_PERC` does not have a `return_type` set which causes junk values:
```
[tburgess@picard bin]$ ./papi_command_line topdown:::TOPDOWN_MEM_BOUND_PERC

This utility lets you add events from the command line interface to see if they work.

Successfully added: topdown:::TOPDOWN_MEM_BOUND_PERC

topdown:::TOPDOWN_MEM_BOUND_PERC : 	4627205775998058496 
```

Along, with resolving Issue #499, units were added for `TOPDOWN_MEM_BOUND_PERC` as well.

## Testing
Testing was done on Picard at Oregon, with the setup:
- CPU: Intel Xeon Gold 6430 (Sapphire Rapids)
- OS: RHEL 8.10
- PAPI Configure: `./configure --prefix=$PWD/test-install --with-components="topdown"`

`TOPDOWN_MEM_BOUND_PERC` does not result in junk values now:
```
[tburgess@picard bin]$ ./papi_command_line topdown:::TOPDOWN_MEM_BOUND_PERC

This utility lets you add events from the command line interface to see if they work.

Successfully added: topdown:::TOPDOWN_MEM_BOUND_PERC

topdown:::TOPDOWN_MEM_BOUND_PERC : 	23.137 

----------------------------------
```

As well as units now show for `TOPDOWN_MEM_BOUND_PERC` when running `./papi_native_avail`:
```
--------------------------------------------------------------------------------
| topdown:::TOPDOWN_MEM_BOUND_PERC                                             |      
|            The percentage of pipeline slots that were stalled due to demand l|
|            oad/store instructions                                            |      
|     Units: %                                                                 |      
--------------------------------------------------------------------------------
```



## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
