### PR TITLE
rocm: Resolve dependency on transitive include of string.h

### DIFF
--- a/src/components/rocm/tests/hl_intercept_multi_thread_monitoring.cpp
+++ b/src/components/rocm/tests/hl_intercept_multi_thread_monitoring.cpp
@@ -4,8 +4,10 @@
  *         gcongiu@icl.utk.edu
  *
  */
-#include "common.h"
 #include <pthread.h>
+#include <string.h>
+
+#include "common.h"
 
 int quiet;
 

--- a/src/components/rocm/tests/hl_intercept_single_thread_monitoring.cpp
+++ b/src/components/rocm/tests/hl_intercept_single_thread_monitoring.cpp
@@ -4,8 +4,10 @@
  *         gcongiu@icl.utk.edu
  *
  */
-#include "common.h"
 #include <pthread.h>
+#include <string.h>
+
+#include "common.h"
 
 int quiet;
 

--- a/src/components/rocm/tests/hl_sample_single_thread_monitoring.cpp
+++ b/src/components/rocm/tests/hl_sample_single_thread_monitoring.cpp
@@ -4,8 +4,10 @@
  *         gcongiu@icl.utk.edu
  *
  */
-#include "common.h"
 #include <pthread.h>
+#include <string.h>
+
+#include "common.h"
 
 int quiet;
 


### PR DESCRIPTION
## Pull Request Description
Issue:
Currently in the master branch, if you compile the `rocm` component with ROCm 7.0.1 you will run into the compilation error `error: use of undeclared identifier 'strlen'` for:

- `hl_intercept_multi_thread_monitoring.cpp`
- `hl_intercept_single_thread_monitoring.cpp`
- `hl_sample_single_thread_monitoring.cpp`

This compilation error did not occur in earlier ROCm versions such as ROCm 6.4.0 as we were transitively including `string.h` via `hip/hip_runtime_api.h`. In ROCm 7.0.1, `hip/hip_runtime_api.h` does not include `string.h` thus resulting in the compilation error.

To resolve the compilation error, `#include <string.h>` is explicitly placed in the aforementioned three files.

## Testing
Testing was done on Odyssey at Oregon with the following setup:
- CPU:MI300A
- GPU: MI300A
- OS: RHEL 8.1.0
- ROCm Version: 7.0.1

- PAPI build successful: ✅ 
- PAPI utilities successful*: ✅ 

__*__ - Utilities tested were `papi_component_avail`, `papi_native_avail`, and `papi_command_line`

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
