### PR TITLE
ROCP_SDK: Enable multi-GPU functionality.

### DIFF
--- a/src/components/rocp_sdk/sdk_class.cpp
+++ b/src/components/rocp_sdk/sdk_class.cpp
@@ -411,11 +411,13 @@ record_callback(rocprofiler_dispatch_counting_service_data_t dispatch_data,
                 continue;
             }
             event_instance_info_t e_inst = e_tmp->second;
+            uint32_t e_id_32 = static_cast<uint32_t>(e_inst.counter_info.id.handle);
 
             for(int i=0; i<record_count; ++i){
                 rec_info_t &rec_info = event_set_to_rec_mapping[i];
+                uint32_t r_id_32 = static_cast<uint32_t>(rec_info.counter_id.handle);
                 if( ( e_inst.device != rec_info.device ) ||
-                    ( e_inst.counter_info.id.handle != rec_info.counter_id.handle ) ||
+                    ( e_id_32 != r_id_32 ) ||
                     !dimensions_match(e_inst.dim_instances, rec_info.recorded_dims)
                   ){
                     continue;
@@ -742,11 +744,13 @@ read_sample(){
                 continue;
             }
             event_instance_info_t e_inst = tmp->second;
+            uint32_t e_id_32 = static_cast<uint32_t>(e_inst.counter_info.id.handle);
 
             for(int i=0; i<rec_count; ++i){
                 rec_info_t &rec_info = event_set_to_rec_mapping[i];
+                uint32_t r_id_32 = static_cast<uint32_t>(rec_info.counter_id.handle);
                 if( ( e_inst.device != rec_info.device ) ||
-                    ( e_inst.counter_info.id.handle != rec_info.counter_id.handle ) ||
+                    ( e_id_32 != r_id_32 ) ||
                     !dimensions_match(e_inst.dim_instances, rec_info.recorded_dims)
                   ){
                     continue;


### PR DESCRIPTION
ROCm-7.2 encodes the device_id in the upper 32 bits of the counter id, so this comparison would fail for all GPUs except zero. Masking off the device_id by comparing only the lower 32 bits solves the problem.
Earlier versions of ROCm do not have this behavior, so the problem does not appear, and it will also be removed from future versions. This fix addresses a narrow range of versions for which this problem is present.

## Pull Request Description


## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
