### PR TITLE
rocm: add AQLPROFILE_READ_API to README

### DIFF
--- a/src/components/rocm/README.md
+++ b/src/components/rocm/README.md
@@ -80,6 +80,9 @@ setting the ROCP\_TOOL\_LIB to the PAPI library as follows:
 
 * For AMD devices older than the AMD Instinct MI300A, PAPI should not be configured with both `rocm` and `rocp_sdk`.
 
+* For ROCm >= 6.2.0, the environment variable `AQLPROFILE_READ_API` should be set to 0 for intercept mode and 1 (or unset) for sampling mode.
+  Otherwise, counter values in intercept mode will return 0. See PAPI Issue #457 for more details.
+
 * PAPI may read zeros for many events if rocprofiler environment variables are
   not exported and HIP functions are executed by the user before the user
   executes PAPI\_library\_init().


### PR DESCRIPTION
## Pull Request Description

Explain how to appropriately set AQLPROFILE_READ_API for ROCm >= 6.2.0.

This documents the key contents of Issue #457 in the `rocm` component's README.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
