### PR TITLE
genpapifdef: Resolve install conflict between i686 and x86_64 papi-de…

### DIFF
--- a/src/maint/genpapifdef.pl
+++ b/src/maint/genpapifdef.pl
@@ -225,7 +225,7 @@ sub write_defs_fort {
     printf STDOUT "C General purpose defines\n";
     printf STDOUT "C\n\n";
 
-    foreach my $key (keys %defs) {
+    foreach my $key (sort keys %defs) {
         # skip unneeded definition
         if ($key =~ /PAPI_MH_/ || $key =~ /PAPI_PRESET_/ || $key =~ /PAPI_DEF_ITIMER/) { next; }
         printf STDOUT "#define %-18s %s\n", $key, ($papi_defs{$key} == 0x80000000) ? "((-2147483647) - 1)" : $papi_defs{$key};
@@ -248,7 +248,7 @@ sub write_defs_f77 {
     printf STDOUT "! General purpose defines\n";
     printf STDOUT "!\n\n";
 
-    foreach my $key (keys %defs) {
+    foreach my $key (sort keys %defs) {
         # skip unneeded definition
         if ($key =~ /PAPI_MH_/ || $key =~ /PAPI_PRESET_/ || $key =~ /PAPI_DEF_ITIMER/) { next; }
         printf STDOUT "INTEGER %-18s\nPARAMETER(%s=%s)\n", $key, $key, ($papi_defs{$key} == 0x80000000) ? "((-2147483647) - 1)" : $papi_defs{$key};
@@ -271,7 +271,7 @@ sub write_defs_f90 {
     printf STDOUT "! General purpose defines\n";
     printf STDOUT "!\n\n";
 
-    foreach my $key (keys %defs) {
+    foreach my $key (sort keys %defs) {
         # skip unneeded definition
         if ($key =~ /PAPI_MH_/ || $key =~ /PAPI_PRESET_/ || $key =~ /PAPI_DEF_ITIMER/) { next; }
         printf STDOUT "INTEGER, PARAMETER :: %-18s = %s\n", $key, ($papi_defs{$key} == 0x80000000) ? "((-2147483647) - 1)" : $papi_defs{$key};
@@ -286,7 +286,7 @@ sub write_presets_fort {
     printf STDOUT "C PAPI preset event values\n";
     printf STDOUT "C\n\n";
 
-    foreach my $key (keys %presets) {
+    foreach my $key (sort keys %presets) {
         if ($papi_presets{$key} == -2147483648) {
             printf STDOUT "#define %-18s ((-2147483647) - 1)\n", $key;
         } else {
@@ -303,7 +303,7 @@ sub write_presets_f77 {
     printf STDOUT "! PAPI preset event values\n";
     printf STDOUT "!\n\n";
 
-    foreach my $key (keys %presets) {
+    foreach my $key (sort keys %presets) {
         if ($papi_presets{$key} == -2147483648) {
             printf STDOUT "INTEGER %-18s\nPARAMETER(%s=(-2147483647) - 1)\n", $key, $key;
         } else {
@@ -320,7 +320,7 @@ sub write_presets_f90 {
     printf STDOUT "! PAPI preset event values\n";
     printf STDOUT "!\n\n";
 
-    foreach my $key (keys %presets) {
+    foreach my $key (sort keys %presets) {
         if ($papi_presets{$key} == -2147483648) {
             printf STDOUT "INTEGER, PARAMETER :: %-18s = ((-2147483647) - 1)\n", $key;
         } else {


### PR DESCRIPTION
…vel RPMs

/usr/include/f77papi.h, /usr/include/f90papi.h, /usr/include/fpapi.h are generated at build time by a perl helper script src/maint/genpapifdef.pl.

The order of the keys in the %defs and %presets hashes are not guaranteed by the perl interpreter to be identical on the i686 and x86_64 architectures. This results in a different header file being generated by the genpapifdef.pl script on each architecture.  When these files are included in a papi-devel RPM package, RPM views the files as conflicting and will not allow installation of both the i686 and x86_64 packages at the same time.

This patch sorts the keys of the %defs and %presets hashes prior to looping through them, which makes the order consistent on i686 and x86_64.  Since the order of the keys is consistent, the same header files are produced, RPM no longer views the files as conflicting, and it is possible to install both the i686 and x86_64 papi-devel packages at the same time.

Orabug: 39036654


Reviewed-by: Alex Burmashev <alexander.burmashev@oracle.com>

## Pull Request Description


## Author Checklist
- [X ] **Description**
We are shipping both i686 and x86_64s builds of papi RPMs as part of Oracle Linux.  Currently it is not possible to install papi-devel.i686 and papi-devel.x86_64 at the same time as some header files conflict:

Total download size: 5.8 M
Installed size: 20 M
Downloading Packages:
(1/10): papi-7.2.0-1.el9.x86_64.rpm             2.6 MB/s | 170 kB     00:00    
(2/10): libpfm-4.13.0-5.el9.i686.rpm            2.3 MB/s | 282 kB     00:00    
(3/10): libpfm-4.13.0-5.el9.x86_64.rpm          2.1 MB/s | 350 kB     00:00    
(4/10): papi-libs-7.2.0-1.el9.i686.rpm          5.4 MB/s | 216 kB     00:00    
(5/10): papi-devel-7.2.0-1.el9.i686.rpm         1.8 MB/s | 373 kB     00:00    
(6/10): papi-devel-7.2.0-1.el9.x86_64.rpm       2.0 MB/s | 373 kB     00:00    
(7/10): papi-libs-7.2.0-1.el9.x86_64.rpm        1.6 MB/s | 209 kB     00:00    
(8/10): libgcc-11.5.0-14.0.1.el9.i686.rpm       2.8 MB/s | 104 kB     00:00    
(9/10): glibc-2.34-245.0.1.el9.i686.rpm          10 MB/s | 1.9 MB     00:00    
(10/10): glibc-gconv-extra-2.34-245.0.1.el9.i68 8.3 MB/s | 1.8 MB     00:00    
--------------------------------------------------------------------------------
Total                                            11 MB/s | 5.8 MB     00:00     
Running transaction check
Transaction check succeeded.
Running transaction test
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'yum clean packages'.
Error: Transaction test error:
  file /usr/include/f77papi.h conflicts between attempted installs of papi-devel-7.2.0-1.el9.x86_64 and papi-devel-7.2.0-1.el9.i686
  file /usr/include/f90papi.h conflicts between attempted installs of papi-devel-7.2.0-1.el9.x86_64 and papi-devel-7.2.0-1.el9.i686
  file /usr/include/fpapi.h conflicts between attempted installs of papi-devel-7.2.0-1.el9.x86_64 and papi-devel-7.2.0-1.el9.i686

The headers conflict because the content differs due to the keys of hashes being in different order on the two architectures.

This patch sorts the hash keys before writing the headers, resulting in identical files on both architectures, and no RPM conflict.
- [X ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [X ] **Tests**
The PR needs to pass all the tests
