### PR TITLE
cuda: Update SUBDBG format specifier from %lu to %u to avoid compilation warning

### DIFF
--- a/src/components/cuda/cupti_event_and_metric.c
+++ b/src/components/cuda/cupti_event_and_metric.c
@@ -1588,7 +1588,7 @@ int cuptie_evt_enum(uint32_t *event_code, int modifier)
 
     int papi_errno = PAPI_OK;
     event_info_t info;
-    SUBDBG("ENTER: event_code: %lu, modifier: %d\n", *event_code, modifier);
+    SUBDBG("ENTER: event_code: %u, modifier: %d\n", *event_code, modifier);
 
     switch(modifier) {
         case PAPI_ENUM_FIRST:


### PR DESCRIPTION
## Pull Request Descriptionl
When configuring PAPI as follows `./configure --prefix=$PWD/test-install --with-components="cuda" --with-debug=yes` and subsequently building on Heimdall at Oregon (1 * NVIDIA GeForce RTX 5080) you will run into the below compilation warnings:
```
components/cuda/cupti_event_and_metric.c:1591:12: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘uint32_t’ {aka ‘unsigned int’} [-Wformat=]
 1591 |     SUBDBG("ENTER: event_code: %lu, modifier: %d\n", *event_code, modifier);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~
      |                                                      |
      |                                                      uint32_t {aka unsigned int}
./papi_debug.h:60:115: note: in definition of macro ‘PAPIDEBUG’
   60 | #define PAPIDEBUG(level,format, args...) { if(_papi_hwi_debug&level){DEBUGLABEL(DEBUGLEVEL(level));fprintf(stderr,format, ## args);}}
      |                                                                                                                   ^~~~~~
components/cuda/cupti_event_and_metric.c:1591:5: note: in expansion of macro ‘SUBDBG’
 1591 |     SUBDBG("ENTER: event_code: %lu, modifier: %d\n", *event_code, modifier);
      |     ^~~~~~
components/cuda/cupti_event_and_metric.c:1591:34: note: format string is defined here
 1591 |     SUBDBG("ENTER: event_code: %lu, modifier: %d\n", *event_code, modifier);
      |                                ~~^
      |                                  |
      |                                  long unsigned int
      |                                %u
+ test  != 
```

This PR resolves this compilation warning and closes Issue #519 by updating a format specifier from `%lu` to `%u`.

## Testing
### Setup
This PR was tested on Heimdall at Oregon with:
- CPU: AMD Ryzen 9 9950X 16-Core Processor
- GPU: 1 * NVIDIA GeForce RTX 5080
- OS: Ubuntu 24.04.3
- Cuda Toolkit: 12.9

### Results
- Compilation and PAPI build: ✅ (compilation warnings did not occur)
- PAPI utilities*: ✅ 
- Cuda component tests: ✅ (Note: Running `runtest.sh` will result in test failures as the event `cuda:::dram__bytes_read:stat=sum:device=0` does not exist on Heimdall)

__*__ - `papi_component_avail`, `papi_native_avail`, `papi_command_line`

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
