### PR TITLE
appio: Mark intercepting functions as public such that they are properly linked when using the PAPI shared library

### DIFF
--- a/src/components/appio/appio.c
+++ b/src/components/appio/appio.c
@@ -176,7 +176,7 @@ static const struct appio_counters {
  ********************************************************************/
 
 int __close(int fd);
-int close(int fd) {
+__attribute__ ((visibility ("default"))) int close(int fd) {
   int retval;
   SUBDBG("appio: intercepted close(%d)\n", fd);
   retval = __close(fd);
@@ -185,7 +185,7 @@ int close(int fd) {
 }
 
 int __open(const char *pathname, int flags, mode_t mode);
-int open(const char *pathname, int flags, mode_t mode) {
+ __attribute__ ((visibility ("default"))) int open(const char *pathname, int flags, mode_t mode) {
   int retval;
   SUBDBG("appio: intercepted open(%s,%d,%d)\n", pathname, flags, mode);
   retval = __open(pathname,flags,mode);
@@ -200,7 +200,7 @@ int open(const char *pathname, int flags, mode_t mode) {
 struct timeval zerotv; /* this has to be zero, so define it here */
 
 int __select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout);
-int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout) {
+__attribute__ ((visibility ("default"))) int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout) {
   int retval;
   SUBDBG("appio: intercepted select(%d,%p,%p,%p,%p)\n", nfds,readfds,writefds,exceptfds,timeout);
   long long start_ts = PAPI_get_real_usec();
@@ -211,7 +211,7 @@ int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struc
 }
 
 off_t __lseek(int fd, off_t offset, int whence);
-off_t lseek(int fd, off_t offset, int whence) {
+__attribute__ ((visibility ("default"))) off_t lseek(int fd, off_t offset, int whence) {
   off_t retval;
   SUBDBG("appio: intercepted lseek(%d,%ld,%d)\n", fd, offset, whence);
   long long start_ts = PAPI_get_real_usec();
@@ -226,7 +226,7 @@ off_t lseek(int fd, off_t offset, int whence) {
 
 extern int errno;
 ssize_t __read(int fd, void *buf, size_t count);
-ssize_t read(int fd, void *buf, size_t count) {
+__attribute__ ((visibility ("default"))) ssize_t read(int fd, void *buf, size_t count) {
   int retval;
   SUBDBG("appio: intercepted read(%d,%p,%lu)\n", fd, buf, (unsigned long)count);
 
@@ -276,7 +276,7 @@ ssize_t read(int fd, void *buf, size_t count) {
 }
 
 size_t _IO_fread(void *ptr, size_t size, size_t nmemb, FILE *stream);
-size_t fread(void *ptr, size_t size, size_t nmemb, FILE *stream) {
+__attribute__ ((visibility ("default"))) size_t fread(void *ptr, size_t size, size_t nmemb, FILE *stream) {
   size_t retval;
   SUBDBG("appio: intercepted fread(%p,%lu,%lu,%p)\n", ptr, (unsigned long) size, (unsigned long) nmemb, (void*) stream);
   long long start_ts = PAPI_get_real_usec();
@@ -299,7 +299,7 @@ size_t fread(void *ptr, size_t size, size_t nmemb, FILE *stream) {
 }
 
 ssize_t __write(int fd, const void *buf, size_t count);
-ssize_t write(int fd, const void *buf, size_t count) {
+__attribute__ ((visibility ("default"))) ssize_t write(int fd, const void *buf, size_t count) {
   int retval;
   SUBDBG("appio: intercepted write(%d,%p,%lu)\n", fd, buf, (unsigned long)count);
   struct stat st;
@@ -350,7 +350,7 @@ ssize_t write(int fd, const void *buf, size_t count) {
 // The PIC test implies it's built for shared linkage
 #ifdef PIC
 static ssize_t (*__recv)(int sockfd, void *buf, size_t len, int flags) = NULL;
-ssize_t recv(int sockfd, void *buf, size_t len, int flags) {
+__attribute__ ((visibility ("default"))) ssize_t recv(int sockfd, void *buf, size_t len, int flags) {
   int retval;
   SUBDBG("appio: intercepted recv(%d,%p,%lu,%d)\n", sockfd, buf, (unsigned long)len, flags);
   if (!__recv) __recv  = dlsym(RTLD_NEXT, "recv");
@@ -388,7 +388,7 @@ ssize_t recv(int sockfd, void *buf, size_t len, int flags) {
 #endif /* PIC */
 
 size_t _IO_fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
-size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream) {
+__attribute__ ((visibility ("default"))) size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream) {
   size_t retval;
   SUBDBG("appio: intercepted fwrite(%p,%lu,%lu,%p)\n", ptr, (unsigned long) size, (unsigned long) nmemb, (void*) stream);
   long long start_ts = PAPI_get_real_usec();


### PR DESCRIPTION
## Pull Request Description
In the appio component, if you compile the tests `appio_test_seek.c`, `appio_test_fread_fwrite.c`, `appio_test_read_write.c`, `appio_test_values_by_code.c`, `appio_test_values_by_name.c` , and `appio_test_pthreads.c` with the PAPI shared library, the counter values will be zero:
```
[ICL:methane tests]$ gcc -I. -I../../.. -I../../../testlib -I../../../validation_tests appio_test_read_write.c -o appio_test_read_write ../../../testlib/libtestlib.a ../../../libpapi.so
[ICL:methane tests]$ ./appio_test_read_write
This program will read /etc/group and write it to /dev/null
----
OPEN_CALLS: 0
OPEN_FDS: 0
READ_CALLS: 0
READ_BYTES: 0
READ_USEC: 0
READ_ERR: 0
READ_INTERRUPTED: 0
READ_WOULD_BLOCK: 0
WRITE_CALLS: 0
WRITE_BYTES: 0
WRITE_USEC: 0
WRITE_WOULD_BLOCK: 0
PASSED
```

With the PAPI static library this does not occur. 

Further, if we use `LD_DEBUG=all` on the executable for `test_appio_read_write.c` you will see that for `open` we bind with `libc.so.6`versions rather than our own implementation:
```
3890941: symbol=open;  lookup in file=/home/tburgess/papi_fork/papi/src/test-install/lib/libpapi.so.7.2 [0]
3890941: symbol=open;  lookup in file=/lib64/libc.so.6 [0]
3890941: binding file ./appio_test_read_write [0] to /lib64/libc.so.6 [0]: normal symbol `open' [GLIBC_2.2.5]
```

This PR resolves this behavior by explicitly setting our intercepting functions as public.

## Testing
Testing was done on Methane at ICL with the setup of:
- CPU: Intel Xeon Gold 6140
- OS: Rocky Linux 9.6
- GCC: 11.5

The aforementioned tests that returned 0 values when linking with the PAPI shared library now do not show zero values. Further, these values are comparable to the case of linking with the static library:
```
[ICL:methane tests]$ gcc -I. -I../../.. -I../../../testlib -I../../../validation_tests appio_test_read_write.c -o appio_test_read_write ../../../testlib/libtestlib.a ../../../libpapi.so
[ICL:methane tests]$ ./appio_test_read_write 
This program will read /etc/group and write it to /dev/null
----
OPEN_CALLS: 2
OPEN_FDS: 0
READ_CALLS: 2
READ_BYTES: 766
READ_USEC: 3
READ_ERR: 0
READ_INTERRUPTED: 0
READ_WOULD_BLOCK: 0
WRITE_CALLS: 1
WRITE_BYTES: 766
WRITE_USEC: 1
WRITE_WOULD_BLOCK: 0
PASSED
```

If we again look at the output when using `LD_DEBUG=all` on the executable for `test_appio_read_write.c`, you will now see we bind with our internal implementation of `open`:
```
symbol=open;  lookup in file=./appio_test_read_write [0]
symbol=open;  lookup in file=/home/tburgess/papi_fork/papi/src/test-install/lib/libpapi.so.7.2 [0]
binding file ./appio_test_read_write [0] to /home/tburgess/papi_fork/papi/src/test-install/lib/libpapi.so.7.2 [0]: normal symbol `open'
```

NOTE: The tests `appio_test_blocking.c`, `appio_test_recv`, `appio_test_select`, and `appio_test_socket` were not tested as they currently hang in the master branch and need to be addressed in a separate PR.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
