### PR TITLE
Restrict workflow permissions to minimum required

### DIFF
--- a/.github/workflows/amd_smi_component_workflow.yml
+++ b/.github/workflows/amd_smi_component_workflow.yml
@@ -8,6 +8,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   component_tests:
     strategy:

--- a/.github/workflows/appio_component_workflow.yml
+++ b/.github/workflows/appio_component_workflow.yml
@@ -9,6 +9,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   component_tests:
     strategy:

--- a/.github/workflows/cat_workflow.yml
+++ b/.github/workflows/cat_workflow.yml
@@ -8,6 +8,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   cat_tests:
     strategy:

--- a/.github/workflows/coretemp_component_workflow.yml
+++ b/.github/workflows/coretemp_component_workflow.yml
@@ -8,6 +8,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   component_tests:
     strategy:

--- a/.github/workflows/cuda_component_workflow.yml
+++ b/.github/workflows/cuda_component_workflow.yml
@@ -8,6 +8,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   component_tests:
     strategy:

--- a/.github/workflows/default_components_workflow.yml
+++ b/.github/workflows/default_components_workflow.yml
@@ -11,6 +11,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   component_tests:
     strategy:

--- a/.github/workflows/example_component_workflow.yml
+++ b/.github/workflows/example_component_workflow.yml
@@ -8,6 +8,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   component_tests:
     strategy:

--- a/.github/workflows/intel_gpu_component_workflow.yml
+++ b/.github/workflows/intel_gpu_component_workflow.yml
@@ -8,6 +8,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   component_tests:
     strategy:

--- a/.github/workflows/io_component_workflow.yml
+++ b/.github/workflows/io_component_workflow.yml
@@ -8,6 +8,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   component_tests:
     strategy:

--- a/.github/workflows/lmsensors_component_workflow.yml
+++ b/.github/workflows/lmsensors_component_workflow.yml
@@ -8,6 +8,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   component_tests:
     strategy:

--- a/.github/workflows/net_component_workflow.yml
+++ b/.github/workflows/net_component_workflow.yml
@@ -8,6 +8,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   component_tests:
     strategy:

--- a/.github/workflows/nvml_component_workflow.yml
+++ b/.github/workflows/nvml_component_workflow.yml
@@ -8,6 +8,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   component_tests:
     strategy:

--- a/.github/workflows/papi_framework_workflow.yml
+++ b/.github/workflows/papi_framework_workflow.yml
@@ -10,6 +10,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   # build PAPI with multiple components to simulate a users' workflow
   papi_components_comprehensive:

--- a/.github/workflows/powercap_component_workflow.yml
+++ b/.github/workflows/powercap_component_workflow.yml
@@ -8,6 +8,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   component_tests:
     strategy:

--- a/.github/workflows/rocm_component_workflow.yml
+++ b/.github/workflows/rocm_component_workflow.yml
@@ -8,6 +8,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   component_tests:
     strategy:

--- a/.github/workflows/rocm_smi_component_workflow.yml
+++ b/.github/workflows/rocm_smi_component_workflow.yml
@@ -8,6 +8,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   component_tests:
     strategy:

--- a/.github/workflows/rocp_sdk_component_workflow.yml
+++ b/.github/workflows/rocp_sdk_component_workflow.yml
@@ -8,6 +8,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   component_tests:
     strategy:

--- a/.github/workflows/sde_component_workflow.yml
+++ b/.github/workflows/sde_component_workflow.yml
@@ -8,6 +8,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   component_tests:
     strategy:

--- a/.github/workflows/stealtime_component_workflow.yml
+++ b/.github/workflows/stealtime_component_workflow.yml
@@ -8,6 +8,9 @@ on:
   # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   component_tests:
     strategy:


### PR DESCRIPTION
## Pull Request Description
Limiting the scope of the GITHUB_TOKEN via the [permissions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions) attribute is best practice to prevent a leaked GITHUB_TOKEN from allowing repository write access.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
