### PR TITLE
cuda: Allow for and restrict use of Cuda Toolkits to >= 11.4.

### DIFF
--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -2948,7 +2948,9 @@ static int create_raw_metric_requests(NVPW_MetricsEvaluator *pMetricsEvaluator, 
     getMetricRawDependenciesParams.metricEvalRequestStructSize = NVPW_MetricEvalRequest_STRUCT_SIZE;
     getMetricRawDependenciesParams.metricEvalRequestStrideSize = sizeof(NVPW_MetricEvalRequest);
     getMetricRawDependenciesParams.ppRawDependencies = NULL;
+    #if CUDA_VERSION >= 11050
     getMetricRawDependenciesParams.ppOptionalRawDependencies = NULL;
+    #endif
     getMetricRawDependenciesParams.pPriv = NULL;
     nvpwCheckErrors( NVPW_MetricsEvaluator_GetMetricRawDependenciesPtr(&getMetricRawDependenciesParams), return PAPI_EMISC );
 


### PR DESCRIPTION
## Pull Request Description
In the master branch, the `cuda` component supports down to Cuda Toolkit 11.5; however, support can go down even further to Cuda Toolkit 11.3 when the MetricsEvaluator API was initially introduced. 

This PR adds support for Cuda Toolkit >= 11.3.

## Testing

### Setup
Testing was done on Athena at Oregon, with the following setup:
- OS: RHEL 8.9
- CPU: AMD EPYC 7662
- GPUs: 4 * A100
- Cuda Toolkits 11.3, 11.4, and 12.8.1

### Results
- PAPI compilation: ✅ (with Cuda Toolkits 11.3, 11.4, and 12.8.1)
- PAPI utilities*: ✅

__*__ - `papi_component_avail`, `papi_native_avail`, and `papi_command_line`.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
