### PR TITLE
amd_smi: fail on unexpected add/start errors

### DIFF
--- a/src/components/amd_smi/tests/test_harness.h
+++ b/src/components/amd_smi/tests/test_harness.h
@@ -218,11 +218,14 @@ static inline int harness_eval_result(const char *file, int line, HarnessOpts op
  *        limits, exit as "PASSED with WARNING".
  *
  * Recognizes PAPI_ENOEVNT, PAPI_ECNFLCT, PAPI_EPERM, and PAPI_ENOSUPP.
+ * Any other non-OK return code is treated as a test failure.
  */
 #define EXIT_WARNING_ON_ADD(rc, evname) do { \
     if ((rc) == PAPI_ENOEVNT || (rc) == PAPI_ECNFLCT || (rc) == PAPI_EPERM || (rc) == PAPI_ENOSUPP) { \
         EXIT_WARNING("Event unavailable (%s): %s", PAPI_strerror(rc), (evname)); \
     } \
+    fprintf(stderr, "Unexpected error encountered (%d) when adding the event %s.\n", (rc), (evname)); \
+    exit(1); \
 } while (0)
 
 /**


### PR DESCRIPTION
## Pull Request Description
Updates EXIT_WARNING_ON_ADD to treat unexpected error codes (e.g., PAPI_EISRUN, PAPI_EINVAL) as test failures. Previously, non-listed errors were silently ignored, causing tests to pass incorrectly.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
