### PR TITLE
cuda: Allow for compilation of cuda toolkit 13.1.1

### DIFF
--- a/src/components/cuda/cupti_event_and_metric.c
+++ b/src/components/cuda/cupti_event_and_metric.c
@@ -1,4 +1,5 @@
 #include <dlfcn.h>
+#include <stdbool.h>
 
 #include "papi.h"
 #include "papi_debug.h"

--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -7,6 +7,7 @@
  */
 
 #include <dlfcn.h>
+#include <stdbool.h>
 #include <papi.h>
 #include "papi_memory.h"
 


### PR DESCRIPTION
## Pull Request Description
Compiling the cuda component on Gilgamesh at Oregon with Cuda Toolkit 13.1.1 will result in the following compilation error:
```
In file included from components/cuda/cupti_event_and_metric.c:15:
/packages/cuda/13.1.1/extras/CUPTI/include/cupti_profiler_target.h:558:5: error: unknown type name ‘bool’
     bool bAllowDeviceLevelCounters;                      //!< [in] if true, device level counters are included in the counter availability image
```

This PR resolves this behavior by including `stdbool.h` in `cupti_profiler.c` and `cupti_event_and_metric.c`.

## Testing

Testing was done on Gilgamesh at Oregon with Cuda Toolkit 13.1.1:

- Compilation: ✅ 
- PAPI Utilities*: ✅ 
- Cuda component tests: ✅ 

__*__ - `papi_component_avail`, `papi_command_line`, `papi_native_avail`

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
