### PR TITLE
amd_smi: PAPI_ENOSUPP as warning in EXIT_WARNING_ON_ADD

### DIFF
--- a/src/components/amd_smi/tests/test_harness.h
+++ b/src/components/amd_smi/tests/test_harness.h
@@ -217,12 +217,11 @@ static inline int harness_eval_result(const char *file, int line, HarnessOpts op
  * @brief If adding the event set fails due to unsupported or hardware/resource
  *        limits, exit as "PASSED with WARNING".
  *
- * Recognizes PAPI_ENOEVNT, PAPI_ECNFLCT, and PAPI_EPERM.
+ * Recognizes PAPI_ENOEVNT, PAPI_ECNFLCT, PAPI_EPERM, and PAPI_ENOSUPP.
  */
 #define EXIT_WARNING_ON_ADD(rc, evname) do { \
-    if ((rc) == PAPI_ENOEVNT || (rc) == PAPI_ECNFLCT || (rc) == PAPI_EPERM) { \
-        EXIT_WARNING("Event unavailable (%s): %s", \
-            ((rc) == PAPI_ENOEVNT ? "ENOEVNT" : (rc) == PAPI_ECNFLCT ? "ECNFLCT" : "EPERM"), (evname)); \
+    if ((rc) == PAPI_ENOEVNT || (rc) == PAPI_ECNFLCT || (rc) == PAPI_EPERM || (rc) == PAPI_ENOSUPP) { \
+        EXIT_WARNING("Event unavailable (%s): %s", PAPI_strerror(rc), (evname)); \
     } \
 } while (0)
 


### PR DESCRIPTION
## Pull Request Description
Add PAPI_ENOSUPP to EXIT_WARNING_ON_ADD so tests explicitly report unsupported event-add cases (e.g., amd_smi:::power_cap) instead of silently skipping.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
