### PR TITLE
riscv: Add pthread mutex and libpfm4 config support

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -4976,7 +4976,7 @@ _ACEOF
 
 # First set pthread-mutexes based on arch
 case $arch in
-  aarch64|arm*|parisc*)
+  aarch64|arm*|parisc*|riscv*)
     pthread_mutexes=yes
     CFLAGS="$CFLAGS -DUSE_PTHREAD_MUTEXES"
     echo "forcing use of pthread mutexes... " >&6

--- a/src/configure.in
+++ b/src/configure.in
@@ -577,7 +577,7 @@ AC_DEFINE_UNQUOTED(CPU,$CPU,[cpu type])
 
 # First set pthread-mutexes based on arch                                       
 case $arch in
-  aarch64|arm*|parisc*)
+  aarch64|arm*|parisc*|riscv*)
     pthread_mutexes=yes
     CFLAGS="$CFLAGS -DUSE_PTHREAD_MUTEXES"
     echo "forcing use of pthread mutexes... " >&6

--- a/src/libpfm4/config.mk
+++ b/src/libpfm4/config.mk
@@ -179,6 +179,9 @@ ifeq ($(ARCH),cell)
 CONFIG_PFMLIB_CELL=y
 endif
 
+ifeq ($(ARCH),riscv64)
+CONFIG_PFMLIB_ARCH_RISCV64=y
+endif
 
 #
 # you shouldn't have to touch anything beyond this point


### PR DESCRIPTION
Following commit b464420f3, add pthread mutex configuration for riscv*
architectures and libpfm4 CONFIG_PFMLIB_ARCH_RISCV64 configuration. Tested
on a SiFive P550 processor.

Signed-off-by: Lucas Zampieri <lzampier@redhat.com>