### PR TITLE
cuda perfworks api: Update internal string handling

### DIFF
--- a/src/components/cuda/cupti_utils.h
+++ b/src/components/cuda/cupti_utils.h
@@ -31,8 +31,8 @@ typedef struct {
 } StringVector;
 
 typedef struct event_record_s {
-    char name[PAPI_2MAX_STR_LEN];
-    char basenameWithStatReplaced[PAPI_2MAX_STR_LEN];
+    char name[PAPI_HUGE_STR_LEN];
+    char basenameWithStatReplaced[PAPI_HUGE_STR_LEN];
     char desc[PAPI_HUGE_STR_LEN];
     StringVector * stat;
     cuptiu_bitmap_t device_map;
@@ -42,7 +42,7 @@ typedef struct event_table_s {
     unsigned int count;
     unsigned int event_stats_count;
     unsigned int capacity;
-    char cuda_evts[30][PAPI_2MAX_STR_LEN];
+    char cuda_evts[30][PAPI_HUGE_STR_LEN];
     int cuda_devs[30];
     int evt_pos[30];
     gpu_record_t *avail_gpu_info;

--- a/src/components/cuda/linux-cuda.c
+++ b/src/components/cuda/linux-cuda.c
@@ -371,7 +371,7 @@ static int cuda_init_comp_presets(void)
     char *cname = _cuda_vector.cmp_info.name;
 
     /* Setup presets. */
-    char arch_name[PAPI_2MAX_STR_LEN];
+    char arch_name[PAPI_MAX_STR_LEN];
     int devIdx = -1;
     int numDevices = 0;
 


### PR DESCRIPTION
## Pull Request Description
Issue:
Currently when using the master branch with the following configure `./configure --prefix=$PWD/test-install --with-components="cuda" --with-debug=yes` and on a machine (Hopper1 at Oregon) with an NVIDIA GH200, the following will output when running `papi_native_avail`:
```
[tburgess@hopper1 bin]$ ./papi_native_avail > ntv.out
PAPI Error: Error Code -6,Internal error, please send mail to the developers
PAPI Error: Error Code -6,Internal error, please send mail to the developers
PAPI Error: Error Code -6,Internal error, please send mail to the developers
PAPI Error: Error Code -6,Internal error, please send mail to the developers
PAPI Error: Error Code -6,Internal error, please send mail to the developers
PAPI Error: Error Code -6,Internal error, please send mail to the developers
```

This is due to a few of the CUPTI metrics having a total of 128 characters or more and us internally only copying 128 characters (`PAPI_MAX_STR_LEN`). Which results in us internally chopping off the last few chars and the CUPTI call failing.

This PR resolves this behavior.

## Testing
Testing was done on Hopper1 at Oregon with the setup:
- CPU: ARM Neoverse V2
- GPU: 1 * GH200
- OS: RHEL 9.4
- Cuda Toolkit: 12.8.1

The PAPI utilities `papi_component_avail`, `papi_native_avail`, and `papi_command_line` all ran successfully. Along with the utilities, the Cuda component tests all passed.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
