### PR TITLE
nvml: Update getDeviceFieldValue to check value of nvmlReturn and use correct valueType

### DIFF
--- a/src/components/nvml/linux-nvml.c
+++ b/src/components/nvml/linux-nvml.c
@@ -346,7 +346,57 @@ getDeviceFieldValue(nvmlDevice_t dev, int value_count, nvmlFieldValue_t* field_v
         SUBDBG("something went wrong %s\n", (*nvmlErrorStringPtr)(bad));
         return (unsigned long long) - 1;
     }
-    return field_value->value.ullVal;
+
+    if (NVML_SUCCESS != field_value->nvmlReturn) {
+        SUBDBG("Failed to obtain value for fieldId %d: %s\n",
+               field_value->fieldId, (*nvmlErrorStringPtr) (field_value->nvmlReturn));
+        return (unsigned long long) - 1;
+    }
+
+    unsigned long long counter_value = 0;
+    switch(field_value->valueType) {
+        case NVML_VALUE_TYPE_DOUBLE:
+            if (field_value->value.dVal >= 0.0) {
+                counter_value = (unsigned long long) field_value->value.dVal;
+            }
+            else {
+                SUBDBG("Detected negative value for NVML_VALUE_TYPE_DOUBLE clamping at zero.\n");
+            }
+            break;
+        case NVML_VALUE_TYPE_UNSIGNED_INT:
+            counter_value = (unsigned long long) field_value->value.uiVal;
+            break;
+        case NVML_VALUE_TYPE_UNSIGNED_LONG:
+            counter_value = (unsigned long long) field_value->value.ulVal;
+            break;
+        case NVML_VALUE_TYPE_UNSIGNED_LONG_LONG:
+            counter_value = field_value->value.ullVal;
+            break;
+        case NVML_VALUE_TYPE_SIGNED_LONG_LONG:
+            if (field_value->value.sllVal >= 0) {
+                counter_value = (unsigned long long) field_value->value.sllVal;
+            }
+            else {
+                SUBDBG("Detected negative value for NVML_VALUE_TYPE_SIGNED_LONG_LONG clamping at zero.\n");
+            }
+            break;
+        case NVML_VALUE_TYPE_SIGNED_INT:
+            if (field_value->value.siVal >= 0) {
+                counter_value = (unsigned long long) field_value->value.siVal;
+            }
+            else {
+                SUBDBG("Detected negative value for NVML_VALUE_TYPE_SIGNED_INT clamping at zero.\n");
+            }
+            break;
+        case NVML_VALUE_TYPE_UNSIGNED_SHORT:
+            counter_value = (unsigned long long) field_value->value.usVal;
+            break;
+        default:
+            SUBDBG("Unsupported valueType %d for fieldId %d\n", field_value->valueType, field_value->fieldId);
+            counter_value = (unsigned long long) - 1;
+    }
+
+    return counter_value;
 }
 
 unsigned long long


### PR DESCRIPTION
## Pull Request Description
This PR updates the function `getDeviceFieldValue` to:

1. Properly check the value of the member variable `nvmlReturn` as it must be checked before looking at `value` as `value` is undefined if `nvmlReturn != NVML_SUCCESS`.
2.  Account for the different `valueType` as there are multiple:
```
NVML_VALUE_TYPE_DOUBLE = 0
NVML_VALUE_TYPE_UNSIGNED_INT = 1
NVML_VALUE_TYPE_UNSIGNED_LONG = 2
NVML_VALUE_TYPE_UNSIGNED_LONG_LONG = 3
NVML_VALUE_TYPE_SIGNED_LONG_LONG = 4
NVML_VALUE_TYPE_SIGNED_INT = 5
NVML_VALUE_TYPE_UNSIGNED_SHORT = 6
```

Due to not checking the `valueType` there were cases when extremely large numbers would output for `nvml:::NVIDIA_A100-PCIE-40GB:device_0:gpu_inst_power`:
```
[ICL:methane bin]$ ./papi_command_line nvml:::NVIDIA_A100-PCIE-40GB:device_0:gpu_inst_power

This utility lets you add events from the command line interface to see if they work.

Successfully added: nvml:::NVIDIA_A100-PCIE-40GB:device_0:gpu_inst_power

nvml:::NVIDIA_A100-PCIE-40GB:device_0:gpu_inst_power : 	4991201436214789335 mW
```

## Testing

### Setup

Testing was done on Methane at ICL with:
- OS: RHEL 9.6
- CPU: Intel Xeon Gold 6140
- GPU: 1 * A100
- Cuda Toolkit: 12.9

### Results
- PAPI build: ✅ 
- PAPI utilities*: ✅ 
```
# Sanity checking nvml:::NVIDIA_A100-PCIE-40GB:device_0:gpu_inst_power via 
# papi_command_line did not show an extremely large value after 10 runs:

[ICL:methane bin]$ ./papi_command_line nvml:::NVIDIA_A100-PCIE-40GB:device_0:gpu_inst_power

This utility lets you add events from the command line interface to see if they work.

Successfully added: nvml:::NVIDIA_A100-PCIE-40GB:device_0:gpu_inst_power

nvml:::NVIDIA_A100-PCIE-40GB:device_0:gpu_inst_power : 	33925 mW

```
- `nvml` HelloWorld.cu test: ✅ 

__*__ - `papi_component_avail`, `papi_native_avail`, and `papi_command_line`


## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
