### PR TITLE
Pin GHA dependencies by hash

### DIFF
--- a/.github/workflows/appio_component_workflow.yml
+++ b/.github/workflows/appio_component_workflow.yml
@@ -20,6 +20,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: appio component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/cat_workflow.yml
+++ b/.github/workflows/cat_workflow.yml
@@ -18,6 +18,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: counter analysis toolkit tests
         run: .github/workflows_scripts/ci_cat.sh ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/coretemp_component_workflow.yml
+++ b/.github/workflows/coretemp_component_workflow.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: coretemp component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/cuda_component_workflow.yml
+++ b/.github/workflows/cuda_component_workflow.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: [self-hosted, gpu_nvidia]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: cuda component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/default_components_workflow.yml
+++ b/.github/workflows/default_components_workflow.yml
@@ -21,6 +21,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: default components tests
         run: .github/workflows_scripts/ci_default_components.sh ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/example_component_workflow.yml
+++ b/.github/workflows/example_component_workflow.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: example component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/intel_gpu_component_workflow.yml
+++ b/.github/workflows/intel_gpu_component_workflow.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: [self-hosted, gpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: intel_gpu component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/io_component_workflow.yml
+++ b/.github/workflows/io_component_workflow.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: io component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/lmsensors_component_workflow.yml
+++ b/.github/workflows/lmsensors_component_workflow.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: lmsensors component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/net_component_workflow.yml
+++ b/.github/workflows/net_component_workflow.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: net component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/nvml_component_workflow.yml
+++ b/.github/workflows/nvml_component_workflow.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: [self-hosted, gpu_nvidia]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: nvml component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/papi_framework_workflow.yml
+++ b/.github/workflows/papi_framework_workflow.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: [self-hosted, cpu_intel, gpu_nvidia]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: comprehensive component tests 
         run: .github/workflows_scripts/ci_papi_framework.sh "${{matrix.components}}" ${{matrix.debug}} ${{matrix.shlib}} ${{matrix.hardware}}
   # build PAPI only with rocm and rocm_smi components, as they will not be active in the above comprehensive job
@@ -38,7 +38,7 @@ jobs:
     runs-on: [self-hosted, gpu_amd]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: rocp_sdk and rocm_smi component tests
         run: .github/workflows_scripts/ci_papi_framework.sh "${{matrix.components}}" ${{matrix.debug}} ${{matrix.shlib}} ${{matrix.hardware}}
   # build PAPI only with the infiniband component, as it will not always be active in the above comrehensive job
@@ -53,24 +53,24 @@ jobs:
     runs-on: [self-hosted, infiniband]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: infiniband component tests
         run: .github/workflows_scripts/ci_papi_framework.sh ${{matrix.components}} ${{matrix.debug}} ${{matrix.shlib}} ${{matrix.hardware}}
   papi_spack:
     runs-on: cpu
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build/Test/Install via Spack
         run: .github/workflows_scripts/spack.sh
   papi_clang_analysis:
     runs-on: cpu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Run static analysis
         run: .github/workflows_scripts/clang_analysis.sh clang-analysis-output
       - name: Archive analysis results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: clang-analysis-output

--- a/.github/workflows/powercap_component_workflow.yml
+++ b/.github/workflows/powercap_component_workflow.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: powercap component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/rocm_component_workflow.yml
+++ b/.github/workflows/rocm_component_workflow.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: [self-hosted, gpu_amd]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: rocm component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/rocm_smi_component_workflow.yml
+++ b/.github/workflows/rocm_smi_component_workflow.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: [self-hosted, gpu_amd]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: rocm_smi component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/rocp_sdk_component_workflow.yml
+++ b/.github/workflows/rocp_sdk_component_workflow.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: [self-hosted, gpu_amd]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: rocp_sdk component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/sde_component_workflow.yml
+++ b/.github/workflows/sde_component_workflow.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: sde component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/stealtime_component_workflow.yml
+++ b/.github/workflows/stealtime_component_workflow.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: stealtime component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}


### PR DESCRIPTION
## Pull Request Description

Hash-pinned dependencies are an important requirement enforced by the OpenSSF scorecard tool: https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies

This commit pins all GitHub Actions workflows to a commit hash.
