### PR TITLE
rocp_sdk: Update README to remove FAQ section and properly jump to enabling the rocp_sdk component

### DIFF
--- a/src/components/rocp_sdk/README.md
+++ b/src/components/rocp_sdk/README.md
@@ -3,11 +3,10 @@
 The ROCP\_SDK component exposes numerous performance events on AMD GPUs and APUs.
 The component is an adapter to the ROCm profiling library ROCprofiler-SDK which is included in a standard ROCM release.
 
-* [Enabling the ROCP\_SDK Component](#enabling-the-rocm-component)
+* [Enabling the ROCP\_SDK Component](#enabling-the-rocp_sdk-component)
 * [Environment Variables](#environment-variables)
 * [Hardware and Software Support](#hardware-and-software-support)
 * [Known Limitations](#known-limitations)
-* [FAQ](#faq)
 ***
 ## Enabling the ROCP\_SDK Component
     


### PR DESCRIPTION
## Pull Request Description
Update the `rocp_sdk` to remove the FAQ section for the table of contents and to properly link to the section "Enabling the ROCP_SDK Component".

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
