### PR TITLE
resolve contentious AMD components

### DIFF
--- a/src/components/amd_smi/README.md
+++ b/src/components/amd_smi/README.md
@@ -107,3 +107,10 @@ After changing `PAPI_AMDSMI_ROOT` or related library paths, rerun make clobber &
 
 ## Hardware and Software Support
 To see the `amd_smi` component's current supported hardware and software please visit the GitHub wiki page [Hardware and Software Support - AMD\_SMI Component](https://github.com/icl-utk-edu/papi/wiki/Hardware-and-Software-Support-%E2%80%90-AMD_SMI-Component).
+
+## Known Limitations
+
+* For AMD devices older than the AMD Instinct MI300A, PAPI should not be configured with both `rocm_smi` and `amd_smi`.
+  If both components are configured, then `rocm_smi` will be active by default for ROCm < 6.4.0; `amd_smi` will be active by default for ROCm >= 6.4.0.
+  Users can override this when running an application by setting `export PAPI_DISABLE_COMPONENTS=rocm_smi` when `rocm_smi` is active by default, or
+  `export PAPI_DISABLE_COMPONENTS=amd_smi` when `amd_smi` is active by default.

--- a/src/components/amd_smi/linux-amd-smi.c
+++ b/src/components/amd_smi/linux-amd-smi.c
@@ -57,11 +57,40 @@ static int _amd_smi_init_component(int cidx) {
     _amd_smi_vector.cmp_info.num_mpx_cntrs = -1;
     _amd_smi_lock = PAPI_NUM_LOCK + NUM_INNER_LOCK + cidx;
 
-    CHECK_SNPRINTF(doNotAllowTruncation, _amd_smi_vector.cmp_info.disabled_reason, PAPI_MAX_STR_LEN,
-             "Not initialized. Access an AMD SMI event to initialize.");
-    _amd_smi_vector.cmp_info.disabled = PAPI_EDELAY_INIT;
+    /* Manage contension between rocm_smi and amd_smi components. */
+    int use_amd_smi = 0;
+    #if defined(DEFAULT_TO_AMD_SMI)
+    use_amd_smi = 1;
+    #endif
+    #if defined(DEFAULT_TO_ROCM_SMI)
+        char *disabledComps = getenv("PAPI_DISABLE_COMPONENTS");
+        if (disabledComps != NULL) {
+            char *penv = strdup(disabledComps);
+            char *p;
+            for (p = strtok (penv, ",:"); p != NULL; p = strtok (NULL, ",:")) {
+                if(!strcmp(p, "rocm_smi")) use_amd_smi = 1;
+            }
+            free(penv);
+        } else {
+            SUBDBG("amd_smi: getenv(PAPI_DISABLE_COMPONENTS) was not set.\n");
+        }
+    #endif
 
-    return PAPI_EDELAY_INIT;
+    int papi_errno;
+    if (use_amd_smi) {
+        CHECK_SNPRINTF(_amd_smi_vector.cmp_info.disabled_reason, PAPI_HUGE_STR_LEN,
+                 "Not initialized. Access an AMD SMI event to initialize.");
+        papi_errno = PAPI_EDELAY_INIT;
+        _amd_smi_vector.cmp_info.disabled = papi_errno;
+        return papi_errno;
+    } else {
+        CHECK_SNPRINTF(_amd_smi_vector.cmp_info.disabled_reason, PAPI_HUGE_STR_LEN,
+                 "Not active while rocm_smi component is active. Set 'export PAPI_DISABLE_COMPONENTS=rocm_smi' to override.");
+        papi_errno = PAPI_ECOMBO;
+        _amd_smi_vector.cmp_info.disabled = papi_errno;
+        return papi_errno;
+    }
+
 }
 
 static int evt_get_count(int *count) {
@@ -92,9 +121,14 @@ static int _amd_smi_init_private(void) {
         amds_err_get_last(&error_str);
         if (!error_str || !error_str[0])
             error_str = "AMD SMI component initialization failed";
+<<<<<<< HEAD
         CHECK_SNPRINTF(doNotAllowTruncation, _amd_smi_vector.cmp_info.disabled_reason,
                  sizeof _amd_smi_vector.cmp_info.disabled_reason, "%s",
                  error_str);
+=======
+        CHECK_SNPRINTF(_amd_smi_vector.cmp_info.disabled_reason,
+                 PAPI_HUGE_STR_LEN, "%s", error_str);
+>>>>>>> e27d70a7e (amd comps: contentious components in same config)
         goto fn_fail;
     }
 

--- a/src/components/rocm/README.md
+++ b/src/components/rocm/README.md
@@ -79,6 +79,9 @@ setting the ROCP\_TOOL\_LIB to the PAPI library as follows:
   Please instead use the [`rocp_sdk`](https://github.com/icl-utk-edu/papi/blob/master/src/components/rocp_sdk/README.md) component.
 
 * For AMD devices older than the AMD Instinct MI300A, PAPI should not be configured with both `rocm` and `rocp_sdk`.
+  If both components are configured, then `rocm` will be active by default for ROCm < 6.3.2; `rocp_sdk` will be active by default for ROCm >= 6.3.2.
+  Users can override this when running an application by setting `export PAPI_DISABLE_COMPONENTS=rocm` when `rocm` is active by default, or
+  `export PAPI_DISABLE_COMPONENTS=rocp_sdk` when `rocp_sdk` is active by default.
 
 * For ROCm >= 6.2.0, the environment variable `AQLPROFILE_READ_API` should be set to 0 for intercept mode and 1 (or unset) for sampling mode.
   Otherwise, counter values in intercept mode will return 0. See PAPI Issue #457 for more details.

--- a/src/components/rocm/rocm.c
+++ b/src/components/rocm/rocm.c
@@ -133,24 +133,57 @@ rocm_init_component(int cid)
     _rocm_lock = PAPI_NUM_LOCK + NUM_INNER_LOCK + cid;
     SUBDBG("ENTER: cid: %d\n", cid);
 
-    int papi_errno = rocd_init_environment();
-    if (papi_errno != PAPI_OK) {
-        _rocm_vector.cmp_info.initialized = 0;
-        _rocm_vector.cmp_info.disabled = papi_errno;
-        const char *err_string;
-        rocd_err_get_last(&err_string);
-        int expect = snprintf(_rocm_vector.cmp_info.disabled_reason,
-                              PAPI_MAX_STR_LEN, "%s", err_string);
-        if (expect > PAPI_MAX_STR_LEN) {
+    /* Manage contension between rocm and rocp_sdk components. */
+    int use_rocm = 0;
+    #if defined(DEFAULT_TO_ROCM)
+    use_rocm = 1;
+    #endif
+    #if defined(DEFAULT_TO_ROCP_SDK)
+        char *disabledComps = getenv("PAPI_DISABLE_COMPONENTS");
+        if (disabledComps != NULL) {
+            char *penv = strdup(disabledComps);
+            char *p;
+            for (p = strtok (penv, ",:"); p != NULL; p = strtok (NULL, ",:")) {
+                if(!strcmp(p, "rocp_sdk")) use_rocm = 1;
+            }
+            free(penv);
+        } else {
+            SUBDBG("rocm: getenv(PAPI_DISABLE_COMPONENTS) was not set.\n");
+        }
+    #endif
+
+    int papi_errno, expect;
+    if (use_rocm) {
+        papi_errno = rocd_init_environment();
+        if (papi_errno != PAPI_OK) {
+            _rocm_vector.cmp_info.initialized = 1;
+            _rocm_vector.cmp_info.disabled = papi_errno;
+            const char *err_string;
+            rocd_err_get_last(&err_string);
+            expect = snprintf(_rocm_vector.cmp_info.disabled_reason,
+                              PAPI_HUGE_STR_LEN, "%s", err_string);
+            if (expect < 0 || expect >= PAPI_HUGE_STR_LEN) {
+                SUBDBG("disabled_reason truncated");
+            }
+            goto fn_fail;
+        }
+
+        expect = snprintf(_rocm_vector.cmp_info.disabled_reason, PAPI_HUGE_STR_LEN, "%s",
+                         "Not initialized. Access component events to initialize it.");
+        if (expect < 0 || expect >= PAPI_HUGE_STR_LEN) {
             SUBDBG("disabled_reason truncated");
         }
-        goto fn_fail;
+        papi_errno = PAPI_EDELAY_INIT;
+        _rocm_vector.cmp_info.disabled = papi_errno;
+    } else {
+        expect = snprintf(_rocm_vector.cmp_info.disabled_reason, PAPI_HUGE_STR_LEN, "%s",
+                          "Not active while rocp_sdk component is active. Set 'export PAPI_DISABLE_COMPONENTS=rocp_sdk' to override.");
+        if (expect < 0 || expect >= PAPI_HUGE_STR_LEN) {
+            SUBDBG("disabled_reason truncated");
+        }
+        papi_errno = PAPI_ECOMBO;
+        _rocm_vector.cmp_info.disabled = papi_errno;
     }
-
-    sprintf(_rocm_vector.cmp_info.disabled_reason,
-            "Not initialized. Access component events to initialize it.");
-    papi_errno = PAPI_EDELAY_INIT;
-    _rocm_vector.cmp_info.disabled = papi_errno;
 
   fn_exit:
     SUBDBG("EXIT: %s\n", PAPI_strerror(papi_errno));
@@ -209,8 +242,8 @@ rocm_init_private(void)
         const char *err_string;
         rocd_err_get_last(&err_string);
         int expect = snprintf(_rocm_vector.cmp_info.disabled_reason,
-                              PAPI_MAX_STR_LEN, "%s", err_string);
-        if (expect > PAPI_MAX_STR_LEN) {
+                              PAPI_HUGE_STR_LEN, "%s", err_string);
+        if (expect > PAPI_HUGE_STR_LEN) {
             SUBDBG("disabled_reason truncated");
         }
 
@@ -222,8 +255,8 @@ rocm_init_private(void)
     _rocm_vector.cmp_info.num_native_events = count;
     _rocm_vector.cmp_info.num_cntrs = count;
     _rocm_vector.cmp_info.initialized = 1;
-    int strLen = snprintf(_rocm_vector.cmp_info.disabled_reason, PAPI_MAX_STR_LEN, "%s", "");
-    if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+    int strLen = snprintf(_rocm_vector.cmp_info.disabled_reason, PAPI_HUGE_STR_LEN, "%s", "");
+    if (strLen < 0 || strLen >= PAPI_HUGE_STR_LEN) {
         SUBDBG("Failed to fully write disabled_reason.\n");
     }
 

--- a/src/components/rocm_smi/README.md
+++ b/src/components/rocm_smi/README.md
@@ -48,6 +48,11 @@ In both cases, the directory specified by `PAPI_ROCMSMI_ROOT` **must contain** t
 
 ## Known Limitations
 
+* For AMD devices older than the AMD Instinct MI300A, PAPI should not be configured with both `rocm_smi` and `amd_smi`.
+  If both components are configured, then `rocm_smi` will be active by default for ROCm < 6.4.0; `amd_smi` will be active by default for ROCm >= 6.4.0.
+  Users can override this when running an application by setting `export PAPI_DISABLE_COMPONENTS=rocm_smi` when `rocm_smi` is active by default, or
+  `export PAPI_DISABLE_COMPONENTS=amd_smi` when `amd_smi` is active by default.
+
 * Only sets of metrics and events that can be gathered in a single pass are supported.
 
 * Although AMD metrics may be floating point, all values are recast and returned as long long integers.

--- a/src/components/rocp_sdk/README.md
+++ b/src/components/rocp_sdk/README.md
@@ -65,5 +65,9 @@ To see the ROCP\_SDK component's current supported hardware and software please 
 
 ## Known Limitations
 
+* For AMD devices older than the AMD Instinct MI300A, PAPI should not be configured with both `rocm` and `rocp_sdk`.
+  If both components are configured, then `rocm` will be active by default for ROCm < 6.3.2; `rocp_sdk` will be active by default for ROCm >= 6.3.2.
+  Users can override this when running an application by setting `export PAPI_DISABLE_COMPONENTS=rocm` when `rocm` is active by default, or
+  `export PAPI_DISABLE_COMPONENTS=rocp_sdk` when `rocp_sdk` is active by default.
 * In dispatch mode, PAPI may read zeros if reading takes place immediately after the return of a GPU kernel. This is not a PAPI bug. It may occur because calls such as hipDeviceSynchronize() do not guarantee that ROCprofiler has been called and all counter buffers have been flushed.  Therefore, it is recommended that the user code adds a delay between the return of a kernel and calls to PAPI_read(), PAPI_stop(), etc.
 * If an application is linked against the static PAPI library libpapi.a, then the application must call PAPI_library_init() through PAPI_add_named_event()/PAPI_add_event()/PAPI_enum_cmp_event() before calling any hip routines (e.g. hipInit(), hipGetDeviceCount(), hipLaunchKernelGGL(), etc). If the application is linked against the dynamic library libpapi.so, then the order of operations does not matter.

--- a/src/components/rocp_sdk/rocp_sdk.c
+++ b/src/components/rocp_sdk/rocp_sdk.c
@@ -133,28 +133,57 @@ rocp_sdk_init_component(int cid)
     _rocp_sdk_vector.cmp_info.num_cntrs = -1;
     _rocp_sdk_lock = PAPI_NUM_LOCK + NUM_INNER_LOCK + cid;
 
-    // We set this env variable to silence some unnecessary ROCprofiler-SDK debug messages.
-    // It is not critical, so if it fails to be set, we can safely ignore the error.
-    (void)setenv("ROCPROFILER_LOG_LEVEL","fatal",0);
+    /* Manage contension between rocm and rocp_sdk components. */
+    int use_rocp_sdk = 0;
+    #if defined(DEFAULT_TO_ROCP_SDK)
+    use_rocp_sdk = 1;
+    #endif
+    #if defined(DEFAULT_TO_ROCM)
+        char *disabledComps = getenv("PAPI_DISABLE_COMPONENTS");
+        if (disabledComps != NULL) {
+            char *penv = strdup(disabledComps);
+            char *p;
+            for (p = strtok (penv, ",:"); p != NULL; p = strtok (NULL, ",:")) {
+                if(!strcmp(p, "rocm")) use_rocp_sdk = 1;
+            }
+            free(penv);
+        } else {
+            SUBDBG("rocp_sdk: getenv(PAPI_DISABLE_COMPONENTS) was not set.\n");
+        }
+    #endif
 
-    int papi_errno = rocprofiler_sdk_init_pre();
-    if (papi_errno != PAPI_OK) {
-        _rocp_sdk_vector.cmp_info.initialized = 0;
+    int papi_errno, expect;
+    if( use_rocp_sdk) {
+        // We set this env variable to silence some unnecessary ROCprofiler-SDK debug messages.
+        // It is not critical, so if it fails to be set, we can safely ignore the error.
+        (void)setenv("ROCPROFILER_LOG_LEVEL","fatal",0);
+
+        papi_errno = rocprofiler_sdk_init_pre();
+        if (papi_errno != PAPI_OK) {
+            _rocp_sdk_vector.cmp_info.initialized = 1;
+            _rocp_sdk_vector.cmp_info.disabled = papi_errno;
+            const char *err_string;
+            rocprofiler_sdk_err_get_last(&err_string);
+            expect = snprintf(_rocp_sdk_vector.cmp_info.disabled_reason, PAPI_HUGE_STR_LEN, "%s", err_string);
+            if (expect < 0 || expect >= PAPI_HUGE_STR_LEN) {
+                SUBDBG("disabled_reason truncated");
+            }
+            return papi_errno;
+        }
+
+        // This component needs to be fully initialized from the beginning,
+        // because interleaving hip calls and PAPI calls leads to errors.
+        return check_n_initialize();
+    } else {
+        expect = snprintf(_rocp_sdk_vector.cmp_info.disabled_reason, PAPI_HUGE_STR_LEN, "%s",
+                          "Not active while rocm component is active. Set 'export PAPI_DISABLE_COMPONENTS=rocm' to override.");
+        if (expect < 0 || expect >= PAPI_HUGE_STR_LEN) {
+            SUBDBG("disabled_reason truncated");
+        }
+        papi_errno = PAPI_ECOMBO;
         _rocp_sdk_vector.cmp_info.disabled = papi_errno;
-        const char *err_string;
-        rocprofiler_sdk_err_get_last(&err_string);
-        snprintf(_rocp_sdk_vector.cmp_info.disabled_reason, PAPI_MAX_STR_LEN, "%s", err_string);
         return papi_errno;
     }
-
-    int strLen = snprintf(_rocp_sdk_vector.cmp_info.disabled_reason, PAPI_HUGE_STR_LEN, "%s", \
-                          "Not initialized. Access component events to initialize it.");
-    if (strLen < 0 || strLen >= PAPI_HUGE_STR_LEN) {
-        SUBDBG("Failed to fully write initial disabled_reason.\n");
-        return PAPI_EBUF;
-    }
-    _rocp_sdk_vector.cmp_info.disabled = PAPI_EDELAY_INIT;
-    return PAPI_EDELAY_INIT;
 }
 
 int
@@ -215,7 +244,10 @@ rocp_sdk_init_private(void)
         _rocp_sdk_vector.cmp_info.disabled = papi_errno;
         const char *err_string;
         rocprofiler_sdk_err_get_last(&err_string);
-        snprintf(_rocp_sdk_vector.cmp_info.disabled_reason, PAPI_MAX_STR_LEN, "%s", err_string);
+        int expect = snprintf(_rocp_sdk_vector.cmp_info.disabled_reason, PAPI_HUGE_STR_LEN, "%s", err_string);
+        if (expect < 0 || expect >= PAPI_HUGE_STR_LEN) {
+            SUBDBG("disabled_reason truncated");
+        }
         goto fn_fail;
     }
 

--- a/src/configure
+++ b/src/configure
@@ -6546,150 +6546,6 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $components" >&5
 $as_echo "$components" >&6; }
 
-# Check whether rocm and rocp_sdk were configured together
-rocm_found=0
-rocp_sdk_found=0
-for comp in $components
-do
-    if test "$comp" = "rocm"; then
-        rocm_found=1
-    fi
-
-    if test "$comp" = "rocp_sdk"; then
-        rocp_sdk_found=1
-    fi
-done
-if test $rocm_found -eq 1 && test $rocp_sdk_found -eq 1; then
-    echo "WARNING: Components rocm and rocp_sdk should not be configured together. See components/rocm/README.md for more details."
-fi
-
-# If both SMI components were requested, select the one that matches the
-# available ROCm stack. amd_smi should be used for ROCm >= 6.4.0, while
-# rocm_smi remains the fallback for older releases.
-amd_smi_found=0
-rocm_smi_found=0
-for comp in $components
-do
-    case "$comp" in
-    amd_smi)
-        amd_smi_found=1
-        ;;
-    rocm_smi)
-        rocm_smi_found=1
-        ;;
-    esac
-done
-
-if test $amd_smi_found -eq 1 && test $rocm_smi_found -eq 1; then
-    rocm_version=""
-
-    for root in "$PAPI_AMDSMI_ROOT" "$PAPI_ROCMSMI_ROOT" "$PAPI_ROCM_ROOT"
-    do
-        if test "x$root" != "x"; then
-            for probe in "$root/.info/version" "$root/../.info/version" "$root/version.txt"
-            do
-                if test -f "$probe"; then
-                    rocm_version=`head -n 1 "$probe" 2>/dev/null`
-                    break 2
-                fi
-            done
-        fi
-    done
-
-    if test "x$rocm_version" = "x"; then
-        if command -v hipconfig >/dev/null 2>&1; then
-            rocm_version=`hipconfig --rocm-version 2>/dev/null | head -n 1`
-        elif command -v rocminfo >/dev/null 2>&1; then
-            rocm_version=`rocminfo --version 2>/dev/null | head -n 1`
-        elif command -v amd-smi >/dev/null 2>&1; then
-            rocm_version=`amd-smi --version 2>/dev/null | head -n 1`
-        elif command -v rocm-smi >/dev/null 2>&1; then
-            rocm_version=`rocm-smi --version 2>/dev/null | head -n 1`
-        fi
-    fi
-
-    rocm_version_clean=`echo "$rocm_version" | sed -n 's/[^0-9]*\([0-9][0-9]*\.[0-9][0-9]*\(\.[0-9][0-9]*\)\?\).*/\1/p'`
-    if test "x$rocm_version_clean" = "x"; then
-        rocm_version_clean=`echo "$rocm_version" | tr -cd '0-9.'`
-    fi
-
-    have_amd_smi_lib=0
-    have_rocm_smi_lib=0
-    for root in "$PAPI_AMDSMI_ROOT" "$PAPI_ROCM_ROOT"
-    do
-        if test "x$root" != "x"; then
-            if test -f "$root/lib/libamd_smi.so" || test -f "$root/lib64/libamd_smi.so"; then
-                have_amd_smi_lib=1
-            fi
-        fi
-    done
-    for root in "$PAPI_ROCMSMI_ROOT" "$PAPI_ROCM_ROOT"
-    do
-        if test "x$root" != "x"; then
-            if test -f "$root/lib/librocm_smi64.so" || test -f "$root/lib64/librocm_smi64.so"; then
-                have_rocm_smi_lib=1
-            fi
-        fi
-    done
-
-    selected_smi="amd_smi"
-    rocm_version_value=""
-    if test "x$rocm_version_clean" != "x"; then
-        rocm_major=`echo "$rocm_version_clean" | cut -d. -f1`
-        rocm_minor=`echo "$rocm_version_clean" | cut -d. -f2`
-        rocm_patch=`echo "$rocm_version_clean" | cut -d. -f3`
-        if test "x$rocm_minor" = "x"; then
-            rocm_minor=0
-        fi
-        if test "x$rocm_patch" = "x"; then
-            rocm_patch=0
-        fi
-        rocm_version_value=$((10#$rocm_major * 10000 + 10#$rocm_minor * 100 + 10#$rocm_patch))
-        if test $rocm_version_value -lt 60400; then
-            selected_smi="rocm_smi"
-        fi
-    else
-        if test $have_amd_smi_lib -eq 0 && test $have_rocm_smi_lib -eq 1; then
-            selected_smi="rocm_smi"
-        elif test $have_amd_smi_lib -eq 0 && test $have_rocm_smi_lib -eq 0; then
-            echo "WARNING: Unable to determine ROCm version or locate AMD/ROCm SMI libraries. Defaulting to amd_smi when both components are requested."
-        else
-            echo "WARNING: Unable to determine ROCm version. Defaulting to amd_smi when both SMI components are requested."
-        fi
-    fi
-
-    filtered_components=""
-    for comp in $components
-    do
-        if test "$comp" = "amd_smi" && test "$selected_smi" = "rocm_smi"; then
-            continue
-        fi
-        if test "$comp" = "rocm_smi" && test "$selected_smi" = "amd_smi"; then
-            continue
-        fi
-        filtered_components="$filtered_components $comp"
-    done
-    components=`echo $filtered_components`
-
-    if test "x$rocm_version_clean" != "x"; then
-        if test "$selected_smi" = "amd_smi"; then
-            echo "INFO: Detected ROCm version $rocm_version_clean. Building amd_smi and skipping rocm_smi."
-        else
-            echo "INFO: Detected ROCm version $rocm_version_clean. Building rocm_smi and skipping amd_smi."
-        fi
-    else
-        if test $have_amd_smi_lib -eq 1 && test $have_rocm_smi_lib -eq 0; then
-            echo "INFO: Only AMD SMI libraries were found. Building amd_smi and skipping rocm_smi."
-        elif test $have_rocm_smi_lib -eq 1 && test $have_amd_smi_lib -eq 0; then
-            echo "INFO: Only ROCm SMI libraries were found. Building rocm_smi and skipping amd_smi."
-        elif test "$selected_smi" = "rocm_smi"; then
-            echo "INFO: Falling back to rocm_smi because AMD SMI libraries were not detected."
-        else
-            echo "INFO: Defaulting to amd_smi when both SMI components are requested."
-        fi
-    fi
-fi
-
 # This is an ugly hack to keep building on configurations covered by any-null in the past.
 if test "$VECTOR" = "_papi_dummy_vector"; then
 	if test "x$components" = "x"; then
@@ -6909,6 +6765,10 @@ for comp in $components; do
   fi
 done
 
+rocm_found=0
+rocp_sdk_found=0
+rocm_smi_found=0
+amd_smi_found=0
 for comp in $components; do
   # check for SDE component to determine linking flags.
   if test "x$comp" = "xsde" ; then
@@ -6926,6 +6786,22 @@ for comp in $components; do
   # check for intel_gpu or rocp_sdk component to determine if we need -lstdc++ in LDFLAGS
   if (test "x$comp" = "xintel_gpu" || test "x$comp" = "xrocp_sdk"); then
     LDFLAGS="$LDFLAGS -lstdc++ -pthread"
+  fi
+
+  # check for rocm and rocp_sdk so that components know about each other
+  if (test "x$comp" = "xrocm"); then
+    rocm_found=1
+  fi
+  if (test "x$comp" = "xrocp_sdk"); then
+    rocp_sdk_found=1
+  fi
+
+  # check for rocm_smi and amd_smi so that components know about each other
+  if (test "x$comp" = "xrocm_smi"); then
+    rocm_smi_found=1
+  fi
+  if (test "x$comp" = "xamd_smi"); then
+    amd_smi_found=1
   fi
 
   if test "x$comp" = "xsysdetect" ; then
@@ -6946,6 +6822,201 @@ for comp in $components; do
       fi
   fi
 done
+
+# Select the components that match the available ROCm stack. amd_smi
+# should be used for ROCm >= 6.4.0, while rocm_smi remains the fallback
+# for older releases. rocp_sdk should be used for ROCm >= 6.3.2, while
+# rocm should be used for older releases.
+if (test $rocm_found -eq 0 && test $rocp_sdk_found -eq 1); then
+    CFLAGS="$CFLAGS -DDEFAULT_TO_ROCP_SDK"
+fi
+if (test $rocm_found -eq 1 && test $rocp_sdk_found -eq 0); then
+    CFLAGS="$CFLAGS -DDEFAULT_TO_ROCM"
+fi
+if (test $rocm_smi_found -eq 0 && test $amd_smi_found -eq 1); then
+    CFLAGS="$CFLAGS -DDEFAULT_TO_AMD_SMI"
+fi
+if (test $rocm_smi_found -eq 1 && test $amd_smi_found -eq 0); then
+    CFLAGS="$CFLAGS -DDEFAULT_TO_ROCM_SMI"
+fi
+
+if (test $rocm_found -eq 1 && test $rocp_sdk_found -eq 1) || \
+   (test $amd_smi_found -eq 1 && test $rocm_smi_found -eq 1); then
+    rocm_version=""
+
+    # Check for inconsistent ROCm versions.
+    active_roots=""
+    if (test $rocm_found -eq 1); then
+        active_roots="$active_roots $PAPI_ROCM_ROOT"
+    fi
+    if (test $rocp_sdk_found -eq 1); then
+        active_roots="$active_roots $PAPI_ROCP_SDK_ROOT"
+    fi
+    if (test $rocm_smi_found -eq 1); then
+        active_roots="$active_roots $PAPI_ROCMSMI_ROOT"
+    fi
+    if (test $amd_smi_found -eq 1); then
+        active_roots="$active_roots $PAPI_AMDSMI_ROOT"
+    fi
+
+    version_found=0
+    prev_version=""
+    prev_root=""
+    for root in $active_roots
+    do
+        if test "x$root" != "x"; then
+            for probe in "$root/.info/version" "$root/../.info/version" "$root/version.txt"
+            do
+                if test -f "$probe"; then
+                    # Whenever else a version is found, we compare it to the previous one.
+                    if test $version_found -eq 1; then
+                        rocm_version=`head -n 1 "$probe" 2>/dev/null`
+                        # If there is a version mismatch, warn the user.
+                        if test "$rocm_version" != "$prev_version"; then
+                            warn_inconsistent_rocm=`echo "
+    ROCm version $rocm_version in $root does not match version $prev_version in $prev_root.
+    Using different ROCm versions could lead to compilation errors."`
+                        fi
+                        prev_version=$rocm_version
+                    # The first time a version is found, we have nothing to which to compare it.
+                    else
+                        prev_version=`head -n 1 "$probe" 2>/dev/null`
+                        version_found=1
+                    fi
+                    prev_root=$root
+                fi
+            done
+        fi
+    done
+
+    if test "x$rocm_version" = "x"; then
+        for root in $active_roots
+        do
+            version_header=`find $root -name rocm_version.h`
+            if test "x$version_header" != "x"; then
+                rocm_major=`grep "ROCM_VERSION_MAJOR" $version_header | awk '{print $3}'`
+                rocm_minor=`grep "ROCM_VERSION_MINOR" $version_header | awk '{print $3}'`
+                rocm_patch=`grep "ROCM_VERSION_PATCH" $version_header | awk '{print $3}'`
+                rocm_version="$rocm_major.$rocm_minor.$rocm_patch"
+                break
+            fi
+        done
+    fi
+
+    if test "x$rocm_version" = "x"; then
+        if command -v hipconfig >/dev/null 2>&1; then
+            rocm_version=`hipconfig --rocm-version 2>/dev/null | head -n 1`
+        elif command -v rocminfo >/dev/null 2>&1; then
+            rocm_version=`rocminfo --version 2>/dev/null | head -n 1`
+        elif command -v amd-smi >/dev/null 2>&1; then
+            rocm_version=`amd-smi --version 2>/dev/null | head -n 1`
+        elif command -v rocm-smi >/dev/null 2>&1; then
+            rocm_version=`rocm-smi --version 2>/dev/null | head -n 1`
+        fi
+    fi
+
+    rocm_version_clean=`echo "$rocm_version" | sed -n 's/[^0-9]*\([0-9][0-9]*\.[0-9][0-9]*\(\.[0-9][0-9]*\)\?\).*/\1/p'`
+    if test "x$rocm_version_clean" = "x"; then
+        rocm_version_clean=`echo "$rocm_version" | tr -cd '0-9.'`
+    fi
+
+    if test $amd_smi_found -eq 1 && test $rocm_smi_found -eq 1; then
+        have_amd_smi_lib=0
+        have_rocm_smi_lib=0
+        if test "x$PAPI_AMDSMI_ROOT" != "x"; then
+            if test -f "$PAPI_AMDSMI_ROOT/lib/libamd_smi.so" || test -f "$PAPI_AMDSMI_ROOT/lib64/libamd_smi.so"; then
+                have_amd_smi_lib=1
+            fi
+        fi
+        if test "x$PAPI_ROCMSMI_ROOT" != "x"; then
+            if test -f "$PAPI_ROCMSMI_ROOT/lib/librocm_smi64.so" || test -f "$PAPI_ROCMSMI_ROOT/lib64/librocm_smi64.so"; then
+                have_rocm_smi_lib=1
+            fi
+        fi
+
+        selected_smi="amd_smi"
+        rocm_version_value=""
+        if test "x$rocm_version_clean" != "x"; then
+            rocm_major=`echo "$rocm_version_clean" | cut -d. -f1`
+            rocm_minor=`echo "$rocm_version_clean" | cut -d. -f2`
+            rocm_patch=`echo "$rocm_version_clean" | cut -d. -f3`
+            if test "x$rocm_minor" = "x"; then
+                rocm_minor=0
+            fi
+            if test "x$rocm_patch" = "x"; then
+                rocm_patch=0
+            fi
+            rocm_version_value=$((10#$rocm_major * 10000 + 10#$rocm_minor * 100 + 10#$rocm_patch))
+            if test $rocm_version_value -lt 60400; then
+                selected_smi="rocm_smi"
+            fi
+        else
+            if test $have_amd_smi_lib -eq 0 && test $have_rocm_smi_lib -eq 1; then
+                selected_smi="rocm_smi"
+            elif test $have_amd_smi_lib -eq 0 && test $have_rocm_smi_lib -eq 0; then
+                info_version="Unable to determine ROCm version or locate AMD/ROCm SMI libraries. Defaulting to amd_smi when both components are requested."
+            else
+                info_version="Unable to determine ROCm version. Defaulting to amd_smi when both SMI components are requested."
+            fi
+        fi
+
+        if test "x$rocm_version_clean" != "x"; then
+            info_smi_choice=`echo "
+    Components rocm_smi and amd_smi cannot be simultaneously active. ROCm version $rocm_version_clean detected; therefore, $selected_smi
+    component is enabled by default. See components/rocm_smi/README or components/amd_smi/README for more details."`
+        else
+            if test $have_amd_smi_lib -eq 1 && test $have_rocm_smi_lib -eq 0; then
+                info_smi_choice="Only AMD SMI libraries were found. Enabling amd_smi by default."
+            elif test $have_rocm_smi_lib -eq 1 && test $have_amd_smi_lib -eq 0; then
+                info_smi_choice="Only ROCm SMI libraries were found. Enabling rocm_smi by default."
+            elif test "$selected_smi" = "rocm_smi"; then
+                info_smi_choice="Falling back to rocm_smi because AMD SMI libraries were not detected."
+            else
+                info_smi_choice="Defaulting to amd_smi when both SMI components are requested."
+            fi
+        fi
+
+        # Set which components will be active by default.
+        if test "x$selected_smi" = "xamd_smi"; then
+            CFLAGS="$CFLAGS -DDEFAULT_TO_AMD_SMI"
+        else
+            CFLAGS="$CFLAGS -DDEFAULT_TO_ROCM_SMI"
+        fi
+    fi
+
+    if test $rocp_sdk_found -eq 1 && test $rocm_found -eq 1; then
+
+        selected_roc="rocp_sdk"
+        rocm_version_value=""
+        if test "x$rocm_version_clean" != "x"; then
+            rocm_major=`echo "$rocm_version_clean" | cut -d. -f1`
+            rocm_minor=`echo "$rocm_version_clean" | cut -d. -f2`
+            rocm_patch=`echo "$rocm_version_clean" | cut -d. -f3`
+            if test "x$rocm_minor" = "x"; then
+                rocm_minor=0
+            fi
+            if test "x$rocm_patch" = "x"; then
+                rocm_patch=0
+            fi
+            rocm_version_value=$((10#$rocm_major * 10000 + 10#$rocm_minor * 100 + 10#$rocm_patch))
+            if test $rocm_version_value -lt 60302; then
+                selected_roc="rocm"
+            fi
+        fi
+
+        if test "x$rocm_version_clean" != "x"; then
+            info_roc_choice=`echo "
+    Components rocm and rocp_sdk cannot be simultaneously active. ROCm version $rocm_version_clean detected; therefore, $selected_roc
+    component is enabled by default. See components/rocm/README or components/rocp_sdk/README for more details."`
+        fi
+
+        if test "x$selected_roc" = "xrocp_sdk"; then
+            CFLAGS="$CFLAGS -DDEFAULT_TO_ROCP_SDK"
+        else
+            CFLAGS="$CFLAGS -DDEFAULT_TO_ROCM"
+        fi
+    fi
+fi
 
 CFLAGS="$CFLAGS -DPAPI_NUM_COMP=$PAPI_NUM_COMP"
 
@@ -8371,6 +8442,24 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
 
+
+if test "x$warn_inconsistent_rocm" != "x"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $warn_inconsistent_rocm" >&5
+$as_echo "$as_me: WARNING: $warn_inconsistent_rocm" >&2;}
+fi
+
+if test "x$info_version" != "x"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: $info_version" >&5
+$as_echo "$as_me: $info_version" >&6;}
+fi
+if test "x$info_smi_choice" != "x"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: $info_smi_choice" >&5
+$as_echo "$as_me: $info_smi_choice" >&6;}
+fi
+if test "x$info_roc_choice" != "x"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: $info_roc_choice" >&5
+$as_echo "$as_me: $info_roc_choice" >&6;}
+fi
 
 if test "$have_paranoid" = "yes"; then
   paranoid_level=`cat /proc/sys/kernel/perf_event_paranoid`

--- a/src/configure.in
+++ b/src/configure.in
@@ -1726,150 +1726,6 @@ fi
 
 AC_MSG_RESULT($components)
 
-# Check whether rocm and rocp_sdk were configured together
-rocm_found=0
-rocp_sdk_found=0
-for comp in $components
-do
-    if test "$comp" = "rocm"; then
-        rocm_found=1
-    fi
-
-    if test "$comp" = "rocp_sdk"; then
-        rocp_sdk_found=1
-    fi
-done
-if test $rocm_found -eq 1 && test $rocp_sdk_found -eq 1; then
-    echo "WARNING: Components rocm and rocp_sdk should not be configured together. See components/rocm/README.md for more details."
-fi
-
-# If both SMI components were requested, select the one that matches the
-# available ROCm stack. amd_smi should be used for ROCm >= 6.4.0, while
-# rocm_smi remains the fallback for older releases.
-amd_smi_found=0
-rocm_smi_found=0
-for comp in $components
-do
-    case "$comp" in
-    amd_smi)
-        amd_smi_found=1
-        ;;
-    rocm_smi)
-        rocm_smi_found=1
-        ;;
-    esac
-done
-
-if test $amd_smi_found -eq 1 && test $rocm_smi_found -eq 1; then
-    rocm_version=""
-
-    for root in "$PAPI_AMDSMI_ROOT" "$PAPI_ROCMSMI_ROOT" "$PAPI_ROCM_ROOT"
-    do
-        if test "x$root" != "x"; then
-            for probe in "$root/.info/version" "$root/../.info/version" "$root/version.txt"
-            do
-                if test -f "$probe"; then
-                    rocm_version=`head -n 1 "$probe" 2>/dev/null`
-                    break 2
-                fi
-            done
-        fi
-    done
-
-    if test "x$rocm_version" = "x"; then
-        if command -v hipconfig >/dev/null 2>&1; then
-            rocm_version=`hipconfig --rocm-version 2>/dev/null | head -n 1`
-        elif command -v rocminfo >/dev/null 2>&1; then
-            rocm_version=`rocminfo --version 2>/dev/null | head -n 1`
-        elif command -v amd-smi >/dev/null 2>&1; then
-            rocm_version=`amd-smi --version 2>/dev/null | head -n 1`
-        elif command -v rocm-smi >/dev/null 2>&1; then
-            rocm_version=`rocm-smi --version 2>/dev/null | head -n 1`
-        fi
-    fi
-
-    rocm_version_clean=`echo "$rocm_version" | sed -n 's/[[^0-9]]*\([[0-9]][[0-9]]*\.[[0-9]][[0-9]]*\(\.[[0-9]][[0-9]]*\)\?\).*/\1/p'`
-    if test "x$rocm_version_clean" = "x"; then
-        rocm_version_clean=`echo "$rocm_version" | tr -cd '0-9.'`
-    fi
-
-    have_amd_smi_lib=0
-    have_rocm_smi_lib=0
-    for root in "$PAPI_AMDSMI_ROOT" "$PAPI_ROCM_ROOT"
-    do
-        if test "x$root" != "x"; then
-            if test -f "$root/lib/libamd_smi.so" || test -f "$root/lib64/libamd_smi.so"; then
-                have_amd_smi_lib=1
-            fi
-        fi
-    done
-    for root in "$PAPI_ROCMSMI_ROOT" "$PAPI_ROCM_ROOT"
-    do
-        if test "x$root" != "x"; then
-            if test -f "$root/lib/librocm_smi64.so" || test -f "$root/lib64/librocm_smi64.so"; then
-                have_rocm_smi_lib=1
-            fi
-        fi
-    done
-
-    selected_smi="amd_smi"
-    rocm_version_value=""
-    if test "x$rocm_version_clean" != "x"; then
-        rocm_major=`echo "$rocm_version_clean" | cut -d. -f1`
-        rocm_minor=`echo "$rocm_version_clean" | cut -d. -f2`
-        rocm_patch=`echo "$rocm_version_clean" | cut -d. -f3`
-        if test "x$rocm_minor" = "x"; then
-            rocm_minor=0
-        fi
-        if test "x$rocm_patch" = "x"; then
-            rocm_patch=0
-        fi
-        rocm_version_value=$((10#$rocm_major * 10000 + 10#$rocm_minor * 100 + 10#$rocm_patch))
-        if test $rocm_version_value -lt 60400; then
-            selected_smi="rocm_smi"
-        fi
-    else
-        if test $have_amd_smi_lib -eq 0 && test $have_rocm_smi_lib -eq 1; then
-            selected_smi="rocm_smi"
-        elif test $have_amd_smi_lib -eq 0 && test $have_rocm_smi_lib -eq 0; then
-            echo "WARNING: Unable to determine ROCm version or locate AMD/ROCm SMI libraries. Defaulting to amd_smi when both components are requested."
-        else
-            echo "WARNING: Unable to determine ROCm version. Defaulting to amd_smi when both SMI components are requested."
-        fi
-    fi
-
-    filtered_components=""
-    for comp in $components
-    do
-        if test "$comp" = "amd_smi" && test "$selected_smi" = "rocm_smi"; then
-            continue
-        fi
-        if test "$comp" = "rocm_smi" && test "$selected_smi" = "amd_smi"; then
-            continue
-        fi
-        filtered_components="$filtered_components $comp"
-    done
-    components=`echo $filtered_components`
-
-    if test "x$rocm_version_clean" != "x"; then
-        if test "$selected_smi" = "amd_smi"; then
-            echo "INFO: Detected ROCm version $rocm_version_clean. Building amd_smi and skipping rocm_smi."
-        else
-            echo "INFO: Detected ROCm version $rocm_version_clean. Building rocm_smi and skipping amd_smi."
-        fi
-    else
-        if test $have_amd_smi_lib -eq 1 && test $have_rocm_smi_lib -eq 0; then
-            echo "INFO: Only AMD SMI libraries were found. Building amd_smi and skipping rocm_smi."
-        elif test $have_rocm_smi_lib -eq 1 && test $have_amd_smi_lib -eq 0; then
-            echo "INFO: Only ROCm SMI libraries were found. Building rocm_smi and skipping amd_smi."
-        elif test "$selected_smi" = "rocm_smi"; then
-            echo "INFO: Falling back to rocm_smi because AMD SMI libraries were not detected."
-        else
-            echo "INFO: Defaulting to amd_smi when both SMI components are requested."
-        fi
-    fi
-fi
-
 # This is an ugly hack to keep building on configurations covered by any-null in the past.
 if test "$VECTOR" = "_papi_dummy_vector"; then
 	if test "x$components" = "x"; then 
@@ -2069,6 +1925,10 @@ for comp in $components; do
   fi
 done
 
+rocm_found=0
+rocp_sdk_found=0
+rocm_smi_found=0
+amd_smi_found=0
 for comp in $components; do
   # check for SDE component to determine linking flags.
   if test "x$comp" = "xsde" ; then
@@ -2086,6 +1946,22 @@ for comp in $components; do
   # check for intel_gpu or rocp_sdk component to determine if we need -lstdc++ in LDFLAGS
   if (test "x$comp" = "xintel_gpu" || test "x$comp" = "xrocp_sdk"); then
     LDFLAGS="$LDFLAGS -lstdc++ -pthread"
+  fi
+
+  # check for rocm and rocp_sdk so that components know about each other
+  if (test "x$comp" = "xrocm"); then
+    rocm_found=1
+  fi
+  if (test "x$comp" = "xrocp_sdk"); then
+    rocp_sdk_found=1
+  fi
+
+  # check for rocm_smi and amd_smi so that components know about each other
+  if (test "x$comp" = "xrocm_smi"); then
+    rocm_smi_found=1
+  fi
+  if (test "x$comp" = "xamd_smi"); then
+    amd_smi_found=1
   fi
 
   if test "x$comp" = "xsysdetect" ; then
@@ -2106,6 +1982,201 @@ for comp in $components; do
       fi
   fi
 done
+
+# Select the components that match the available ROCm stack. amd_smi
+# should be used for ROCm >= 6.4.0, while rocm_smi remains the fallback
+# for older releases. rocp_sdk should be used for ROCm >= 6.3.2, while
+# rocm should be used for older releases.
+if (test $rocm_found -eq 0 && test $rocp_sdk_found -eq 1); then
+    CFLAGS="$CFLAGS -DDEFAULT_TO_ROCP_SDK"
+fi
+if (test $rocm_found -eq 1 && test $rocp_sdk_found -eq 0); then
+    CFLAGS="$CFLAGS -DDEFAULT_TO_ROCM"
+fi
+if (test $rocm_smi_found -eq 0 && test $amd_smi_found -eq 1); then
+    CFLAGS="$CFLAGS -DDEFAULT_TO_AMD_SMI"
+fi
+if (test $rocm_smi_found -eq 1 && test $amd_smi_found -eq 0); then
+    CFLAGS="$CFLAGS -DDEFAULT_TO_ROCM_SMI"
+fi
+
+if (test $rocm_found -eq 1 && test $rocp_sdk_found -eq 1) || \
+   (test $amd_smi_found -eq 1 && test $rocm_smi_found -eq 1); then
+    rocm_version=""
+
+    # Check for inconsistent ROCm versions.
+    active_roots=""
+    if (test $rocm_found -eq 1); then
+        active_roots="$active_roots $PAPI_ROCM_ROOT"
+    fi
+    if (test $rocp_sdk_found -eq 1); then
+        active_roots="$active_roots $PAPI_ROCP_SDK_ROOT"
+    fi
+    if (test $rocm_smi_found -eq 1); then
+        active_roots="$active_roots $PAPI_ROCMSMI_ROOT"
+    fi
+    if (test $amd_smi_found -eq 1); then
+        active_roots="$active_roots $PAPI_AMDSMI_ROOT"
+    fi
+
+    version_found=0
+    prev_version=""
+    prev_root=""
+    for root in $active_roots
+    do
+        if test "x$root" != "x"; then
+            for probe in "$root/.info/version" "$root/../.info/version" "$root/version.txt"
+            do
+                if test -f "$probe"; then
+                    # Whenever else a version is found, we compare it to the previous one.
+                    if test $version_found -eq 1; then
+                        rocm_version=`head -n 1 "$probe" 2>/dev/null`
+                        # If there is a version mismatch, warn the user.
+                        if test "$rocm_version" != "$prev_version"; then
+                            warn_inconsistent_rocm=`echo "
+    ROCm version $rocm_version in $root does not match version $prev_version in $prev_root.
+    Using different ROCm versions could lead to compilation errors."`
+                        fi
+                        prev_version=$rocm_version
+                    # The first time a version is found, we have nothing to which to compare it.
+                    else
+                        prev_version=`head -n 1 "$probe" 2>/dev/null`
+                        version_found=1
+                    fi
+                    prev_root=$root
+                fi
+            done
+        fi
+    done
+
+    if test "x$rocm_version" = "x"; then
+        for root in $active_roots
+        do
+            version_header=`find $root -name rocm_version.h`
+            if test "x$version_header" != "x"; then
+                rocm_major=`grep "ROCM_VERSION_MAJOR" $version_header | awk '{print $3}'`
+                rocm_minor=`grep "ROCM_VERSION_MINOR" $version_header | awk '{print $3}'`
+                rocm_patch=`grep "ROCM_VERSION_PATCH" $version_header | awk '{print $3}'`
+                rocm_version="$rocm_major.$rocm_minor.$rocm_patch"
+                break
+            fi
+        done
+    fi
+
+    if test "x$rocm_version" = "x"; then
+        if command -v hipconfig >/dev/null 2>&1; then
+            rocm_version=`hipconfig --rocm-version 2>/dev/null | head -n 1`
+        elif command -v rocminfo >/dev/null 2>&1; then
+            rocm_version=`rocminfo --version 2>/dev/null | head -n 1`
+        elif command -v amd-smi >/dev/null 2>&1; then
+            rocm_version=`amd-smi --version 2>/dev/null | head -n 1`
+        elif command -v rocm-smi >/dev/null 2>&1; then
+            rocm_version=`rocm-smi --version 2>/dev/null | head -n 1`
+        fi
+    fi
+
+    rocm_version_clean=`echo "$rocm_version" | sed -n 's/[[^0-9]]*\([[0-9]][[0-9]]*\.[[0-9]][[0-9]]*\(\.[[0-9]][[0-9]]*\)\?\).*/\1/p'`
+    if test "x$rocm_version_clean" = "x"; then
+        rocm_version_clean=`echo "$rocm_version" | tr -cd '0-9.'`
+    fi
+
+    if test $amd_smi_found -eq 1 && test $rocm_smi_found -eq 1; then
+        have_amd_smi_lib=0
+        have_rocm_smi_lib=0
+        if test "x$PAPI_AMDSMI_ROOT" != "x"; then
+            if test -f "$PAPI_AMDSMI_ROOT/lib/libamd_smi.so" || test -f "$PAPI_AMDSMI_ROOT/lib64/libamd_smi.so"; then
+                have_amd_smi_lib=1
+            fi
+        fi
+        if test "x$PAPI_ROCMSMI_ROOT" != "x"; then
+            if test -f "$PAPI_ROCMSMI_ROOT/lib/librocm_smi64.so" || test -f "$PAPI_ROCMSMI_ROOT/lib64/librocm_smi64.so"; then
+                have_rocm_smi_lib=1
+            fi
+        fi
+
+        selected_smi="amd_smi"
+        rocm_version_value=""
+        if test "x$rocm_version_clean" != "x"; then
+            rocm_major=`echo "$rocm_version_clean" | cut -d. -f1`
+            rocm_minor=`echo "$rocm_version_clean" | cut -d. -f2`
+            rocm_patch=`echo "$rocm_version_clean" | cut -d. -f3`
+            if test "x$rocm_minor" = "x"; then
+                rocm_minor=0
+            fi
+            if test "x$rocm_patch" = "x"; then
+                rocm_patch=0
+            fi
+            rocm_version_value=$((10#$rocm_major * 10000 + 10#$rocm_minor * 100 + 10#$rocm_patch))
+            if test $rocm_version_value -lt 60400; then
+                selected_smi="rocm_smi"
+            fi
+        else
+            if test $have_amd_smi_lib -eq 0 && test $have_rocm_smi_lib -eq 1; then
+                selected_smi="rocm_smi"
+            elif test $have_amd_smi_lib -eq 0 && test $have_rocm_smi_lib -eq 0; then
+                info_version="Unable to determine ROCm version or locate AMD/ROCm SMI libraries. Defaulting to amd_smi when both components are requested."
+            else
+                info_version="Unable to determine ROCm version. Defaulting to amd_smi when both SMI components are requested."
+            fi
+        fi
+
+        if test "x$rocm_version_clean" != "x"; then
+            info_smi_choice=`echo "
+    Components rocm_smi and amd_smi cannot be simultaneously active. ROCm version $rocm_version_clean detected; therefore, $selected_smi
+    component is enabled by default. See components/rocm_smi/README or components/amd_smi/README for more details."`
+        else
+            if test $have_amd_smi_lib -eq 1 && test $have_rocm_smi_lib -eq 0; then
+                info_smi_choice="Only AMD SMI libraries were found. Enabling amd_smi by default."
+            elif test $have_rocm_smi_lib -eq 1 && test $have_amd_smi_lib -eq 0; then
+                info_smi_choice="Only ROCm SMI libraries were found. Enabling rocm_smi by default."
+            elif test "$selected_smi" = "rocm_smi"; then
+                info_smi_choice="Falling back to rocm_smi because AMD SMI libraries were not detected."
+            else
+                info_smi_choice="Defaulting to amd_smi when both SMI components are requested."
+            fi
+        fi
+
+        # Set which components will be active by default.
+        if test "x$selected_smi" = "xamd_smi"; then
+            CFLAGS="$CFLAGS -DDEFAULT_TO_AMD_SMI"
+        else
+            CFLAGS="$CFLAGS -DDEFAULT_TO_ROCM_SMI"
+        fi
+    fi
+
+    if test $rocp_sdk_found -eq 1 && test $rocm_found -eq 1; then
+
+        selected_roc="rocp_sdk"
+        rocm_version_value=""
+        if test "x$rocm_version_clean" != "x"; then
+            rocm_major=`echo "$rocm_version_clean" | cut -d. -f1`
+            rocm_minor=`echo "$rocm_version_clean" | cut -d. -f2`
+            rocm_patch=`echo "$rocm_version_clean" | cut -d. -f3`
+            if test "x$rocm_minor" = "x"; then
+                rocm_minor=0
+            fi
+            if test "x$rocm_patch" = "x"; then
+                rocm_patch=0
+            fi
+            rocm_version_value=$((10#$rocm_major * 10000 + 10#$rocm_minor * 100 + 10#$rocm_patch))
+            if test $rocm_version_value -lt 60302; then
+                selected_roc="rocm"
+            fi
+        fi
+
+        if test "x$rocm_version_clean" != "x"; then
+            info_roc_choice=`echo "
+    Components rocm and rocp_sdk cannot be simultaneously active. ROCm version $rocm_version_clean detected; therefore, $selected_roc
+    component is enabled by default. See components/rocm/README or components/rocp_sdk/README for more details."`
+        fi
+
+        if test "x$selected_roc" = "xrocp_sdk"; then
+            CFLAGS="$CFLAGS -DDEFAULT_TO_ROCP_SDK"
+        else
+            CFLAGS="$CFLAGS -DDEFAULT_TO_ROCM"
+        fi
+    fi
+fi
 
 CFLAGS="$CFLAGS -DPAPI_NUM_COMP=$PAPI_NUM_COMP"
 
@@ -2233,6 +2304,20 @@ AC_MSG_NOTICE($FILENAME will be included in the generated Makefile)
 AC_CONFIG_FILES([Makefile papi.pc])
 AC_CONFIG_FILES([components/Makefile_comp_tests.target testlib/Makefile.target utils/Makefile.target ctests/Makefile.target ftests/Makefile.target validation_tests/Makefile.target])
 AC_OUTPUT
+
+if test "x$warn_inconsistent_rocm" != "x"; then
+  AC_MSG_WARN($warn_inconsistent_rocm)
+fi
+
+if test "x$info_version" != "x"; then
+  AC_MSG_NOTICE($info_version)
+fi
+if test "x$info_smi_choice" != "x"; then
+  AC_MSG_NOTICE($info_smi_choice)
+fi
+if test "x$info_roc_choice" != "x"; then
+  AC_MSG_NOTICE($info_roc_choice)
+fi
 
 if test "$have_paranoid" = "yes"; then
   paranoid_level=`cat /proc/sys/kernel/perf_event_paranoid`

--- a/src/papi.c
+++ b/src/papi.c
@@ -1049,6 +1049,18 @@ PAPI_library_init( int version )
 
 	int tmp = 0;
 
+    char *disabledComps = getenv("PAPI_DISABLE_COMPONENTS");
+    if (disabledComps != NULL) {
+        char *penv = strdup(disabledComps);
+        char *p;
+        for (p = strtok (penv, ",:"); p != NULL; p = strtok (NULL, ",:")) {
+            (void) PAPI_disable_component_by_name(p);
+        }
+        free(penv);
+    } else {
+        SUBDBG("PAPI_library_init: getenv(PAPI_DISABLE_COMPONENTS) was not set.\n");
+    }
+
 	/* This is a poor attempt at a lock. 
 	   For 3.1 this should be replaced with a 
 	   true UNIX semaphore. We cannot use PAPI


### PR DESCRIPTION
## Pull Request Description

- framework: PAPI_DISABLE_COMPONENTS env var
- amd comps: contentious components in same config

This pull request resolves issues #407, #416, and #478.

ROCm version >= 6.3.2 being the "cutoff" for making `rocp_sdk` active by default over `rocm` was chosen due to known bugs in the ROCProfiler SDK in prior releases.

These changes have been tested using ROCm 7.0.2 on the Frontier supercomputer, which contains the AMD MI250X architecture.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
