### PR TITLE
rocm_smi: Remove the need for users to set PAPI_ROCM_ROOT for tests/Makefile

### DIFF
--- a/src/components/rocm_smi/tests/Makefile
+++ b/src/components/rocm_smi/tests/Makefile
@@ -1,18 +1,28 @@
-# ***NOTE*** The Environment Variable PAPI_ROCM_ROOT must be defined for 
-# programs to compile correctly. one typical location is /opt/rocm, but
-# contact your sysadmin if you cannot find it.
 NAME=rocm_smi
 include ../../Makefile_comp_tests.target
-PAPI_ROCM_ROOT ?= /opt/rocm
-HIPCC ?= $(PAPI_ROCM_ROOT)/bin/hipcc
 
-INCLUDE += -I$(PAPI_ROCMSMI_ROOT)/include
-INCLUDE += -I$(PAPI_ROCM_ROOT)/include
-INCLUDE += -I$(PAPI_ROCM_ROOT)/include/rocm_smi
-INCLUDE += -I$(PAPI_ROCM_ROOT)/include/hip
-INCLUDE += -I$(PAPI_ROCM_ROOT)/include/hsa
-INCLUDE += -I$(PAPI_ROCM_ROOT)/include/rocprofiler
-INCLUDE += -I$(PAPI_ROCM_ROOT)/include/rocblas
+path_to_rocblas =
+rocm_smi_included_in_path := $(shell echo "$(PAPI_ROCMSMI_ROOT)" | grep --ignore-case --fixed-strings rocm_smi)
+# Per the README, for ROCm versions 5.2 and newer users must set PAPI_ROCMSMI_ROOT to /opt/rocm
+ifeq ($(rocm_smi_included_in_path),)
+    HIPCC ?= $(PAPI_ROCMSMI_ROOT)/bin/hipcc
+    INCLUDE += -I$(PAPI_ROCMSMI_ROOT)/include
+    INCLUDE += -I$(PAPI_ROCMSMI_ROOT)/include/rocm_smi
+    INCLUDE += -I$(PAPI_ROCMSMI_ROOT)/include/hip
+    INCLUDE += -I$(PAPI_ROCMSMI_ROOT)/include/hsa
+    INCLUDE += -I$(PAPI_ROCMSMI_ROOT)/include/rocprofiler
+    INCLUDE += -I$(PAPI_ROCMSMI_ROOT)/include/rocblas
+    path_to_rocblas := $(PAPI_ROCMSMI_ROOT)
+# Per the README, for ROCM versions prior to 5.2 users must set PAPI_ROCMSMI_ROOT to /opt/rocm/rocm_smi
+else
+    HIPCC ?= $(PAPI_ROCMSMI_ROOT)/../bin/hipcc
+    INCLUDE += -I$(PAPI_ROCMSMI_ROOT)/../include
+    INCLUDE += -I$(PAPI_ROCMSMI_ROOT)/../include/hip
+    INCLUDE += -I$(PAPI_ROCMSMI_ROOT)/../include/hsa
+    INCLUDE += -I$(PAPI_ROCMSMI_ROOT)/../include/rocprofiler
+    INCLUDE += -I$(PAPI_ROCMSMI_ROOT)/../include/rocblas
+    path_to_rocblas := $(PAPI_ROCMSMI_ROOT)/..
+endif
 ROCM_SMI_LDFLAGS := $(LDFLAGS) -ldl -g -pthread
 
 %.o:%.c


### PR DESCRIPTION
## Pull Request Description
Currently in the master branch, the Makefile in the `rocm_smi` component test directory has a reliance on `PAPI_ROCM_ROOT` even if a user does not have the `rocm` component compiled in:
```
PAPI_ROCM_ROOT ?= /opt/rocm
HIPCC ?= $(PAPI_ROCM_ROOT)/bin/hipcc
```

This can lead to a compile time error if a machine does not have `/opt/rocm` nor has set `PAPI_ROCM_ROOT` which from the `rocm_smi` `README.md`, is not stated as a requirement. Most notably this occurs on Frontier:
```
+ for comp in perf_event perf_event_uncore rocm_smi sysdetect
+ make -C components/rocm_smi/tests
make[2]: Entering directory '/autofs/nccs-svm1_home2/trebu/papi_frontier/papi/src/components/rocm_smi/tests'
/opt/rocm/bin/hipcc -g3  -DHAVE_ROCM_SMI -DPAPI_NUM_COMP=4 -I. -I../../.. -I../../../testlib -I../../../validation_tests -I/opt/rocm-6.1.3/include -I/opt/rocm/include -I/opt/rocm/include/rocm_smi -I/opt/rocm/include/hip -I/opt/rocm/include/hsa -I/opt/rocm/include/rocprofiler -I/opt/rocm/include/rocblas -c rocm_command_line.cpp -o rocm_command_line.o 
make[2]: /opt/rocm/bin/hipcc: Command not found
make[2]: *** [Makefile:37: rocm_command_line.o] Error 127
make[2]: Leaving directory '/autofs/nccs-svm1_home2/trebu/papi_frontier/papi/src/components/rocm_smi/tests'
make[1]: *** [Makefile.inc:266: comp_tests] Error 2
make[1]: Leaving directory '/autofs/nccs-svm1_home2/trebu/papi_frontier/papi/src'
make: *** [Rules.pfm4_pe:43: libpfm4/lib/libpfm.a] Error 2

```

This PR removes the need for users to set `PAPI_ROCM_ROOT` when using `rocm_smi` and instead will completely rely on using `PAPI_ROCMSMI_ROOT` for the Makefile in `components/rocm_smi/tests`.

## Testing
Testing was done on Frontier, with the following setup:
- CPU: AMD EPYC 7763 64-Core Processor
- GPU: AMD Instinct MI210
- OS: SUSE Linux Enterprise Server 15 SP6
- ROCm versions: 5.7.1 and 6.4.0

### ROCm 5.7.1 to simulate path of /opt/rocm-5.7.1/rocm_smi
- PAPI build: ✅ 
- PAPI utilities*: ✅ 
- PAPI component tests**: ✅
    - Note that `rocm_smi_all.cpp` did not successfully run when using ROCm 5.7.1, but this behavior was found in the master branch as well
- `rocmsmi_example`: ✅  

### ROCm 6.4.0 to simulate path of /opt/rocm-6.4.0
- PAPI build: ✅ 
- PAPI utilities*: ✅ 
- PAPI component tests**: ✅
- `rocmsmi_example`: ✅

__*__ - Utilities include `papi_component_avail`, `papi_native_avail`, and `papi_command_line`
__**__ - I do not have the necessary permissions on Frontier to run `rocm_smi_writeTests.cpp` with the `PAPI_write()` calls

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
