### PR TITLE
amd_smi: String description for each device for string meta data events

### DIFF
--- a/src/components/amd_smi/amds_priv.h
+++ b/src/components/amd_smi/amds_priv.h
@@ -42,6 +42,14 @@ typedef enum {
 
 typedef int (*amds_accessor_t)(int mode, void *arg);
 
+/* Native event descriptor flags (native_event_t::evtinfo_flags) */
+#define AMDS_EVTINFO_FLAG_PER_DEVICE_DESCR   0x1u  /* descr differs by device */
+
+typedef struct {
+  int num_devices; /* <= 64 */
+  char **descrs; /* descrs[device] */
+} amds_per_device_descr_t;
+
 /* Native event descriptor */
 typedef struct native_event {
   unsigned int id;
@@ -50,6 +58,8 @@ typedef struct native_event {
   uint64_t device_map;
   uint64_t value;
   uint32_t mode, variant, subvariant;
+  uint32_t evtinfo_flags;
+  amds_per_device_descr_t *per_device_descr;
   void *priv;
   int (*open_func)(struct native_event *);
   int (*close_func)(struct native_event *);


### PR DESCRIPTION
## Pull Request Description
Previously, the event description for string events for amd_smi in papi_native_avail only displayed the string for Device 0. 

Implemented per-device descriptions. Updated initialization to capture and store specific strings (UUIDs, serials, versions) for every device index. Modified amds_evt_code_to_info and amds_evt_code_to_descr to dynamically display the correct source string for the specific device variant being queried. Each :device=N variant now displays its own specific  string in the description, providing necessary context for the hash value.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
