### PR TITLE
Make net refresh latency configurable

### DIFF
--- a/src/components/net/CHANGES
+++ b/src/components/net/CHANGES
@@ -1,5 +1,9 @@
 Net component changelog:
 
+2026-03-10 Aleksandar Janicijevic
+
+* Add support for environment variable PAPI_NET_REFRESH_LATENCY
+
 2011-11-07 Jose Pedro Oliveira
 
  * Dynamically detects the network interfaces
@@ -15,4 +19,3 @@ Net component changelog:
  * Adds support for PAPI_event_name_to_code()
 
  * Adds a couple of small tests/examples
-

--- a/src/components/net/README.md
+++ b/src/components/net/README.md
@@ -17,6 +17,14 @@ Typically, the utility `papi_components_avail` (available in
 `papi/src/utils/papi_components_avail`) will display the components available
 to the user, and whether they are disabled, and when they are disabled why.
 
+## Configuring Refresh Latency
+
+By default the net refresh latency is set to 1000000 microseconds. To update this value set
+`PAPI_NET_REFRESH_LATENCY`, i.e:
+
+    export PAPI_NET_REFRESH_LATENCY=your_value (in microseconds)
+
+
 ***
 ## FAQ
 

--- a/src/components/net/linux-net.c
+++ b/src/components/net/linux-net.c
@@ -22,6 +22,7 @@
 #include <ctype.h>
 #include <string.h>
 #include <net/if.h>
+#include <errno.h>
 
 /* Headers required by PAPI */
 #include "papi.h"
@@ -39,7 +40,7 @@ papi_vector_t _net_vector;
  ********************************************************************/
 
 /* Network stats refresh latency in usec (default: 1 sec) */
-#define NET_REFRESH_LATENCY   1000000
+static long long NET_REFRESH_LATENCY = 1000000;
 
 #define NET_PROC_FILE          "/proc/net/dev"
 
@@ -366,6 +367,24 @@ _net_init_component( int cidx  )
 
     /* Export the component id */
     _net_vector.cmp_info.CmpIdx = cidx;
+
+    /* Set the net refresh latency */
+    char *refresh_latency = getenv("PAPI_NET_REFRESH_LATENCY");
+    if (refresh_latency != NULL) {
+        char *endptr;
+        int base = 10;
+        errno = 0;
+        long long buffer_refresh = strtoll(refresh_latency, &endptr, base);
+        if (errno != 0) {
+            SUBDBG("strtoll failed with error code %d. Net refresh latency is the default (%lld).\n", errno, NET_REFRESH_LATENCY);
+        }
+        else if (*endptr != '\0' || endptr == refresh_latency) {
+            SUBDBG("PAPI_NET_REFRESH_LATENCY was not set properly. Net refresh latency is the default (%lld).\n", NET_REFRESH_LATENCY);
+        }
+        else {
+            NET_REFRESH_LATENCY = buffer_refresh;
+        }
+    }
 
   fn_exit:
     _papi_hwd[cidx]->cmp_info.disabled = retval;


### PR DESCRIPTION
## Pull Request Description


## Author Checklist
- [*] **Description**
Until now, minimum net refresh latency has been hard-coded to 1 second. This PR makes it configurable via
environment variable PAPI_NET_REFRESH_LATENCY.

- [*] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution

- [*] **Tests**
The change has been tested in AMD's [ROCm profiler](https://github.com/ROCm/rocm-systems/tree/develop/projects/rocprofiler-systems). The reason for this change is that 1 second is too long for the purpose of the profiler's automated test, which was causing the test to fail, because it was often finishing too soon, without collecting any network statistics. With this change, the minimum net refresh latency can be made shorter, letting the test pass reliably.
