### PR TITLE
framework: update maint/genpapifdef.pl to add remaining define's in papiStdEventDefs.h

### DIFF
--- a/src/maint/genpapifdef.pl
+++ b/src/maint/genpapifdef.pl
@@ -367,7 +367,7 @@ sub write_presets_defs_fort {
     printf STDOUT "C PAPI preset defines\n";
     printf STDOUT "C\n\n";
 
-    foreach my $key (keys %presets_defs) {
+    foreach my $key (sort keys %presets_defs) {
         printf STDOUT "#define %-18s %s\n", $key, $papi_presets_defs{$key};
     }
 }
@@ -380,7 +380,7 @@ sub write_presets_defs_f77 {
     printf STDOUT "! PAPI preset defines\n";
     printf STDOUT "!\n\n";
 
-    foreach my $key (keys %presets_defs) {
+    foreach my $key (sort keys %presets_defs) {
         printf STDOUT "INTEGER %-18s\nPARAMETER(%s=%s)\n", $key, $key, $papi_presets_defs{$key};
     }
 }
@@ -393,7 +393,7 @@ sub write_presets_defs_f90 {
     printf STDOUT "! PAPI preset defines\n";
     printf STDOUT "!\n\n";
 
-    foreach my $key (keys %presets_defs) {
+    foreach my $key (sort keys %presets_defs) {
         printf STDOUT "INTEGER, PARAMETER :: %-18s = %s\n", $key, $papi_presets_defs{$key};
     }
 }


### PR DESCRIPTION
## Pull Request Description
Currently in the master branch, if you configure with the flag `--enable-warnings` you will see the following compilation warnings:
```
avail.F:55:132:

   55 |       do i=0, PAPI_MAX_PRESET_EVENTS-1
      |                                                                                                                                    ^
Warning: ‘papi_max_preset_events’ is used uninitialized [-Wuninitialized]
gcc -Wall -Wextra  -DPAPI_NUM_COMP=3 -O2  -o papi_multiplex_cost papi_multiplex_cost.o cost_utils.o ../libpapi.a -lm 
gfortran -I../testlib -I. -I.. -Wall -Wextra  -DPAPI_NUM_COMP=3 -ffixed-line-length-132 -O1 openmp.F ../testlib/libtestlib.a ../libpapi.a -o openmp  -fopenmp
fmultiplex2.F:85:41:

   85 |          do while ((avail_flag.EQ.0).AND.
      |                                         ^
Warning: ‘papi_max_preset_events’ is used uninitialized [-Wuninitialized]
```

This is due to the following `#define`'s not being accounted for when creating the fortran header files:
```
#define PAPI_PRESET_MASK     ((int)0x80000000)
#define PAPI_NATIVE_MASK     ((int)0x40000000)
#define PAPI_UE_MASK		 ((int)0xC0000000)
#define PAPI_PRESET_AND_MASK 0x7FFFFFFF
#define PAPI_NATIVE_AND_MASK 0xBFFFFFFF	/* this masks just the native bit */
#define PAPI_UE_AND_MASK     0x3FFFFFFF

#define PAPI_MAX_PRESET_EVENTS 128		/*The maxmimum number of preset events */
#define PAPI_MAX_USER_EVENTS 50			/*The maxmimum number of user defined events */
#define USER_EVENT_OPERATION_LEN 512	/*The maximum length of the operation string for user defined events */
```


Along with the above compilation warning's, if you attempt to run `avail.F` or `fmultiplex2.F` they will not run properly:
```
./[ICL:methane ftests]$ ./avail 
 Hardware information and available events
 -----------------------------------------------------------------------------
 Vendor string and code   : GenuineIntel (           1 )
 Model string and code    : Intel(R) Xeon(R) Gold 6140 CPU @ 2.30GHz (          85 )
 CPU revision             :    4.00000000    
 CPU Megahertz            :    3700.00000    
 CPUs in an SMP node      :           36
 Nodes in the system      :            2
 Total CPUs in the system :           72
 -----------------------------------------------------------------------------
    Name        Code    Avail Deriv              Description                        (note)
 -----------------------------------------------------------------------------
avail.F                                  PASSED
[ICL:methane ftests]$ ./fmultiplex2 
multiplex2: Using *** iterations
 case1: Does PAPI_multiplex_init() handle lots of events?
 Checking for available events...
fmultiplex2.F                            SKIPPED
 Line #          98
 SGI requires root permissions for this test
```

This PR updates `maint/genpapifdef.pl` to account for the aforementioned missing `#define`'s.

## Testing

This pull request was tested on Methane at ICL

- PAPI compilation: ✅ (compilation warnings now do not exist)
- avail.F: ✅ (outputs presets)
- fmultiplex2.F: ✅ (passes)
- PAPI utilities*: ✅ 

__*__ - `papi_component_avail`, `papi_native_avail`, `papi_command_line`


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
