### PR TITLE
rocp_sdk tests: Add a runscript which can toggle desired events to be used and allow each test to be ran without command line args

### DIFF
--- a/src/components/rocp_sdk/tests/advanced.c
+++ b/src/components/rocp_sdk/tests/advanced.c
@@ -1,24 +1,104 @@
+// Standard library headers
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
-#include <papi.h>
-#include <papi_test.h>
+
+// ROCm headers
 #include <hip/hip_runtime.h>
 
-extern int launch_kernel(int device_id);
-extern void add_desired_component_events(int eventSet, int maxEventsToAdd, const char eventsToAdd[][PAPI_MAX_STR_LEN], char metricNamesAdded[][PAPI_MAX_STR_LEN], int *numEventsSuccessfullyAdded);
-extern void enumerate_and_add_component_events(const char *componentName, int eventSet, int maxEventsToAdd, char metricNamesAdded[][PAPI_MAX_STR_LEN], int *numEventsSuccessfullyAdded);
+// Internal headers
+#include <papi.h>
+#include <papi_test.h>
 
-#define NUM_EVENTS (14)
+extern int launch_kernel(int device_id);
+extern void enumerate_and_store_rocp_sdk_native_events(char ***rocp_sdk_native_event_names, int *total_event_count);
+extern void add_rocp_sdk_native_events(int eventSet, int maxNativeEventsToAdd, char **nativeEventsToAdd);
+
+static void print_help_message(void)
+{
+    printf("./advanced --rocp-sdk-native-event-names [list of rocp_sdk native event names separated by a comma].\n");
+
+}
+
+static void parse_and_assign_args(int argc, char *argv[], char ***rocp_sdk_native_event_names, int *total_event_count)
+{
+    int i;
+    for (i = 1; i < argc; ++i)
+    {
+        char *arg = argv[i];
+        if (strcmp(arg, "--help") == 0)
+        {
+            print_help_message();
+            exit(EXIT_SUCCESS);
+        }
+        else if (strcmp(arg, "--rocp-sdk-native-event-names") == 0)
+        {
+            if (!argv[i + 1])
+            {
+                printf("ERROR!! --rocp-sdk-event-names given, but no events listed.\n");
+                exit(EXIT_FAILURE);
+            }
+
+            char **cmd_line_native_event_names = NULL;
+            const char *rocp_sdk_native_event_name = strtok(argv[i+1], ",");
+            while (rocp_sdk_native_event_name != NULL)
+            {
+                cmd_line_native_event_names = (char **) realloc(cmd_line_native_event_names, ((*total_event_count) + 1) * sizeof(char *));
+                if (cmd_line_native_event_names == NULL) {
+                    fprintf(stderr, "%s:%d: Error: Memory allocation failed.\n", __FILE__, __LINE__);
+                    exit(EXIT_FAILURE);
+                }
+
+                cmd_line_native_event_names[(*total_event_count)] = (char *) malloc(PAPI_MAX_STR_LEN * sizeof(char));
+                if (cmd_line_native_event_names[(*total_event_count)] == NULL) {
+                    fprintf(stderr, "Failed to allocate memory for index %d in rocp_sdk_native_event_names.\n", (*total_event_count));
+                    exit(EXIT_FAILURE);
+                }
+
+                int strLen = snprintf(cmd_line_native_event_names[(*total_event_count)], PAPI_MAX_STR_LEN, "%s", rocp_sdk_native_event_name);
+                if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+                    fprintf(stderr, "Failed to fully write rocp_sdk native event name.\n");
+                    exit(EXIT_FAILURE);
+                }
+
+                (*total_event_count)++;
+                rocp_sdk_native_event_name = strtok(NULL, ",");
+            }
+            *rocp_sdk_native_event_names = cmd_line_native_event_names;
+            i++;
+        }
+        else if (strcmp(arg, "TESTS_QUIET") == 0) {
+            // TESTS_QUIET comes from running run_tests.sh.
+            // As stands, we do not silence any printf's in
+            // this application code. Therefore we acknowledge the case
+            // and continue.
+            continue;
+        }
+        else
+        {
+            print_help_message();
+            exit(EXIT_FAILURE);
+        }
+    }
+}
 
 int main(int argc, char *argv[])
 {
-    int dev_count=0;
-    int papi_errno;
-    long long counters[NUM_EVENTS] = { 0 };
+    int total_event_count = 0;
+    char **rocp_sdk_native_event_names = NULL;
+    if (argc > 1) {
+        parse_and_assign_args(argc, argv, &rocp_sdk_native_event_names, &total_event_count);
+    }
 
-    papi_errno = PAPI_library_init(PAPI_VER_CURRENT);
+    int papi_errno = PAPI_library_init(PAPI_VER_CURRENT);
     if (papi_errno != PAPI_VER_CURRENT) {
         test_fail(__FILE__, __LINE__, "PAPI_library_init", papi_errno);
+    }
+
+    // If a user does not provide an event or events, then we go get an event to add
+    if (total_event_count == 0) {
+        enumerate_and_store_rocp_sdk_native_events(&rocp_sdk_native_event_names, &total_event_count);
     }
 
     int eventset = PAPI_NULL;
@@ -27,46 +107,22 @@ int main(int argc, char *argv[])
         test_fail(__FILE__, __LINE__, "PAPI_create_eventset", papi_errno);
     }
 
-    const char desiredEvents[NUM_EVENTS][PAPI_MAX_STR_LEN] = {
-                  "rocp_sdk:::SQ_CYCLES:device=0",
-                  "rocp_sdk:::SQ_BUSY_CYCLES:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=0:device=0",
-                  "rocp_sdk:::SQ_BUSY_CYCLES:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=1:device=0",
-                  "rocp_sdk:::SQ_BUSY_CYCLES:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=2:device=0",
-                  "rocp_sdk:::SQ_BUSY_CYCLES:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=3:device=0",
-                  "rocp_sdk:::SQ_BUSY_CYCLES:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=4:device=0",
-                  "rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=5",
-                  "rocp_sdk:::SQ_BUSY_CYCLES:DIMENSION_INSTANCE=0",
-                  "rocp_sdk:::SQ_WAVE_CYCLES:DIMENSION_SHADER_ENGINE=0:device=0",
-                  "rocp_sdk:::SQ_WAVE_CYCLES:DIMENSION_SHADER_ENGINE=1:device=0",
-                  "rocp_sdk:::SQ_WAVE_CYCLES:DIMENSION_SHADER_ENGINE=2:device=0",
-                  "rocp_sdk:::SQ_WAVE_CYCLES:DIMENSION_SHADER_ENGINE=3:device=0",
-                  "rocp_sdk:::SQ_WAVE_CYCLES:DIMENSION_SHADER_ENGINE=4:device=0",
-                  "rocp_sdk:::SQ_WAVE_CYCLES:device=0"
-    };
-
-    char nativeEventNamesAdded[NUM_EVENTS][PAPI_MAX_STR_LEN] = { 0 };
-    int numNativeEventsAdded = 0;
-    add_desired_component_events(eventset, NUM_EVENTS, desiredEvents, nativeEventNamesAdded, &numNativeEventsAdded);
-
-    // If we are unable to add any desired events then we enumerate through the available
-    // rocp_sdk native events attempting to add up to NUM_EVENTS
-    if (numNativeEventsAdded == 0) {
-        const char *componentName = "rocp_sdk";
-        enumerate_and_add_component_events(componentName, eventset, NUM_EVENTS, nativeEventNamesAdded, &numNativeEventsAdded);
-    }
-
-    // If we are unable to add any rocp_sdk native events whether that is the desired events
-    // or events we enumerate through then skip the test
-    if (numNativeEventsAdded == 0) {
-        fprintf(stderr, "Unable to add any rocp_sdk native events.\n");
-        test_skip(__FILE__, __LINE__, "", 0);
-    }
+    // Add the native events via command line or enumeration to the EventSet
+    add_rocp_sdk_native_events(eventset, total_event_count, rocp_sdk_native_event_names);
 
     papi_errno = PAPI_start(eventset);
     if (papi_errno != PAPI_OK) {
         test_fail(__FILE__, __LINE__, "PAPI_start", papi_errno);
     }
-    for(int rep=0; rep<=4; ++rep){
+
+    long long *counters = (long long *) malloc(total_event_count * sizeof(long long));
+    if (counters == NULL) {
+        fprintf(stderr, "%s:%d: Error: Memory allocation failed.\n", __FILE__, __LINE__);
+        exit(EXIT_FAILURE);
+    }
+
+    int rep, i;
+    for(rep = 0; rep <= 4; ++rep) {
 
         printf("---------------------  launch_kernel(0)\n");
         papi_errno = launch_kernel(0);
@@ -82,8 +138,8 @@ int main(int argc, char *argv[])
         }
         printf("---------------------  PAPI_read()\n");
 
-        for (int i = 0; i < numNativeEventsAdded; ++i) {
-            fprintf(stdout, "%s: %.2lfM\n", nativeEventNamesAdded[i], (double)counters[i]/1e6);
+        for (i = 0; i < total_event_count; ++i) {
+            fprintf(stdout, "%s: %.2lfM\n", rocp_sdk_native_event_names[i], (double)counters[i]/1e6);
         }
     }
 
@@ -94,10 +150,11 @@ int main(int argc, char *argv[])
 
     printf("---------------------  PAPI_stop()\n");
 
-    for (int i = 0; i < numNativeEventsAdded; ++i) {
-            fprintf(stdout, "%s: %.2lfM\n", nativeEventNamesAdded[i], (double)counters[i]/1e6);
+    for (i = 0; i < total_event_count; ++i) {
+            fprintf(stdout, "%s: %.2lfM\n", rocp_sdk_native_event_names[i], (double)counters[i]/1e6);
     }
 
+    int dev_count = 0;
     if (hipGetDeviceCount(&dev_count) != hipSuccess){
         test_fail(__FILE__, __LINE__, "Error while counting AMD devices:", papi_errno);
     }
@@ -107,7 +164,7 @@ int main(int argc, char *argv[])
         printf("==================== SECOND ROUND ====================\n");
         printf("======================================================\n");
 
-        for(int rep=0; rep<=3; ++rep){
+        for(rep = 0; rep <= 3; ++rep){
             papi_errno = PAPI_start(eventset);
             if (papi_errno != PAPI_OK) {
                 test_fail(__FILE__, __LINE__, "PAPI_start", papi_errno);
@@ -127,8 +184,8 @@ int main(int argc, char *argv[])
             }
             printf("---------------------  PAPI_read()\n");
 
-            for (int i = 0; i < numNativeEventsAdded; ++i) {
-                fprintf(stdout, "%s: %.2lfM\n", nativeEventNamesAdded[i], (double)counters[i]/1e6);
+            for (i = 0; i < total_event_count; ++i) {
+                fprintf(stdout, "%s: %.2lfM\n", rocp_sdk_native_event_names[i], (double)counters[i]/1e6);
             }
 
             papi_errno = PAPI_stop(eventset, counters);
@@ -138,8 +195,8 @@ int main(int argc, char *argv[])
 
             printf("---------------------  PAPI_stop()\n");
 
-            for (int i = 0; i < numNativeEventsAdded; ++i) {
-                fprintf(stdout, "%s: %.2lfM\n", nativeEventNamesAdded[i], (double)counters[i]/1e6);
+            for (i = 0; i < total_event_count; ++i) {
+                fprintf(stdout, "%s: %.2lfM\n", rocp_sdk_native_event_names[i], (double)counters[i]/1e6);
             }
         }
     }
@@ -153,6 +210,13 @@ int main(int argc, char *argv[])
     if (papi_errno != PAPI_OK) {
         test_fail(__FILE__, __LINE__, "PAPI_destroy_eventset", papi_errno);
     }
+
+    //Free memory allocation
+    free(counters);
+    for (i = 0; i < total_event_count; i++) {
+        free(rocp_sdk_native_event_names[i]);
+    }
+    free(rocp_sdk_native_event_names);
 
     PAPI_shutdown();
     test_pass(__FILE__);

--- a/src/components/rocp_sdk/tests/helper_rocp_sdk.c
+++ b/src/components/rocp_sdk/tests/helper_rocp_sdk.c
@@ -1,80 +1,92 @@
+// Standard library headers
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Internal headers
 #include <papi.h>
 #include <papi_test.h>
 
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
-
-/*
- * For the rocp_sdk component tests, take the desired events and attempt to add them.
- */
-void add_desired_component_events(int eventSet, int maxNativeEventsToAdd, const char nativeEventsToAdd[][PAPI_MAX_STR_LEN], char nativeEventNamesAdded[][PAPI_MAX_STR_LEN], int *numNativeEventsAdded)
+/** @class add_rocp_sdk_native_events
+  * @brief Wrapper function to simply add the provided native events to an event set by name.
+  *
+  * @param EventSet
+  *   The EventSet we want to add the events to.
+  * @param total_event_count
+  *   The maximum number of events we will attempt to add.
+  * @param **rocp_sdk_native_event_names
+  *   Names of the rocp_sdk native events we want to add.
+*/
+void add_rocp_sdk_native_events(int EventSet, int total_event_count, char **rocp_sdk_native_event_names)
 {
     int i;
-    int *numEventsAdded = numNativeEventsAdded;
-    for (i = 0; i < maxNativeEventsToAdd; i++) {
-        int papi_errno = PAPI_add_named_event(eventSet, nativeEventsToAdd[i]);
-        if (papi_errno == PAPI_ENOEVNT) {
-            continue;
+    for (i = 0; i < total_event_count; i++) {
+        int papi_errno = PAPI_add_named_event(EventSet, rocp_sdk_native_event_names[i]);
+        if (papi_errno != PAPI_OK) {
+            fprintf(stderr, "Unable to add event %s to the EventSet with error code %d.\n", rocp_sdk_native_event_names[i], papi_errno);
+            exit(EXIT_FAILURE);
         }
-        else if (papi_errno != PAPI_OK){
-            test_fail(__FILE__, __LINE__, "PAPI_add_named_event", papi_errno);
-        }
-
-        int strLen = snprintf(nativeEventNamesAdded[(*numEventsAdded)], PAPI_MAX_STR_LEN, "%s", nativeEventsToAdd[i]);
-        if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
-            fprintf(stderr, "Failed to fully write native event name into index: %d\n", i);
-            exit(1);
-        }
-        (*numEventsAdded)++;
     }
 
     return;
 }
 
-/*
- * Enumerate through the rocp_sdk native events and attempt to add them.
- * This function should only be called if none of the desired events were
- * successfully added. 
- */
-void enumerate_and_add_component_events(const char *componentName, int eventSet, int maxNativeEventsToAdd, char nativeEventNamesAdded[][PAPI_MAX_STR_LEN], int *numNativeEventsAdded)
+/** @class enumerate_and_store_rocp_sdk_native_events
+  * @brief For the case users do not add an event on the command line, enumerate through
+  *        the available rocp_sdk native events and store one to be used for profiling.
+  *
+  * @param ***rocp_sdk_native_event_names
+  *   Stores the enumerated event name to be used for profiling.
+  * @param *total_event_count
+  *   Number of events that were stored.
+*/
+void enumerate_and_store_rocp_sdk_native_events(char ***rocp_sdk_native_event_names, int *total_event_count)
 {
+    int rocp_sdk_cmp_idx = PAPI_get_component_index("rocp_sdk");
+    if (rocp_sdk_cmp_idx < 0) {
+        test_fail(__FILE__, __LINE__, "PAPI_get_component_index", rocp_sdk_cmp_idx);
+    }
 
-    int componentIdx = PAPI_get_component_index(componentName);
-    if (componentIdx < 0) {
-        test_fail(__FILE__, __LINE__, "PAPI_get_component_index", componentIdx);
-    }  
-
-    int eventCode = 0 | PAPI_NATIVE_MASK, modifier = PAPI_ENUM_FIRST;
-    int papi_errno = PAPI_enum_cmp_event(&eventCode, modifier, componentIdx);
+    // Get the first rocp_sdk native event on the architecture
+    int modifier = PAPI_ENUM_FIRST;
+    int rocp_sdk_eventcode = 0 | PAPI_NATIVE_MASK;
+    int papi_errno = PAPI_enum_cmp_event(&rocp_sdk_eventcode, modifier, rocp_sdk_cmp_idx);
     if (papi_errno != PAPI_OK) {
         test_fail(__FILE__, __LINE__, "PAPI_enum_cmp_event", papi_errno);
     }
 
-    int *numEventsAdded = numNativeEventsAdded;
+    // Note: We are only going to get a single event here as stands, but if you want to enumerate more events
+    // then update num_spaces_to_allocate to the desired number.
+    int num_spaces_to_allocate = 1;
+    char **enumerated_rocp_sdk_native_event_names = (char **) malloc(num_spaces_to_allocate * sizeof(char *));
+    if (enumerated_rocp_sdk_native_event_names == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    // Enumerate and store rocp_sdk native events on the architecture
     modifier = PAPI_ENUM_EVENTS;
     do {
-        char eventName[PAPI_MAX_STR_LEN];
-        papi_errno = PAPI_event_code_to_name(eventCode, eventName);
+        char rocp_sdk_eventname[PAPI_MAX_STR_LEN];
+        papi_errno = PAPI_event_code_to_name(rocp_sdk_eventcode, rocp_sdk_eventname);
         if (papi_errno != PAPI_OK) {
             test_fail(__FILE__, __LINE__, "PAPI_event_code_to_name", papi_errno);
         }
 
-        papi_errno = PAPI_add_named_event(eventSet, eventName);
-        if (papi_errno == PAPI_ENOEVNT) {
-            continue;
-        }
-        else if (papi_errno != PAPI_OK) {
-            test_fail(__FILE__, __LINE__, "PAPI_add_named_event", papi_errno);
+        enumerated_rocp_sdk_native_event_names[(*total_event_count)] = (char *) malloc(PAPI_MAX_STR_LEN * sizeof(char));
+        if (enumerated_rocp_sdk_native_event_names[(*total_event_count)] == NULL) {
+            exit(EXIT_FAILURE);
         }
 
-        int strLen = snprintf(nativeEventNamesAdded[(*numEventsAdded)], PAPI_MAX_STR_LEN, "%s", eventName);
+        int strLen = snprintf(enumerated_rocp_sdk_native_event_names[(*total_event_count)], PAPI_MAX_STR_LEN, "%s", rocp_sdk_eventname);
         if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
-            fprintf(stderr, "Failed to fully write native event name into index: %d\n", (*numEventsAdded));
-            exit(1);
+            fprintf(stderr, "Unable to copy the event %s.\n", rocp_sdk_eventname);
+            exit(EXIT_FAILURE);
         }
-        (*numEventsAdded)++;
-    } while(PAPI_enum_cmp_event(&eventCode, modifier, componentIdx) == PAPI_OK && (*numEventsAdded) < maxNativeEventsToAdd);
+
+        (*total_event_count)++;
+
+    } while(PAPI_enum_cmp_event(&rocp_sdk_eventcode, modifier, rocp_sdk_cmp_idx) == PAPI_OK && (*total_event_count) != num_spaces_to_allocate);
+    *rocp_sdk_native_event_names = enumerated_rocp_sdk_native_event_names;
 
     return;
 }

--- a/src/components/rocp_sdk/tests/run_rocp_sdk_tests.sh
+++ b/src/components/rocp_sdk/tests/run_rocp_sdk_tests.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+#Note: It is possible that the listed desired events for each test 
+# may not exist on the architecture you are running on or with the 
+# ROCm version you are using. If you run with the option --with-desired-events
+# and the test fails, verify with utils/papi_native_avail the desired event exists with
+# the appended qualifiers.
+
+absolute_path_to_script_dir=$(cd "$(dirname "$0")" && pwd)
+cd "$absolute_path_to_script_dir"
+
+advanced_desired_events="rocp_sdk:::SQ_CYCLES:device=0,\
+rocp_sdk:::SQ_BUSY_CYCLES:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=0:device=0,\
+rocp_sdk:::SQ_BUSY_CYCLES:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=1:device=0,\
+rocp_sdk:::SQ_BUSY_CYCLES:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=2:device=0,\
+rocp_sdk:::SQ_BUSY_CYCLES:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=3:device=0,\
+rocp_sdk:::SQ_BUSY_CYCLES:DIMENSION_INSTANCE=0,\
+rocp_sdk:::SQ_WAVE_CYCLES:DIMENSION_SHADER_ENGINE=0:device=0,\
+rocp_sdk:::SQ_WAVE_CYCLES:DIMENSION_SHADER_ENGINE=1:device=0,\
+rocp_sdk:::SQ_WAVE_CYCLES:DIMENSION_SHADER_ENGINE=2:device=0,\
+rocp_sdk:::SQ_WAVE_CYCLES:DIMENSION_SHADER_ENGINE=3:device=0,\
+rocp_sdk:::SQ_WAVE_CYCLES:device=0"
+
+echo "make advanced:"
+make advanced
+if [ "$1" = "--with-desired-events" ]; then
+    echo "Running: ./advanced --rocp-sdk-native-event-names ${advanced_desired_events[@]}"
+    ./advanced --rocp-sdk-native-event-names "${advanced_desired_events[@]}"
+else
+    echo "Running: ./advanced"
+    ./advanced
+fi
+echo -e "-------------------------------------"
+
+simple_desired_events="rocp_sdk:::SQ_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=3,\
+rocp_sdk:::TCC_CYCLE:device=0:DIMENSION_INSTANCE=2,\
+rocp_sdk:::SQ_INSTS:device=0:DIMENSION_INSTANCE=0,\
+rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=0,\
+rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=1,\
+rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=2,\
+rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0"
+
+echo "make simple:"
+make simple
+if [ "$1" = "--with-desired-events" ]; then
+    echo "Running: ./simple --rocp-sdk-native-event-names ${simple_desired_events[@]}"
+    ./simple --rocp-sdk-native-event-names "${simple_desired_events[@]}"
+else
+    echo "Running ./simple"
+    ./simple
+fi
+echo -e "-------------------------------------"
+
+simple_sampling_desired_events="rocp_sdk:::SQ_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=3,\
+rocp_sdk:::SQ_INSTS:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=0,\
+rocp_sdk:::SQ_INSTS:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=1,\
+rocp_sdk:::SQ_INSTS:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=2,\
+rocp_sdk:::SQ_INSTS:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=3,\
+rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=0,\
+rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=1,\
+rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=2,\
+rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0,\
+rocp_sdk:::SQ_BUSY_CYCLES:device=1:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=0,\
+rocp_sdk:::SQ_BUSY_CYCLES:device=1:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=1,\
+rocp_sdk:::SQ_BUSY_CYCLES:device=1:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=2"
+
+echo "make simple_sampling:"
+make simple_sampling
+if [ "$1" = "--with-desired-events" ]; then
+    echo "Running: ./simple_sampling --rocp-sdk-native-event-names ${simple_sampling_desired_events[@]}"
+    ./simple_sampling --rocp-sdk-native-event-names "${simple_sampling_desired_events[@]}"
+else
+    echo "Running ./simple_sampling"
+    ./simple_sampling
+fi
+echo "-------------------------------------"
+
+two_eventsets_desired_events1="rocp_sdk:::SQ_BUSY_CYCLES:device=0,\
+rocp_sdk:::SQ_BUSY_CYCLES:device=1,\
+rocp_sdk:::TCC_CYCLE:device=1,\
+rocp_sdk:::SQ_WAVES:device=0,\
+rocp_sdk:::SQ_WAVES:device=1"
+two_eventsets_desired_events2="rocp_sdk:::TCC_CYCLE:device=1,\
+rocp_sdk:::SQ_INSTS:device=0,\
+rocp_sdk:::SQ_INSTS:device=1,\
+rocp_sdk:::SQ_BUSY_CYCLES:device=0,\
+rocp_sdk:::SQ_BUSY_CYCLES:device=1"
+
+echo "make two_eventsets:"
+make two_eventsets
+if [ "$1" = "--with-desired-events" ]; then
+    echo "Running: ./two_eventsets --first-eventset-native-eventnames ${two_eventsets_desired_events1[@]} --second-eventset-native-eventnames ${two_eventsets_desired_events2[@]}"
+    ./two_eventsets --first-eventset-native-eventnames ${two_eventsets_desired_events1[@]} --second-eventset-native-eventnames ${two_eventsets_desired_events2[@]}
+else
+    echo "Running: ./two_eventsets"
+    ./two_eventsets
+fi

--- a/src/components/rocp_sdk/tests/simple.c
+++ b/src/components/rocp_sdk/tests/simple.c
@@ -1,22 +1,100 @@
+// Standard library headers
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
+
+// Internal headers
 #include <papi.h>
 #include <papi_test.h>
 
 extern int launch_kernel(int device_id);
-extern void add_desired_component_events(int eventSet, int maxEventsToAdd, const char eventsToAdd[][PAPI_MAX_STR_LEN], char metricNamesAdded[][PAPI_MAX_STR_LEN], int *numEventsSuccessfullyAdded);
-extern void enumerate_and_add_component_events(const char *componentName, int eventSet, int maxEventsToAdd, char metricNamesAdded[][PAPI_MAX_STR_LEN], int *numEventsSuccessfullyAdded);
+extern void enumerate_and_store_rocp_sdk_native_events(char ***rocp_sdk_native_event_names, int *total_event_count);
+extern void add_rocp_sdk_native_events(int eventSet, int maxNativeEventsToAdd, char **nativeEventsToAdd);
 
-#define NUM_EVENTS (7)
+static void print_help_message(void)
+{
+    printf("./simple --rocp-sdk-native-event-names [list of rocp_sdk native event names separated by a comma].\n");
+}
+
+static void parse_and_assign_args(int argc, char *argv[], char ***rocp_sdk_native_event_names, int *total_event_count)
+{
+    int i;
+    for (i = 1; i < argc; ++i)
+    {
+        char *arg = argv[i];
+        if (strcmp(arg, "--help") == 0)
+        {
+            print_help_message();
+            exit(EXIT_SUCCESS);
+        }
+        else if (strcmp(arg, "--rocp-sdk-native-event-names") == 0)
+        {
+            if (!argv[i + 1])
+            {
+                printf("ERROR!! --rocp-sdk-event-names given, but no events listed.\n");
+                exit(EXIT_FAILURE);
+            }
+
+            char **cmd_line_native_event_names = NULL;
+            const char *rocp_sdk_native_event_name = strtok(argv[i+1], ",");
+            while (rocp_sdk_native_event_name != NULL)
+            {
+                cmd_line_native_event_names = (char **) realloc(cmd_line_native_event_names, ((*total_event_count) + 1) * sizeof(char *));
+                if (cmd_line_native_event_names == NULL) {
+                    fprintf(stderr, "%s:%d: Error: Memory allocation failed.\n", __FILE__, __LINE__);
+                    exit(EXIT_FAILURE);
+                }
+
+                cmd_line_native_event_names[(*total_event_count)] = (char *) malloc(PAPI_MAX_STR_LEN * sizeof(char));
+                if (cmd_line_native_event_names[(*total_event_count)] == NULL) {
+                    fprintf(stderr, "Failed to allocate memory for index %d in rocp_sdk_native_event_names.\n", (*total_event_count));
+                    exit(EXIT_FAILURE);
+                }
+
+                int strLen = snprintf(cmd_line_native_event_names[(*total_event_count)], PAPI_MAX_STR_LEN, "%s", rocp_sdk_native_event_name);
+                if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+                    fprintf(stderr, "Failed to fully write rocp_sdk native event name.\n");
+                    exit(EXIT_FAILURE);
+                }
+
+                (*total_event_count)++;
+                rocp_sdk_native_event_name = strtok(NULL, ",");
+            }
+            *rocp_sdk_native_event_names = cmd_line_native_event_names;
+            i++;
+        }
+        else if (strcmp(arg, "TESTS_QUIET") == 0) {
+            // TESTS_QUIET comes from running run_tests.sh.
+            // As stands, we do not silence any printf's in
+            // this application code. Therefore we acknowledge the case
+            // and continue.
+            continue;
+        }
+        else
+        {
+            print_help_message();
+            exit(EXIT_FAILURE);
+        }
+    }
+}
 
 int main(int argc, char *argv[])
 {
-    int papi_errno;
-    long long counters[NUM_EVENTS] = { 0 };
+    int total_event_count = 0;
+    char **rocp_sdk_native_event_names = NULL;
+    if (argc > 1) {
+        parse_and_assign_args(argc, argv, &rocp_sdk_native_event_names, &total_event_count);
+    }
 
-    papi_errno = PAPI_library_init(PAPI_VER_CURRENT);
+    int papi_errno = PAPI_library_init(PAPI_VER_CURRENT);
     if (papi_errno != PAPI_VER_CURRENT) {
         test_fail(__FILE__, __LINE__, "PAPI_library_init", papi_errno);
+    }
+
+    // If a user does not provide an event or events, then we go get an event to add
+    if (total_event_count == 0) {
+        enumerate_and_store_rocp_sdk_native_events(&rocp_sdk_native_event_names, &total_event_count);
     }
 
     int eventset = PAPI_NULL;
@@ -25,33 +103,8 @@ int main(int argc, char *argv[])
         test_fail(__FILE__, __LINE__, "PAPI_create_eventset", papi_errno);
     }
 
-    const char desiredEvents[NUM_EVENTS][PAPI_MAX_STR_LEN] = {
-        "rocp_sdk:::SQ_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=3",
-        "rocp_sdk:::TCC_CYCLE:device=0:DIMENSION_INSTANCE=2",
-        "rocp_sdk:::SQ_INSTS:device=0:DIMENSION_INSTANCE=0",
-        "rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=0",
-        "rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=1",
-        "rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=2",
-        "rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0"
-    };
-
-    char nativeEventNamesAdded[NUM_EVENTS][PAPI_MAX_STR_LEN] = { 0 };
-    int numNativeEventsAdded = 0;
-    add_desired_component_events(eventset, NUM_EVENTS, desiredEvents, nativeEventNamesAdded, &numNativeEventsAdded);
-
-    // If we are unable to add any desired events then we enumerate through the available
-    // rocp_sdk native events attempting to add up to NUM_EVENTS
-    if (numNativeEventsAdded == 0) {
-        const char *componentName = "rocp_sdk";
-        enumerate_and_add_component_events(componentName, eventset, NUM_EVENTS, nativeEventNamesAdded, &numNativeEventsAdded);
-    }
-
-    // If we are unable to add any rocp_sdk native events whether that is the desired events
-    // or events we enumerate through then skip the test
-    if (numNativeEventsAdded == 0) {
-        fprintf(stderr, "Unable to add any rocp_sdk native events.\n");
-        test_skip(__FILE__, __LINE__, "", 0);
-    }
+    // Add the native events via command line or enumeration to the EventSet
+    add_rocp_sdk_native_events(eventset, total_event_count, rocp_sdk_native_event_names);
 
     papi_errno = PAPI_start(eventset);
     if (papi_errno != PAPI_OK) {
@@ -66,14 +119,21 @@ int main(int argc, char *argv[])
 
     usleep(10000);
 
+    long long *counters = (long long *) malloc(total_event_count * sizeof(long long));
+    if (counters == NULL) {
+        fprintf(stderr, "%s:%d: Error: Memory allocation failed.\n", __FILE__, __LINE__);
+        exit(EXIT_FAILURE);
+    }
+
     papi_errno = PAPI_read(eventset, counters);
     if (papi_errno != PAPI_OK) {
         test_fail(__FILE__, __LINE__, "PAPI_read", papi_errno);
     }
     printf("---------------------  PAPI_read()\n");
 
-    for (int i = 0; i < numNativeEventsAdded; ++i) {
-        printf("%s: %.2lfM\n", nativeEventNamesAdded[i], (double)counters[i]/1e6);
+    int i;
+    for (i = 0; i < total_event_count; ++i) {
+        printf("%s: %.2lfM\n", rocp_sdk_native_event_names[i], (double)counters[i]/1e6);
     }
 
     papi_errno = PAPI_stop(eventset, counters);
@@ -83,8 +143,8 @@ int main(int argc, char *argv[])
 
     printf("---------------------  PAPI_stop()\n");
 
-    for (int i = 0; i < numNativeEventsAdded; ++i) {
-        printf("%s: %.2lfM\n", nativeEventNamesAdded[i], (double)counters[i]/1e6);
+    for (i = 0; i < total_event_count; ++i) {
+        printf("%s: %.2lfM\n", rocp_sdk_native_event_names[i], (double)counters[i]/1e6);
     }
     
     papi_errno = PAPI_cleanup_eventset(eventset);
@@ -96,6 +156,13 @@ int main(int argc, char *argv[])
     if (papi_errno != PAPI_OK) {
         test_fail(__FILE__, __LINE__, "PAPI_destroy_eventset", papi_errno);
     }
+
+    //Free memory allocation
+    free(counters);
+    for (i = 0; i < total_event_count; i++) {
+        free(rocp_sdk_native_event_names[i]);
+    }
+    free(rocp_sdk_native_event_names);
 
     PAPI_shutdown();
     test_pass(__FILE__);

--- a/src/components/rocp_sdk/tests/simple_sampling.c
+++ b/src/components/rocp_sdk/tests/simple_sampling.c
@@ -1,47 +1,111 @@
-#include <stdio.h>
-#include <unistd.h>
+// Standard library headers
 #include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+// Internal headers
 #include <papi.h>
 #include <papi_test.h>
 
-#define NUM_EVENTS (12)
-
-extern int launch_kernel(int device_id);
-extern void add_desired_component_events(int eventSet, int maxEventsToAdd, const char eventsToAdd[][PAPI_MAX_STR_LEN], char metricNamesAdded[][PAPI_MAX_STR_LEN], int *numEventsSuccessfullyAdded);
-extern void enumerate_and_add_component_events(const char *componentName, int eventSet, int maxEventsToAdd, char metricNamesAdded[][PAPI_MAX_STR_LEN], int *numEventsSuccessfullyAdded);
-
 int eventset = PAPI_NULL;
-int numNativeEventsAdded = 0;
-
-char nativeEventNamesAdded[NUM_EVENTS][PAPI_MAX_STR_LEN] = { 0 };
-
-const char desiredEvents[NUM_EVENTS][PAPI_MAX_STR_LEN] = { 
-    "rocp_sdk:::SQ_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=3",
-    "rocp_sdk:::SQ_INSTS:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=0",
-    "rocp_sdk:::SQ_INSTS:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=1",
-    "rocp_sdk:::SQ_INSTS:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=2",
-    "rocp_sdk:::SQ_INSTS:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=3",
-    "rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=0",
-    "rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=1",
-    "rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=2",
-    "rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0",
-    "rocp_sdk:::SQ_BUSY_CYCLES:device=1:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=0",
-    "rocp_sdk:::SQ_BUSY_CYCLES:device=1:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=1",
-    "rocp_sdk:::SQ_BUSY_CYCLES:device=1:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=2"
-};
+int total_event_count = 0;
+char **rocp_sdk_native_event_names = NULL;
 
 volatile int gv=0;
 
-void *thread_main(void *arg){
-    long long counters[NUM_EVENTS] = { 0 };
-    while(0==gv){;}
+extern int launch_kernel(int device_id);
+extern void enumerate_and_store_rocp_sdk_native_events(char ***rocp_sdk_native_event_names, int *total_event_count);
+extern void add_rocp_sdk_native_events(int eventSet, int maxNativeEventsToAdd, char **nativeEventsToAdd);
+
+static void print_help_message(void)
+{
+    printf("./simple_sampling --rocp-sdk-native-event-names [list of rocp_sdk native event names separated by a comma].\n");
+}
+
+static void parse_and_assign_args(int argc, char *argv[], char ***rocp_sdk_native_event_names, int *total_event_count)
+{
+    int i;
+    for (i = 1; i < argc; ++i)
+    {
+        char *arg = argv[i];
+        if (strcmp(arg, "--help") == 0)
+        {
+            print_help_message();
+            exit(EXIT_SUCCESS);
+        }
+        else if (strcmp(arg, "--rocp-sdk-native-event-names") == 0)
+        {
+            if (!argv[i + 1])
+            {
+                printf("ERROR!! --rocp-sdk-event-names given, but no events listed.\n");
+                exit(EXIT_FAILURE);
+            }
+
+            char **cmd_line_native_event_names = NULL;
+            const char *rocp_sdk_native_event_name = strtok(argv[i+1], ",");
+            while (rocp_sdk_native_event_name != NULL)
+            {
+                cmd_line_native_event_names = (char **) realloc(cmd_line_native_event_names, ((*total_event_count) + 1) * sizeof(char *));
+                if (cmd_line_native_event_names == NULL) {
+                    fprintf(stderr, "%s:%d: Error: Memory allocation failed.\n", __FILE__, __LINE__);
+                    exit(EXIT_FAILURE);
+                }
+
+                cmd_line_native_event_names[(*total_event_count)] = (char *) malloc(PAPI_MAX_STR_LEN * sizeof(char));
+                if (cmd_line_native_event_names[(*total_event_count)] == NULL) {
+                    fprintf(stderr, "Failed to allocate memory for index %d in rocp_sdk_native_event_names.\n", (*total_event_count));
+                    exit(EXIT_FAILURE);
+                }
+
+                int strLen = snprintf(cmd_line_native_event_names[(*total_event_count)], PAPI_MAX_STR_LEN, "%s", rocp_sdk_native_event_name);
+                if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+                    fprintf(stderr, "Failed to fully write rocp_sdk native event name.\n");
+                    exit(EXIT_FAILURE);
+                }
+
+                (*total_event_count)++;
+                rocp_sdk_native_event_name = strtok(NULL, ",");
+            }
+            *rocp_sdk_native_event_names = cmd_line_native_event_names;
+            i++;
+        }
+        else if (strcmp(arg, "TESTS_QUIET") == 0) {
+            // TESTS_QUIET comes from running run_tests.sh.
+            // As stands, we do not silence any printf's in
+            // this application code. Therefore we acknowledge the case
+            // and continue.
+            continue;
+        }
+        else
+        {
+            print_help_message();
+            exit(EXIT_FAILURE);
+        }
+    }
+}
+
+
+void *thread_main(void *arg)
+{
+    long long *counters = (long long *) malloc(total_event_count * sizeof(long long));
+    if (counters == NULL) {
+        fprintf(stderr, "%s:%d: Error: Memory allocation failed.\n", __FILE__, __LINE__);
+        exit(EXIT_FAILURE);
+    }
+
+    while( 0 == gv) {;}
     usleep(150*1000);
-    for(int i=0; i<30; i++){
+
+    int i;
+    for( i = 0; i < 30; i++) {
         printf("Sample: %2d\n", gv);
         fflush(stdout);
         PAPI_read(eventset, counters);
-        for (int i = 0; i < numNativeEventsAdded; ++i) {
-            printf("%s: %.2lfM\n", nativeEventNamesAdded[i], (double)counters[i]/1e6);
+        int j;
+        for (j = 0; j < total_event_count; ++j) {
+            printf("%s: %.2lfM\n", rocp_sdk_native_event_names[j], (double)counters[j]/1e6);
             fflush(stdout);
         }
         printf("\n");
@@ -49,17 +113,26 @@ void *thread_main(void *arg){
         usleep(30*1000);
         ++gv;
     }
+    free(counters);
+
     return NULL;
 }
 
 
 int main(int argc, char *argv[])
 {
-    int papi_errno;
+    if (argc > 1) {
+        parse_and_assign_args(argc, argv, &rocp_sdk_native_event_names, &total_event_count);
+    }
 
-    papi_errno = PAPI_library_init(PAPI_VER_CURRENT);
+    int papi_errno = PAPI_library_init(PAPI_VER_CURRENT);
     if (papi_errno != PAPI_VER_CURRENT) {
         test_fail(__FILE__, __LINE__, "PAPI_library_init", papi_errno);
+    }
+
+    // If a user does not provide an event or events, then we go get an event to add
+    if (total_event_count == 0) {
+        enumerate_and_store_rocp_sdk_native_events(&rocp_sdk_native_event_names, &total_event_count);
     }
 
     papi_errno = PAPI_create_eventset(&eventset);
@@ -67,23 +140,9 @@ int main(int argc, char *argv[])
         test_fail(__FILE__, __LINE__, "PAPI_create_eventset", papi_errno);
     }
 
-    add_desired_component_events(eventset, NUM_EVENTS, desiredEvents, nativeEventNamesAdded, &numNativeEventsAdded);
+    // Add the native events via command line or enumeration to the EventSet
+    add_rocp_sdk_native_events(eventset, total_event_count, rocp_sdk_native_event_names);
 
-    // If we are unable to add any desired events then we enumerate through the available
-    // rocp_sdk native events attempting to add up to NUM_EVENTS
-    if (numNativeEventsAdded == 0) {
-        const char *componentName = "rocp_sdk";
-        enumerate_and_add_component_events(componentName, eventset, NUM_EVENTS, nativeEventNamesAdded, &numNativeEventsAdded);
-    }
-
-    // If we are unable to add any rocp_sdk native events whether that is the desired events
-    // or events we enumerate through then skip the test
-    if (numNativeEventsAdded == 0) {
-        fprintf(stderr, "Unable to add any rocp_sdk native events.\n");
-        test_skip(__FILE__, __LINE__, "", 0);
-    }
-
-    long long counters[NUM_EVENTS] = { 0 };
     papi_errno = PAPI_start(eventset);
     if (papi_errno != PAPI_OK) {
         test_fail(__FILE__, __LINE__, "PAPI_start", papi_errno);
@@ -101,14 +160,21 @@ int main(int argc, char *argv[])
 
     usleep(20000);
 
+    long long *counters = (long long *) malloc(total_event_count * sizeof(long long));
+    if (counters == NULL) {
+        fprintf(stderr, "%s:%d: Error: Memory allocation failed.\n", __FILE__, __LINE__);
+        exit(EXIT_FAILURE);
+    }
+
     papi_errno = PAPI_read(eventset, counters);
     if (papi_errno != PAPI_OK) {
         test_fail(__FILE__, __LINE__, "PAPI_read", papi_errno);
     }
     printf("---------------------  PAPI_read()\n");
 
-    for (int i = 0; i < numNativeEventsAdded; ++i) {
-        printf("%s: %.2lfM\n", nativeEventNamesAdded[i], (double)counters[i]/1e6);
+    int i;
+    for (i = 0; i < total_event_count; ++i) {
+        printf("%s: %.2lfM\n", rocp_sdk_native_event_names[i], (double)counters[i]/1e6);
     }
 
     papi_errno = PAPI_stop(eventset, counters);
@@ -118,8 +184,8 @@ int main(int argc, char *argv[])
 
     printf("---------------------  PAPI_stop()\n");
 
-    for (int i = 0; i < numNativeEventsAdded; ++i) {
-        printf("%s: %.2lfM\n", nativeEventNamesAdded[i], (double)counters[i]/1e6);
+    for (i = 0; i < total_event_count; ++i) {
+        printf("%s: %.2lfM\n", rocp_sdk_native_event_names[i], (double)counters[i]/1e6);
     }
     
     papi_errno = PAPI_cleanup_eventset(eventset);
@@ -131,6 +197,14 @@ int main(int argc, char *argv[])
     if (papi_errno != PAPI_OK) {
         test_fail(__FILE__, __LINE__, "PAPI_destroy_eventset", papi_errno);
     }
+
+    //Free memory allocation
+    free(counters);
+    for (i = 0; i < total_event_count; i++) {
+        free(rocp_sdk_native_event_names[i]);
+    }
+    free(rocp_sdk_native_event_names);
+
 
     PAPI_shutdown();
     test_pass(__FILE__);

--- a/src/components/rocp_sdk/tests/two_eventsets.c
+++ b/src/components/rocp_sdk/tests/two_eventsets.c
@@ -1,96 +1,162 @@
+// Standard library headers
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
+
+// Internal headers
 #include <papi.h>
 #include <papi_test.h>
 
 extern int launch_kernel(int device_id);
-extern void add_desired_component_events(int eventSet, int maxEventsToAdd, const char eventsToAdd[][PAPI_MAX_STR_LEN], char metricNamesAdded[][PAPI_MAX_STR_LEN], int *numEventsSuccessfullyAdded);
-extern void enumerate_and_add_component_events(const char *componentName, int eventSet, int maxEventsToAdd, char metricNamesAdded[][PAPI_MAX_STR_LEN], int *numEventsSuccessfullyAdded);
+extern void enumerate_and_store_rocp_sdk_native_events(char ***rocp_sdk_native_event_names, int *total_event_count);
+extern void add_rocp_sdk_native_events(int eventSet, int maxNativeEventsToAdd, char **nativeEventsToAdd);
 
-#define NUM_EVENTS (5)
+static void print_help_message(void)
+{
+    printf("./two_eventsets --first-eventset-native-eventnames [list of rocp_sdk native event names separated by a comma] --second-eventset-native-eventnames [list of rocp_sdk native event names separated by a comma].\n");
+}
+
+static void parse_and_assign_args(int argc, char *argv[], char ***rocp_sdk_native_event_names_eventset1, int *total_event_count_eventset1, char ***rocp_sdk_native_event_names_eventset2, int *total_event_count_eventset2)
+{
+    int i;
+    for (i = 1; i < argc; ++i)
+    {
+        char *arg = argv[i];
+        if (strcmp(arg, "--help") == 0)
+        {
+            print_help_message();
+            exit(EXIT_SUCCESS);
+        }
+        else if (strcmp(arg, "--first-eventset-native-eventnames") == 0)
+        {
+            if (!argv[i + 1])
+            {
+                printf("ERROR!! --first-eventset-native-eventnames given, but no events listed.\n");
+                exit(EXIT_FAILURE);
+            }
+
+            char **cmd_line_native_event_names_eventset1 = NULL;
+            const char *rocp_sdk_native_event_name = strtok(argv[i+1], ",");
+            while (rocp_sdk_native_event_name != NULL)
+            {
+                cmd_line_native_event_names_eventset1 = (char **) realloc(cmd_line_native_event_names_eventset1, ((*total_event_count_eventset1) + 1) * sizeof(char *));
+                if (cmd_line_native_event_names_eventset1 == NULL) {
+                    fprintf(stderr, "%s:%d: Error: Memory allocation failed.\n", __FILE__, __LINE__);
+                    exit(EXIT_FAILURE);
+                }
+
+                cmd_line_native_event_names_eventset1[(*total_event_count_eventset1)] = (char *) malloc(PAPI_MAX_STR_LEN * sizeof(char));
+                if (cmd_line_native_event_names_eventset1[(*total_event_count_eventset1)] == NULL) {
+                    fprintf(stderr, "Failed to allocate memory for index %d in rocp_sdk_native_event_names.\n", (*total_event_count_eventset1));
+                    exit(EXIT_FAILURE);
+                }
+
+                int strLen = snprintf(cmd_line_native_event_names_eventset1[(*total_event_count_eventset1)], PAPI_MAX_STR_LEN, "%s", rocp_sdk_native_event_name);
+                if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+                    fprintf(stderr, "Failed to fully write rocp_sdk native event name.\n");
+                    exit(EXIT_FAILURE);
+                }
+
+                (*total_event_count_eventset1)++;
+                rocp_sdk_native_event_name = strtok(NULL, ",");
+            }
+            *rocp_sdk_native_event_names_eventset1 = cmd_line_native_event_names_eventset1;
+            i++;
+        }
+        else if (strcmp(arg, "--second-eventset-native-eventnames") == 0)
+        {
+            if (!argv[i + 1])
+            {
+                printf("ERROR!! --second-eventset-native-eventnames given, but no events listed.\n");
+                exit(EXIT_FAILURE);
+            }
+
+            char **cmd_line_native_event_names_eventset2 = NULL;
+            const char *rocp_sdk_native_event_name = strtok(argv[i+1], ",");
+            while (rocp_sdk_native_event_name != NULL)
+            {
+                cmd_line_native_event_names_eventset2 = (char **) realloc(cmd_line_native_event_names_eventset2, ((*total_event_count_eventset2) + 1) * sizeof(char *));
+                if (cmd_line_native_event_names_eventset2 == NULL) {
+                    fprintf(stderr, "%s:%d: Error: Memory allocation failed.\n", __FILE__, __LINE__);
+                    exit(EXIT_FAILURE);
+                }
+
+                cmd_line_native_event_names_eventset2[(*total_event_count_eventset2)] = (char *) malloc(PAPI_MAX_STR_LEN * sizeof(char));
+                if (cmd_line_native_event_names_eventset2[(*total_event_count_eventset2)] == NULL) {
+                    fprintf(stderr, "Failed to allocate memory for index %d in rocp_sdk_native_event_names.\n", (*total_event_count_eventset2));
+                    exit(EXIT_FAILURE);
+                }
+
+                int strLen = snprintf(cmd_line_native_event_names_eventset2[(*total_event_count_eventset2)], PAPI_MAX_STR_LEN, "%s", rocp_sdk_native_event_name);
+                if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+                    fprintf(stderr, "Failed to fully write rocp_sdk native event name.\n");
+                    exit(EXIT_FAILURE);
+                }
+
+                (*total_event_count_eventset2)++;
+                rocp_sdk_native_event_name = strtok(NULL, ",");
+            }
+            *rocp_sdk_native_event_names_eventset2 = cmd_line_native_event_names_eventset2;
+            i++;
+        }
+        else if (strcmp(arg, "TESTS_QUIET") == 0) {
+            // TESTS_QUIET comes from running run_tests.sh.
+            // As stands, we do not silence any printf's in
+            // this application code. Therefore we acknowledge the case
+            // and continue.
+            continue;
+        }
+        else
+        {
+            print_help_message();
+            exit(EXIT_FAILURE);
+        }
+    }
+}
 
 int main(int argc, char *argv[])
 {
-    int papi_errno;
-    long long counters1[NUM_EVENTS] = { 0 };
-    long long counters2[NUM_EVENTS] = { 0 };
-    int eventset1 = PAPI_NULL;
-    int eventset2 = PAPI_NULL;
-    double exp1[NUM_EVENTS] = {1, 1300000000, 55000000000, 1, 1};
-    double exp2[NUM_EVENTS] = {45000000000, 1, 40000000, 1, 1300000000};
-    double exp3[NUM_EVENTS] = {28000000000, 40000000, 1, 1300000000, 1};
+    int total_event_count_eventset1 = 0, total_event_count_eventset2 = 0;
+    char **rocp_sdk_native_event_names_eventset1 = NULL, **rocp_sdk_native_event_names_eventset2 = NULL;
+    if (argc > 1) {
+        parse_and_assign_args(argc, argv, &rocp_sdk_native_event_names_eventset1, &total_event_count_eventset1, &rocp_sdk_native_event_names_eventset2, &total_event_count_eventset2);
+    }
 
-
-    const char desiredEvents1[NUM_EVENTS][PAPI_MAX_STR_LEN] = {
-                  "rocp_sdk:::SQ_BUSY_CYCLES:device=0",
-                  "rocp_sdk:::SQ_BUSY_CYCLES:device=1",
-                  "rocp_sdk:::TCC_CYCLE:device=1",
-                  "rocp_sdk:::SQ_WAVES:device=0",
-                  "rocp_sdk:::SQ_WAVES:device=1"
-    };
-
-    const char desiredEvents2[NUM_EVENTS][PAPI_MAX_STR_LEN] = {
-                  "rocp_sdk:::TCC_CYCLE:device=1",
-                  "rocp_sdk:::SQ_INSTS:device=0",
-                  "rocp_sdk:::SQ_INSTS:device=1",
-                  "rocp_sdk:::SQ_BUSY_CYCLES:device=0",
-                  "rocp_sdk:::SQ_BUSY_CYCLES:device=1"
-    };
-
-    papi_errno = PAPI_library_init(PAPI_VER_CURRENT);
+    int papi_errno = PAPI_library_init(PAPI_VER_CURRENT);
     if (papi_errno != PAPI_VER_CURRENT) {
         test_fail(__FILE__, __LINE__, "PAPI_library_init", papi_errno);
     }
 
     /* ---------- Setup for eventset1 ---------- */
-
+    int eventset1 = PAPI_NULL;
     papi_errno = PAPI_create_eventset(&eventset1);
     if (papi_errno != PAPI_OK) {
         test_fail(__FILE__, __LINE__, "PAPI_create_eventset", papi_errno);
     }
 
-    char nativeEventNamesAdded1[NUM_EVENTS][PAPI_MAX_STR_LEN] = { 0 };
-    int numNativeEventsAdded1 = 0;
-    add_desired_component_events(eventset1, NUM_EVENTS, desiredEvents1, nativeEventNamesAdded1, &numNativeEventsAdded1);
-
-    // If we are unable to add any desired events then we enumerate through the available
-    // rocp_sdk native events attempting to add up to NUM_EVENTS
-    if (numNativeEventsAdded1 == 0) {
-        const char *componentName = "rocp_sdk";
-        enumerate_and_add_component_events(componentName, eventset1, NUM_EVENTS, nativeEventNamesAdded1, &numNativeEventsAdded1);
+    // If a user does not provide an event or events, then we go get an event to add
+    if (total_event_count_eventset1 == 0) {
+        enumerate_and_store_rocp_sdk_native_events(&rocp_sdk_native_event_names_eventset1, &total_event_count_eventset1);
     }
 
-    // If we are unable to add any rocp_sdk native events whether that is the desired events
-    // or events we enumerate through then skip the test
-    if (numNativeEventsAdded1 == 0) {
-        fprintf(stderr, "Unable to add any rocp_sdk native events for eventset2.\n");
-        test_skip(__FILE__, __LINE__, "", 0);
-    }
+    // Add the native events via command line or enumeration to evnetset1
+    add_rocp_sdk_native_events(eventset1, total_event_count_eventset1, rocp_sdk_native_event_names_eventset1);
 
     /* ---------- Setup for eventset2 ---------- */
-
+    int eventset2 = PAPI_NULL;
     papi_errno = PAPI_create_eventset(&eventset2);
     if (papi_errno != PAPI_OK) {
         test_fail(__FILE__, __LINE__, "PAPI_create_eventset", papi_errno);
     }
 
-    char nativeEventNamesAdded2[NUM_EVENTS][PAPI_MAX_STR_LEN] = { 0 };
-    int numNativeEventsAdded2 = 0;
-    add_desired_component_events(eventset2, NUM_EVENTS, desiredEvents2, nativeEventNamesAdded2, &numNativeEventsAdded2);
-
-    // If we are unable to add any desired events then we enumerate through the available
-    // rocp_sdk native events attempting to add up to NUM_EVENTS
-    if (numNativeEventsAdded2 == 0) {
-        const char *componentName = "rocp_sdk";
-        enumerate_and_add_component_events(componentName, eventset2, NUM_EVENTS, nativeEventNamesAdded2, &numNativeEventsAdded2);
+    // If a user does not provide an event or events, then we go get an event to add
+    if (total_event_count_eventset2 == 0) {
+        enumerate_and_store_rocp_sdk_native_events(&rocp_sdk_native_event_names_eventset2, &total_event_count_eventset2);
     }
 
-    // If we are unable to add any rocp_sdk native events whether that is the desired events
-    // or events we enumerate through then skip the test
-    if (numNativeEventsAdded2 == 0) {
-        fprintf(stderr, "Unable to add any rocp_sdk native events for eventset2.\n");
-        test_skip(__FILE__, __LINE__, "", 0);
-    }
+    // Add the native events via command line or enumeration to eventset2
+    add_rocp_sdk_native_events(eventset2, total_event_count_eventset2, rocp_sdk_native_event_names_eventset2);
 
     printf("==================== FIRST EVENTSET - DEVICE 1 ====================\n");
 
@@ -98,7 +164,15 @@ int main(int argc, char *argv[])
     if (papi_errno != PAPI_OK) {
         test_fail(__FILE__, __LINE__, "PAPI_start", papi_errno);
     }
-    for(int rep=0; rep<=3; ++rep){
+
+    long long *counters1 = (long long *) malloc(total_event_count_eventset1 * sizeof(long long));
+    if (counters1 == NULL) {
+        fprintf(stderr, "%s:%d: Error: Memory allocation failed.\n", __FILE__, __LINE__);
+        exit(EXIT_FAILURE);
+    }
+
+    int rep, i;
+    for(rep = 0; rep <= 3; ++rep){
 
         papi_errno = launch_kernel(1);
         if (papi_errno != 0) {
@@ -113,8 +187,8 @@ int main(int argc, char *argv[])
         }
         printf("---------------------  PAPI_read()\n");
 
-        for (int i = 0; i < numNativeEventsAdded1; ++i) {
-            printf("%s: %lld (%.2lf)\n", nativeEventNamesAdded1[i], counters1[i], 1.0*counters1[i]/((1.0+rep)*exp1[i]));
+        for (i = 0; i < total_event_count_eventset1; ++i) {
+            printf("%s: %lld (%.2lf)\n", rocp_sdk_native_event_names_eventset1[i], counters1[i], 1.0*counters1[i]/(1.0+rep));
         }
     }
 
@@ -125,8 +199,8 @@ int main(int argc, char *argv[])
 
     printf("---------------------  PAPI_stop()\n");
 
-    for (int i = 0; i < numNativeEventsAdded1; ++i) {
-        printf("%s: %lld (%.2lf)\n", nativeEventNamesAdded1[i], counters1[i], 1.0*counters1[i]/((1.0+3)*exp1[i]));
+    for (i = 0; i < total_event_count_eventset1; ++i) {
+        printf("%s: %lld (%.2lf)\n", rocp_sdk_native_event_names_eventset1[i], counters1[i], 1.0*counters1[i]/(1.0+3));
     }
 
     printf("==================== SECOND EVENTSET - DEVICE 1 ====================\n");
@@ -136,7 +210,14 @@ int main(int argc, char *argv[])
     if (papi_errno != PAPI_OK) {
         test_fail(__FILE__, __LINE__, "PAPI_start", papi_errno);
     }
-    for(int rep=0; rep<=3; ++rep){
+
+    long long *counters2 = (long long *) malloc(total_event_count_eventset2 * sizeof(long long));
+    if (counters2 == NULL) {
+        fprintf(stderr, "%s:%d: Error: Memory allocation failed.\n", __FILE__, __LINE__);
+        exit(EXIT_FAILURE);
+    }
+
+    for(rep = 0; rep <= 3; ++rep){
 
         papi_errno = launch_kernel(1);
         if (papi_errno != 0) {
@@ -151,8 +232,8 @@ int main(int argc, char *argv[])
         }
         printf("---------------------  PAPI_read()\n");
 
-        for (int i = 0; i < numNativeEventsAdded2; ++i) {
-            printf("%s: %lld (%.2lf)\n", nativeEventNamesAdded2[i], counters2[i], 1.0*counters2[i]/((1.0+rep)*exp2[i]));
+        for (i = 0; i < total_event_count_eventset2; ++i) {
+            printf("%s: %lld (%.2lf)\n", rocp_sdk_native_event_names_eventset2[i], counters2[i], 1.0*counters2[i]/(1.0+rep));
         }
     }
 
@@ -163,8 +244,8 @@ int main(int argc, char *argv[])
 
     printf("---------------------  PAPI_stop()\n");
 
-    for (int i = 0; i < numNativeEventsAdded2; ++i) {
-        printf("%s: %lld (%.2lf)\n", nativeEventNamesAdded2[i], counters2[i], 1.0*counters2[i]/((1.0+3)*exp2[i]));
+    for (i = 0; i < total_event_count_eventset2; ++i) {
+        printf("%s: %lld (%.2lf)\n", rocp_sdk_native_event_names_eventset2[i], counters2[i], 1.0*counters2[i]/(1.0+3));
     }
 
     printf("==================== SECOND EVENTSET - DEVICE 0 ====================\n");
@@ -173,7 +254,8 @@ int main(int argc, char *argv[])
     if (papi_errno != PAPI_OK) {
         test_fail(__FILE__, __LINE__, "PAPI_start", papi_errno);
     }
-    for(int rep=0; rep<=2; ++rep){
+
+    for(rep = 0; rep <= 2; ++rep){
 
         papi_errno = launch_kernel(0);
         if (papi_errno != 0) {
@@ -188,8 +270,8 @@ int main(int argc, char *argv[])
         }
         printf("---------------------  PAPI_read()\n");
 
-        for (int i = 0; i < numNativeEventsAdded2; ++i) {
-            printf("%s: %lld (%.2lf)\n", nativeEventNamesAdded2[i], counters2[i], 1.0*counters2[i]/((1.0+rep)*exp3[i]));
+        for (i = 0; i < total_event_count_eventset2; ++i) {
+            printf("%s: %lld (%.2lf)\n", rocp_sdk_native_event_names_eventset2[i], counters2[i], 1.0*counters2[i]/(1.0+rep));
         }
     }
 
@@ -200,8 +282,8 @@ int main(int argc, char *argv[])
 
     printf("---------------------  PAPI_stop()\n");
 
-    for (int i = 0; i < numNativeEventsAdded2; ++i) {
-        printf("%s: %lld (%.2lf)\n", nativeEventNamesAdded2[i], counters2[i], 1.0*counters2[i]/((1.0+2)*exp3[i]));
+    for (i = 0; i < total_event_count_eventset2; ++i) {
+        printf("%s: %lld (%.2lf)\n", rocp_sdk_native_event_names_eventset2[i], counters2[i], 1.0*counters2[i]/(1.0+2));
     }
 
     /* * * Cleanup * * */
@@ -225,6 +307,20 @@ int main(int argc, char *argv[])
     if (papi_errno != PAPI_OK) {
         test_fail(__FILE__, __LINE__, "PAPI_destroy_eventset", papi_errno);
     }
+
+    // Free memory allocation
+    free(counters1);
+    free(counters2);
+
+    for (i = 0; i < total_event_count_eventset1; i++) {
+        free(rocp_sdk_native_event_names_eventset1[i]);
+    }
+    free(rocp_sdk_native_event_names_eventset1);
+
+    for (i = 0; i < total_event_count_eventset2; i++) {
+        free(rocp_sdk_native_event_names_eventset2[i]);
+    }
+    free(rocp_sdk_native_event_names_eventset2);
 
     PAPI_shutdown();
     test_pass(__FILE__);


### PR DESCRIPTION
## Pull Request Description
This PR updates the `rocp_sdk` component tests to:
1. Take optional command line arguments to pass `rocp_sdk` native events
2. If no optional `rocp_sdk` native events are provided via the command line we internally will enumerate through the available events on the architecture and ROCm version to get one

Along with the above two updates, the PR adds a run script which will run all four of the current tests for the `rocp_sdk` component. An optional flag `--with-desired-events` can be provided to this run script. Doing so will see the component tests ran with desired events listed in `run_rocp_sdk_tests.sh`.

Note: The desired events that had the `DIMENSION_SHADER_ENGINE` qualifier appended with a value greater than 3 were removed. As from testing with ROCm versions 7.0.1 and up these values did not exist anymore. 

This partially closes Issue #524 as one other PR to update error codes is needed.

## Testing

### Setup
Testing was done on Odyssey at Oregon with the following setup:
- OS: RHEL 8.10
- CPU: MI300A
- GPU: MI300A
- ROCm versions: 6.4.4, 7.1.1, and 7.2.0 (pre-release)
- PAPI Configure: `./configure --prefix=$PWD/test-install --with-components="rocp_sdk" --with-debug=yes`

### Results
- `advanced`, `simple`, `simple_sampling`, and `two_eventsets` all passed without providing event names on the command line*
- `advanced`, `simple`, `simple_sampling`, and `two_eventsets` all passed when providing event names on the command line*

__*__ - For ROCm 7.2.0 `two_eventsets.c` shows zero values for events which previously did not have zero values this is a separate issue and will be looked into)


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
