### PR TITLE
nvml: internal vendor api reproducer for get device field

### DIFF
--- a/src/components/nvml/nvml_vendor_api_reproducers_internal/Makefile
+++ b/src/components/nvml/nvml_vendor_api_reproducers_internal/Makefile
@@ -1,0 +1,18 @@
+# Set CUDA_HOME only if it is not set already
+CUDA_HOME ?= /usr/local/cuda
+# Define includes needed for vendor reproducers
+NVML_VENDOR_REPRODUCERS_INCLUDES += -I$(CUDA_HOME)/include
+# Define libraries needed for vendor reproducers
+NVML_VENDOR_REPRODUCERS_LIBS += -L$(CUDA_HOME)/lib64 -lnvidia-ml
+# Define flags needed for vendor reproducers
+NVML_VENDOR_REPRODUCER_FLAGS += -Wno-deprecated-gpu-targets
+# Define the path to the NVIDIA CUDA Compiler
+nvcc_nvml_vendor_reproducers := $(CUDA_HOME)/bin/nvcc
+
+nvml_vendor_reproducers := nvml_get_device_field_vendor_reproducer
+nvml_vendor_reproducers_all: $(nvml_vendor_reproducers)
+
+nvml_get_device_field_vendor_reproducer: nvml_get_device_field_vendor_reproducer.cu
+	$(nvcc_nvml_vendor_reproducers) $(NVML_VENDOR_REPRODUCER_FLAGS) $(NVML_VENDOR_REPRODUCERS_INCLUDES) nvml_get_device_field_vendor_reproducer.cu -o nvml_get_device_field_vendor_reproducer $(NVML_VENDOR_REPRODUCERS_LIBS)
+clean:
+	rm -rf $(nvml_vendor_reproducers)

--- a/src/components/nvml/nvml_vendor_api_reproducers_internal/README.md
+++ b/src/components/nvml/nvml_vendor_api_reproducers_internal/README.md
@@ -1,0 +1,7 @@
+# Vendor Reproducers for the `nvml` Component
+The `Makefile` and subsequent source files are designed to only be used by the PAPI team.
+They serve as a starting point **IF** a reproducer needs to be created for the `nvml` component
+using **ONLY** NVIDIA Management Library code.
+
+# Required Cuda Toolkit Version
+For successful compilation a Cuda Toolkit >= 12.6.3 is needed.

--- a/src/components/nvml/nvml_vendor_api_reproducers_internal/nvml_get_device_field_vendor_reproducer.cu
+++ b/src/components/nvml/nvml_vendor_api_reproducers_internal/nvml_get_device_field_vendor_reproducer.cu
@@ -1,0 +1,97 @@
+/**
+ * @file nvml_get_device_field_vendor_reproducer.cu
+ *
+ * @brief This vendor sample code will get the values for the fieldId NVML_FI_DEV_POWER_INSTANT
+ *        and the scopeId NVML_POWER_SCOPE_GPU for each GPU detected on the machine.
+ * 
+ *        This file also can serves as a starting point as a reproducer if a bug report needs to be
+ *        sent to NVIDIA for the nvml component.
+ *
+ *        Tested on:
+ *        - Methane at ICL - 1 * A100 
+ *        - Athena at Oregon - 4 * A100
+ */
+
+// C library headers
+#include <stdio.h>
+
+// Cuda Toolkit headers
+#include <nvml.h>
+
+int main()
+{
+    nvmlReturn_t status = nvmlInit();
+    if (status != NVML_SUCCESS) {
+        printf("nvmlInit error %d: %s\n", status, nvmlErrorString(status));
+        return status;
+    }
+
+    unsigned int device_count = 0;
+    status = nvmlDeviceGetCount(&device_count);
+    if (status != NVML_SUCCESS) {
+        printf("nvmlDeviceGetCount error %d: %s\n", status, nvmlErrorString(status));
+        return status;
+    }
+
+    for (unsigned int device_index = 0; device_index < device_count; device_index++) {
+
+        nvmlDevice_t device;
+        status = nvmlDeviceGetHandleByIndex(device_index, &device);
+        if (status != NVML_SUCCESS) {
+            printf("For device index %u nvmlDeviceGetHandleByIndex error %d: %s - continuing to next device if applicable\n", device_index, status, nvmlErrorString(status));
+            continue;
+        }
+
+        int value_count = 1;
+        nvmlFieldValue_t field_value[value_count];
+        field_value->fieldId = NVML_FI_DEV_POWER_INSTANT;
+        field_value->scopeId = NVML_POWER_SCOPE_GPU;
+
+        status = nvmlDeviceGetFieldValues(device, value_count, field_value);
+        if (status != NVML_SUCCESS) {
+            printf("For device index %u nvmlDeviceGetFieldValues error %d: %s - continuing to next device if applicable\n", device_index, status, nvmlErrorString(status));
+            continue;
+        }
+
+        if (field_value->nvmlReturn != NVML_SUCCESS) {
+            printf("For device index %u failed to obtain value for fieldId %d: %s - continuing to next device if applicable\n",
+                   device_index, field_value->fieldId, nvmlErrorString(field_value->nvmlReturn));
+            continue;
+        }
+
+        switch(field_value->valueType) {
+            case NVML_VALUE_TYPE_DOUBLE:
+                printf("Power for device index %d is %f\n", device_index, field_value->value.dVal);
+                break;
+            case NVML_VALUE_TYPE_UNSIGNED_INT:
+                printf("Power for device index %d is %u\n", device_index, field_value->value.uiVal);
+                break;
+            case NVML_VALUE_TYPE_UNSIGNED_LONG:
+                printf("Power for device index %d is %lu\n", device_index, field_value->value.ulVal);
+                break;
+            case NVML_VALUE_TYPE_UNSIGNED_LONG_LONG:
+                printf("Power for device index %d is %llu\n", device_index, field_value->value.ullVal);
+                break;
+            case NVML_VALUE_TYPE_SIGNED_LONG_LONG:
+                printf("Power for device index %d is %lld\n", device_index, field_value->value.sllVal);
+                break;
+            case NVML_VALUE_TYPE_SIGNED_INT:
+                printf("Power for device index %d is %d\n", device_index, field_value->value.siVal);
+                break;
+            case NVML_VALUE_TYPE_UNSIGNED_SHORT:
+                printf("Power for device index %d is %hu\n", device_index, field_value->value.usVal);
+                break;
+            default:
+                printf("valueType is not recognized.\n");
+                break;
+        }
+    }
+
+    status = nvmlShutdown();
+    if (status != NVML_SUCCESS) {
+        printf("nvmlShutdown error %d: %s\n", status, nvmlErrorString(status));
+        return status;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Pull Request Description
During a PICL meeting it was discussed to add vendor api reproducers we have created. Therefore, this PR adds a vendor api reproducer for get device field.

## Testing
I tested this reproducer on Methane at ICL (1 * A100) and Athena at Oregon (4 * A100).


## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
