### PR TITLE
framework: correct the handling of user-defined events

### DIFF
--- a/src/papi_preset.c
+++ b/src/papi_preset.c
@@ -703,7 +703,6 @@ check_derived_events(char *target, int derived_type, hwi_presets_t* results, hwi
 				results->code[results->count] = search[j].code[k];
 				INTDBG("results: %p, name[%d]: %s, code[%d]: %#x\n", results, results->count, results->name[results->count], results->count, results->code[results->count]);
 
-				results->count++;
 			}
 		}
 


### PR DESCRIPTION
## Pull Request Description

- Remove extraneous usage of the masks PAPI_PRESET_MASK and PAPI_UE_MASK.

- Commit 6094678 moved the increment to the number of native terms in a derived event to outside of the function check_native_events. However, the analogous increment was never removed from the function check_derived_events. This commit removes this extraneous increment, which causes errors with user-defined events.

This solves the error which occurs when a user tries to add a user-defined event to an event set:

```
$> PAPI_USER_EVENTS_FILE=./user_events.csv papi_command_line USER_FLOPS
This utility lets you add events from the command line interface to see if they work.
Segmentation fault (core dumped)
```

These changes have been tested on the Frontier supercomputer, which contains the AMD Zen3 architecture.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
