### PR TITLE
rocp_sdk: Update errorcodes

### DIFF
--- a/src/components/rocp_sdk/sdk_class.cpp
+++ b/src/components/rocp_sdk/sdk_class.cpp
@@ -840,7 +840,7 @@ build_event_info_from_name(std::string event_name, event_instance_info_t *ev_ins
         // All qualifiers must have the form "qual_name=qual_value".
         pos=qual.find('=');
         if( pos == qual.npos){
-            return PAPI_EINVAL;
+            return PAPI_ENOEVNT;
         }
 
         std::string qual_name = qual.substr(0, pos-0);
@@ -859,7 +859,7 @@ build_event_info_from_name(std::string event_name, event_instance_info_t *ev_ins
                 if( qual_name.compare(dim.name) == 0 ){
                     // Make sure that the qualifier value is within the proper range.
                     if( qual_val >= dim.instance_size ){
-                        return PAPI_EINVAL;
+                        return PAPI_ENOEVNT;
                     }
                     dim_instances.emplace_back( std::make_pair(dim.id, qual_val) );
                     // Mark which qualifiers we have found based on the order in which they appear in


### PR DESCRIPTION
## Pull Request Description
Background:
Currently in the master branch, the `rocp_sdk` component tests have "desired events" or events that we want to run the tests with as they will actually give non-zero values back to us. A helper function exists which attempts to add these events and if `PAPI_ENOEVNT` is returned then we continue to the next "desired event"; however, if an errorcode besides `PAPI_ENOEVNT` is returned then the test fails. 

Issue #524 was created as in ROCm versions >= 7.0.1 the `advanced.c` test fails due to a subset of the "desired events" not existing anymore. The helper function should catch this and move onto the next desired event, but the actual errorcode being returned internally is `PAPI_EINVAL`. Thus resulting in the test failing.

After discussion with Daniel, we agreed that updating `PAPI_EINVAL` to `PAPI_ENOEVNT` where applicable was the proper step to remedy this issue.

## Testing

### Setup
System: Odyssey at Oregon
OS: RHEL 8.10
CPU: AMD MI300A
GPU: AMD MI300A
ROCm version: 7.1.1 and 7.2.0 (pre-release)

### Results
- PAPI build: ✅ 
- `advanced.c` passes: ✅ 
- `simple.c`, `simple_sampling.c`, and `two_eventsets.c` pass: ✅ (for 7.2.0 `two_eventsets.c` shows zero values for events which previously did not have zero values this is a separate issue and will be looked into)
- Running `./papi_command_line rocp_sdk:::SQ_BUSY_CYCLES:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=4:device=0` returns `PAPI_ENOEVNT`: ✅ 
```
[tburgess@odyssey bin]$ ./papi_command_line rocp_sdk:::SQ_BUSY_CYCLES:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=4:device=0

This utility lets you add events from the command line interface to see if they work.

Failed adding: rocp_sdk:::SQ_BUSY_CYCLES:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=4:device=0
because: Event does not exist
No events specified!
Try running something like: ./papi_command_line PAPI_TOT_CYC
```

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
