### PR TITLE
amd_smi: fix linker error

### DIFF
--- a/src/components/amd_smi/tests/Makefile
+++ b/src/components/amd_smi/tests/Makefile
@@ -1,3 +1,6 @@
+NAME=amd_smi
+include ../../Makefile_comp_tests.target
+
 # ROCm + PAPI build settings
 # Set PAPI_AMDSMI_ROOT to your ROCm install prefix (e.g., /opt/rocm or /opt/rocm-6.4.0).
 # Used to find AMD SMI / HIP / ROCm headers and libraries. You can override on the command line.
@@ -31,16 +34,16 @@ EFFECTIVE_INCLUDE_C := $(INCLUDE_PAPI) $(INCLUDE_AMDSMI)
 EFFECTIVE_INCLUDE_HIP := $(EFFECTIVE_INCLUDE_C) $(INCLUDE_HIP)
 
 # Linker flags
-RPATH_FLAGS     ?= -Wl,-rpath,$(PAPI_AMDSMI_ROOT)/lib64 -Wl,-rpath,$(PAPI_AMDSMI_ROOT)/lib
-COMMON_LDFLAGS  = $(RPATH_FLAGS) -ldl -g -lpthread
-LDFLAGS_AMDSMI  = $(UTILOBJS) $(PAPILIB) -L$(PAPI_AMDSMI_ROOT)/lib -lamd_smi $(COMMON_LDFLAGS)
-LDFLAGS_GEMM    = $(UTILOBJS) $(PAPILIB) -L$(PAPI_AMDSMI_ROOT)/lib -lrocblas $(COMMON_LDFLAGS)
+COMMON_LDFLAGS  = $(UTILOBJS) $(PAPILIB) -L$(PAPI_AMDSMI_ROOT)/lib -L$(PAPI_AMDSMI_ROOT)/lib64 $(LDFLAGS) -pthread
+LDFLAGS_AMDSMI  = $(COMMON_LDFLAGS) -lamd_smi
+LDFLAGS_GEMM    = $(COMMON_LDFLAGS) -lrocblas
 
 # AMD SMI tests to build with 'make tests'
 TESTS_AMDSMI := amdsmi_energy_monotonic amdsmi_ctx_conflict amdsmi_set_test
 
 # Default target
-all: amdsmi_hello amdsmi_basics amdsmi_gemm $(TESTS_AMDSMI)
+TESTS = amdsmi_hello amdsmi_basics amdsmi_gemm $(TESTS_AMDSMI)
+amd_smi_tests: $(TESTS)
 
 # ------------------------
 # Compile rules
@@ -60,14 +63,14 @@ amdsmi_gemm.o: amdsmi_gemm.c
 
 # amdsmi_hello replaces the older amdsmi_example
 amdsmi_hello: amdsmi_hello.o $(UTILOBJS) $(PAPILIB)
-	$(CC) $(CFLAGS) $(CSTD) $(OPTFLAGS) $(EFFECTIVE_INCLUDE_C) -o $@ amdsmi_hello.o $(LDFLAGS_AMDSMI)
+	$(HIPCC) $(CFLAGS) $(CSTD) $(OPTFLAGS) $(EFFECTIVE_INCLUDE_C) -o $@ amdsmi_hello.o $(LDFLAGS_AMDSMI)
 
 # Back-compat alias: allow 'make amdsmi_example' to build amdsmi_hello
 amdsmi_example: amdsmi_hello
 	@true
 
 amdsmi_basics: amdsmi_basics.o $(UTILOBJS) $(PAPILIB)
-	$(CC) $(CFLAGS) $(CSTD) $(OPTFLAGS) $(EFFECTIVE_INCLUDE_C) -o $@ amdsmi_basics.o $(LDFLAGS_AMDSMI)
+	$(HIPCC) $(CFLAGS) $(CSTD) $(OPTFLAGS) $(EFFECTIVE_INCLUDE_C) -o $@ amdsmi_basics.o $(LDFLAGS_AMDSMI)
 
 # GEMM sample linked against rocBLAS
 amdsmi_gemm: amdsmi_gemm.o $(UTILOBJS) $(PAPILIB)
@@ -75,13 +78,13 @@ amdsmi_gemm: amdsmi_gemm.o $(UTILOBJS) $(PAPILIB)
 
 # Tests
 amdsmi_energy_monotonic: amdsmi_energy_monotonic.o $(UTILOBJS) $(PAPILIB)
-	$(CC) $(CFLAGS) $(CSTD) $(OPTFLAGS) $(EFFECTIVE_INCLUDE_C) -o $@ amdsmi_energy_monotonic.o $(LDFLAGS_AMDSMI)
+	$(HIPCC) $(CFLAGS) $(CSTD) $(OPTFLAGS) $(EFFECTIVE_INCLUDE_C) -o $@ amdsmi_energy_monotonic.o $(LDFLAGS_AMDSMI)
 
 amdsmi_ctx_conflict: amdsmi_ctx_conflict.o $(UTILOBJS) $(PAPILIB)
-	$(CC) $(CFLAGS) $(CSTD) $(OPTFLAGS) $(EFFECTIVE_INCLUDE_C) -o $@ amdsmi_ctx_conflict.o $(LDFLAGS_AMDSMI)
+	$(HIPCC) $(CFLAGS) $(CSTD) $(OPTFLAGS) $(EFFECTIVE_INCLUDE_C) -o $@ amdsmi_ctx_conflict.o $(LDFLAGS_AMDSMI)
 
 amdsmi_set_test: amdsmi_set_test.o $(UTILOBJS) $(PAPILIB)
-	$(CC) $(CFLAGS) $(CSTD) $(OPTFLAGS) $(EFFECTIVE_INCLUDE_C) -o $@ amdsmi_set_test.o $(LDFLAGS_AMDSMI)
+	$(HIPCC) $(CFLAGS) $(CSTD) $(OPTFLAGS) $(EFFECTIVE_INCLUDE_C) -o $@ amdsmi_set_test.o $(LDFLAGS_AMDSMI)
 
 $(UTILOBJS):
 	$(MAKE) -C ../../../testlib libtestlib.a
@@ -120,6 +123,7 @@ checkpath:
 	@echo "OPTFLAGS = $(OPTFLAGS)"
 	@echo "UTILOBJS = $(UTILOBJS)"
 	@echo "PAPILIB = $(PAPILIB)"
+	@echo "LDFLAGS = $(LDFLAGS)"
 	@echo "COMMON_LDFLAGS = $(COMMON_LDFLAGS)"
 	@echo "LDFLAGS_AMDSMI = $(LDFLAGS_AMDSMI)"
 	@echo "LDFLAGS_GEMM = $(LDFLAGS_GEMM)"


### PR DESCRIPTION
## Pull Request Description
I encountered the following error when I configure PAPI with both the amd_smi and rocp_sdk components:
>Error:  Unable to find cray-libsci/24.11.0 libraries compatible with gcc/12.2.0 targeting 'x86-trento'.

Unloading the `cray-libsci` module resolves the above error, but then yields the following:
> cc -DPAPI_NUM_COMP=3 -std=c11 -O2 -I. -I../../.. -I../../../testlib -I../../../validation_tests -I../../../include -I/opt/rocm-7.0.2/include -I/opt/rocm-7.0.2/include/rocm_smi -o amdsmi_hello amdsmi_hello.o ../../../testlib/libtestlib.a ../../../libpapi.a -L/opt/rocm-7.0.2/lib -lamd_smi -Wl,-rpath,/opt/rocm-7.0.2/lib64 -Wl,-rpath,/opt/rocm-7.0.2/lib -ldl -g -lpthread
> /usr/lib64/gcc/x86_64-suse-linux/7/../../../../x86_64-suse-linux/bin/ld: ../../../libpapi.a(sdk_class.o): undefined reference to symbol '_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7compareEPKc@@GLIBCXX_3.4.21'
> /usr/lib64/gcc/x86_64-suse-linux/7/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/libstdc++.so.6: error adding symbols: DSO missing from command line

This can be resolved by appending -lstdc++ to the linker flags, and the most consistent manner to achieve this is to use the existing LDFLAGS variable by including Makefile_comp_tests.target. However, this also overwrites the CC variable from cc (which in my case aliases a different compiler). In my testing, this results in the error:
> /usr/bin/ld: /opt/rocm-7.0.2/lib/libamd_smi.so: undefined reference to `std::ios_base_library_init()@GLIBCXX_3.4.32'

This error is resolved by using HIPCC instead of CC for the targets.

These changes have been tested on Frontier, which has the AMD MI250X architecture and ROCm 7.0.2.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
