### PR TITLE
framework: Resolve compilation warnings

### DIFF
--- a/src/papi.c
+++ b/src/papi.c
@@ -1505,7 +1505,7 @@ PAPI_event_code_to_name( int EventCode, char *out )
             return PAPI_ENOEVNT;
         }
         if ( _papi_hwd[compIdx]->cmp_info.disabled == PAPI_EDELAY_INIT ) {
-            int junk;
+            unsigned int junk;
             _papi_hwd[compIdx]->ntv_enum_events(&junk, PAPI_ENUM_FIRST);
         }
 
@@ -1632,7 +1632,7 @@ PAPI_event_name_to_code( const char *in, int *out )
                      *out = ( int ) ( (i + _papi_hwi_start_idx[cmpnt]) | PAPI_PRESET_MASK );
 
                      if ( _papi_hwd[cmpnt]->cmp_info.disabled == PAPI_EDELAY_INIT ) {
-                         int junk;
+                         unsigned int junk;
                          _papi_hwd[cmpnt]->ntv_enum_events(&junk, PAPI_ENUM_FIRST);
                      }
 
@@ -1820,7 +1820,7 @@ PAPI_enum_event( int *EventCode, int modifier )
                 if (cidx < 0) return PAPI_ENOCMP;
                 if ( _papi_hwd[cidx]->cmp_info.disabled == PAPI_EDELAY_INIT ) {
                     APIDBG("Triggered forced initialization of component ID=%d.\n", cidx);
-                    int junk;
+                    unsigned int junk;
                     _papi_hwd[cidx]->ntv_enum_events(&junk, PAPI_ENUM_FIRST);
                 }
 
@@ -1855,7 +1855,7 @@ PAPI_enum_event( int *EventCode, int modifier )
             }
 
             if ( _papi_hwd[first_comp_with_presets]->cmp_info.disabled == PAPI_EDELAY_INIT ) {
-                int junk;
+                unsigned int junk;
                 _papi_hwd[first_comp_with_presets]->ntv_enum_events(&junk, PAPI_ENUM_FIRST);
             }
 
@@ -2072,7 +2072,7 @@ PAPI_enum_cmp_event( int *EventCode, int modifier, int cidx )
     if ( IS_PRESET(i) ) {
 
         if ( _papi_hwd[cidx]->cmp_info.disabled == PAPI_EDELAY_INIT ) {
-            int junk;
+            unsigned int junk;
             _papi_hwd[cidx]->ntv_enum_events(&junk, PAPI_ENUM_FIRST);
         }
 

--- a/src/papi_internal.c
+++ b/src/papi_internal.c
@@ -167,72 +167,6 @@ _papi_hwi_get_ntv_idx (unsigned int papi_evt_code) {
 	return result;
 }
 
-//
-// Check for the presence of a component name or pmu name in the event string.
-// If found check if it matches this component or one of the pmu's supported by this component.
-//
-// returns true if the event could be for this component and false if it is not for this component.
-//    if there is no component or pmu name then it could be for this component and returns true.
-//
-static int
-is_supported_by_component(int cidx, char *event_name) {
-	INTDBG("ENTER: cidx: %d, event_name: %s\n", cidx, event_name);
-	int i;
-	int component_name = 0;
-	int pmu_name = 0;
-	char *wptr = NULL;
-
-	// if event does not have a component name or pmu name, return to show it could be supported by this component
-	// when component and pmu names are not provided, we just have to call the components to see if they recognize the event
-	//
-
-	// look for component names first
-	if ((wptr = strstr(event_name, ":::")) != NULL) {
-		component_name = 1;
-	} else if ((wptr = strstr(event_name, "::")) != NULL) {
-		pmu_name = 1;
-	} else {
-		INTDBG("EXIT: No Component or PMU name in event string, try this component\n");
-		// need to force all components to be called to find owner of this event
-		// ????  can we assume the default pmu when no component or pmu name is provided ????
-		return 1;
-	}
-
-	// get a temporary copy of the component or pmu name
-	int name_len = wptr - event_name;
-	wptr = strdup(event_name);
-	wptr[name_len] = '\0';
-
-	// if a component name was found, compare it to the component name in the component info structure
-	if (component_name) {
-//		INTDBG("component_name: %s\n", _papi_hwd[cidx]->cmp_info.name);
-		if (strcmp (wptr, _papi_hwd[cidx]->cmp_info.name) == 0) {
-			free (wptr);
-			INTDBG("EXIT: Component %s supports this event\n", _papi_hwd[cidx]->cmp_info.name);
-			return 1;
-		}
-	}
-
-	// if a pmu name was found, compare it to the pmu name list if the component info structure (if there is one)
-	if (pmu_name) {
-		for ( i=0 ; i<PAPI_PMU_MAX ; i++) {
-			if (_papi_hwd[cidx]->cmp_info.pmu_names[i] == NULL) {
-				continue;
-			}
-//			INTDBG("pmu_name[%d]: %p (%s)\n", i, _papi_hwd[cidx]->cmp_info.pmu_names[i], _papi_hwd[cidx]->cmp_info.pmu_names[i]);
-			if (strcmp (wptr, _papi_hwd[cidx]->cmp_info.pmu_names[i]) == 0) {
-				INTDBG("EXIT: Component %s supports PMU %s and this event\n", _papi_hwd[cidx]->cmp_info.name, wptr);
-				free (wptr);
-				return 1;
-			}
-		}
-	}
-
-	free (wptr);
-	INTDBG("EXIT: Component does not support this event\n");
-	return 0;
-}
-
 /** @internal
  * @class _papi_hwi_prefix_component_name
  * @brief Prefixes a component's name to each of its events.
@@ -622,7 +556,7 @@ construct_qualified_event(hwi_presets_t *prstPtr) {
     char *tmpEvent = NULL;
     char *tmpQuals = NULL;
 
-    int j;
+    unsigned int j;
     for(j = 0; j < prstPtr->count; j++ ) {
         /* Construct event with all qualifiers. */
         int k, strLenSum = 0, baseLen = 1+strlen(prstPtr->base_name[j]);
@@ -673,7 +607,8 @@ construct_qualified_event(hwi_presets_t *prstPtr) {
         }
 
         /* Set the corresponding new code. */
-        status = _papi_hwi_native_name_to_code( tmpEvent, &(prstPtr->code[j]) );
+        int code_converted = (int) prstPtr->code[j];
+        status = _papi_hwi_native_name_to_code( tmpEvent, &code_converted );
         if( PAPI_OK != status ) {
             PAPIERROR("Failed to get code for native event %s used in derived event %s\n",
                       tmpEvent, prstPtr->symbol);
@@ -735,7 +670,7 @@ overwrite_qualifiers(hwi_presets_t *prstPtr, const char *in, int is_preset) {
     while( qualName != NULL ) {
         size_t qualLen = 1+strlen(qualDelim)+strlen(qualName);
         int status = snprintf(providedQuals[k], qualLen, "%s%s", qualDelim, qualName);
-        if( status < 0 || status >= qualLen ) {
+        if( status < 0 || (size_t) status >= qualLen ) {
             PAPIERROR("Failed to make copy of qualifier %s", qualName);
             ret = PAPI_ENOMEM;
             goto done;
@@ -822,9 +757,9 @@ get_first_cmp_preset_idx( void ) {
 
 /* Return index of component containing preset with given index. */
 int
-get_preset_cmp( unsigned int *index ) {
+get_preset_cmp( int *index ) {
 
-    unsigned int sum = 0;
+    int sum = 0;
     if(pe_disabled) {
         sum += PAPI_MAX_PRESET_EVENTS;
         if(*index < sum) {
@@ -848,8 +783,8 @@ get_preset_cmp( unsigned int *index ) {
 /* Return a pointer to preset which has given event code. */
 hwi_presets_t*
 get_preset( int event_code ) {
-    unsigned int preset_index = ( event_code & PAPI_PRESET_AND_MASK );
-    hwi_presets_t *_papi_hwi_list = NULL;
+    int preset_index = ( event_code & PAPI_PRESET_AND_MASK );
+    hwi_presets_t *_papi_hwi_list;
 
     int i = get_preset_cmp(&preset_index);
     if( i == PAPI_EINVAL ) {
@@ -2230,7 +2165,7 @@ _papi_hwi_init_global( int PE_OR_PEU )
 int
 _papi_hwi_init_global_presets( void )
 {
-    int retval = PAPI_OK, is_pe, i = 0;
+    int retval = PAPI_OK, i = 0;
 
     /* Determine whether or not perf_event is available. */
     while ( _papi_hwd[i] ) {
@@ -2247,10 +2182,7 @@ _papi_hwi_init_global_presets( void )
 
     i = 0;
     while ( _papi_hwd[i] ) {
-        is_pe = 0;
-        if (strcmp(_papi_hwd[i]->cmp_info.name, "perf_event") == 0) {
-            is_pe = 1;
-        } else {
+        if (strcmp(_papi_hwd[i]->cmp_info.name, "perf_event") != 0) {
             /* Only set the first non-perf_event component with presets once. */
             if ( -1 == first_comp_with_presets && _papi_hwi_max_presets[i] > 0 ) {
                 first_comp_with_presets = i;
@@ -2900,7 +2832,7 @@ _papi_hwi_native_name_to_code( const char *in, int *out )
 		// Make sure it is big enough
 		char name[PAPI_HUGE_STR_LEN];
 
-		int i = 0;
+		unsigned int i = 0;
 		retval = _papi_hwd[cidx]->ntv_enum_events( &i, PAPI_ENUM_FIRST );
 		if (retval != PAPI_OK) {
 			free (full_event_name);

--- a/src/papi_internal.h
+++ b/src/papi_internal.h
@@ -528,7 +528,7 @@ int _papi_hwi_get_dev_attr(void *handle, int id, PAPI_dev_attr_e attr, void *val
 int construct_qualified_event(hwi_presets_t *prstPtr);
 int overwrite_qualifiers(hwi_presets_t *prstPtr, const char *in, int is_preset);
 int get_first_cmp_preset_idx( void );
-int get_preset_cmp( unsigned int *index );
+int get_preset_cmp( int *index );
 hwi_presets_t* get_preset( int event_code );
 
 #endif /* PAPI_INTERNAL_H */

--- a/src/papi_preset.c
+++ b/src/papi_preset.c
@@ -120,7 +120,6 @@ int
 _papi_hwi_cleanup_all_presets( void )
 {
     int preset_index,cidx;
-    unsigned int j;
     hwi_presets_t *_papi_hwi_list;
 
     for(cidx=0;cidx<papi_num_components;cidx++) {
@@ -137,12 +136,14 @@ _papi_hwi_cleanup_all_presets( void )
            _papi_hwi_list[preset_index].note = NULL;
         }
         /* Free the event names used to define the preset. */
-        for(j=0; j<_papi_hwi_list[preset_index].count;j++) {
-           free(_papi_hwi_list[preset_index].name[j]);
-           free(_papi_hwi_list[preset_index].base_name[j]);
-           free(_papi_hwi_list[preset_index].default_name[j]);
+        unsigned int i;
+        for(i=0; i<_papi_hwi_list[preset_index].count;i++) {
+           free(_papi_hwi_list[preset_index].name[i]);
+           free(_papi_hwi_list[preset_index].base_name[i]);
+           free(_papi_hwi_list[preset_index].default_name[i]);
         }
         /* Free the qualifier names and descriptions. */
+        int j;
         for(j=0; j<_papi_hwi_list[preset_index].num_quals;j++) {
            free(_papi_hwi_list[preset_index].quals[j]);
            free(_papi_hwi_list[preset_index].quals_descrs[j]);
@@ -1431,7 +1432,6 @@ papi_load_derived_events_component (char *comp_str, char *arch_str, int cidx) {
 			}
 
 			if (strcasecmp(t, arch_name) == 0) {
-				int type;
 
                 breakAfter = 1;
 
@@ -1549,7 +1549,7 @@ papi_load_derived_events_component (char *comp_str, char *arch_str, int cidx) {
 				// this also clears any values left over from a previous call
 				_papi_hwi_set_papi_event_code(-1, -1);
 
-                unsigned int eventCode;
+                int eventCode;
                 char *tmpEvent, *tmpQuals;
                 char *qualDelim = ":";
                 PAPI_event_info_t eventInfo;
@@ -1591,7 +1591,7 @@ papi_load_derived_events_component (char *comp_str, char *arch_str, int cidx) {
                         prstPtr->quals[prstPtr->num_quals] = (char*)malloc(qualLen*sizeof(char));
                         if( NULL != prstPtr->quals[prstPtr->num_quals] ) {
                             status = snprintf(prstPtr->quals[prstPtr->num_quals], qualLen, "%s%s", qualDelim, qualPtr);
-                            if( status < 0 || status >= qualLen ) {
+                            if( status < 0 || (size_t) status >= qualLen ) {
                                 invalid_event = 1;
                                 PAPIERROR("Failed to store qualifier for native event %s,",
                                           " used in derived event %s",
@@ -1620,7 +1620,7 @@ papi_load_derived_events_component (char *comp_str, char *arch_str, int cidx) {
                         prstPtr->quals_descrs[count] = (char*)malloc(descLen*sizeof(char));
                         if( NULL != prstPtr->quals_descrs[count] ) {
                             status = snprintf(prstPtr->quals_descrs[count], descLen, "%s", descPtr);
-                            if( status < 0 || status >= descLen ) {
+                            if( status < 0 || (size_t) status >= descLen ) {
                                 invalid_event = 1;
                                 PAPIERROR("Failed to store qualifier description for native event %s,",
                                           " used in derived event %s",

--- a/src/utils/papi_hardware_avail.c
+++ b/src/utils/papi_hardware_avail.c
@@ -197,7 +197,7 @@ main( int argc, char **argv )
 #define MAX_NUMA_NODES  (16)
 #define MAX_CPU_THREADS (512)
                 unsigned int j;
-                unsigned int affinity[MAX_CPU_THREADS];
+                int affinity[MAX_CPU_THREADS];
                 unsigned int numa_threads_count[MAX_NUMA_NODES] = { 0 };
                 unsigned int numa_threads[MAX_NUMA_NODES][MAX_CPU_THREADS];
                 for (j = 0; j < threads; ++j) {

--- a/src/validation_tests/load_store_testcode.c
+++ b/src/validation_tests/load_store_testcode.c
@@ -24,6 +24,7 @@ int execute_stores(int n) {
 	return 0;
 
 #endif
+	(void) n;
 	return CODE_UNIMPLEMENTED;
 
 }
@@ -52,6 +53,7 @@ int execute_loads(int n) {
 	return 0;
 
 #endif
+	(void) n;
 	return CODE_UNIMPLEMENTED;
 
 }


### PR DESCRIPTION
## Pull Request Description
This pull request resolves compilation warnings that are encountered with the following configure on Methane at ICL:
```
./configure --prefix=$PWD/test-install  --enable-warnings
```

Note: There still will exist a singular compilation warning that involves avail.F and fmultiplex2.F. I believe the solution to resolve these compilation warnings deserves a separate PR.

## Testing

Testing was done on Methane at ICL, the following were the results:

- PAPI build: ✅ 
- PAPI utilities*: ✅ (matches master branch)
- perf_event component tests: ✅  (matches master branch)
- perf_event_uncore component tests: ✅ (matches master branch)
- sysdetect component tests: ✅ (matches master branch)

__*__ - Utilities ran include `papi_avail`, `papi_native_avail`, `papi_command_line`, `papi_hardware_avail`



## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
