### PR TITLE
Update libpfm4 to commit eeda3b

### DIFF
--- a/src/libpfm4/lib/events/intel_icl_events.h
+++ b/src/libpfm4/lib/events/intel_icl_events.h
@@ -3159,7 +3159,7 @@ static const intel_x86_entry_t intel_icl_pe[]={
   },
   { .name   = "MEM_LOAD_MISC_RETIRED",
     .desc   = "Miscellaneous loads retired",
-    .code   = 0xc4,
+    .code   = 0xd4,
     .modmsk = INTEL_V5_ATTRS,
     .cntmsk = 0xfull,
     .ngrp   = 1,


### PR DESCRIPTION

## Pull Request Description
Current with
commit 4d6a907932a2273e23ef578cda68e154c0eeda3b
Author: Stephane Eranian <eranian@gmail.com>
Date:   Wed Mar 11 20:37:01 2026 -0700

    fix Intel Icelake MEM_LOAD_MISC_RETIRED event code

    Was set to 0xc4 instead of 0xd4

    Signed-off-by: Stephane Eranian <eranian@gmail.com>

Note: This update was tested on a Intel(R) Xeon(R) Silver 4309Y CPU @ 2.80GHz. papi_component_avail, papi_native_avail, and papi_avail all function as expected. papi_command_line now shows a 0 value for MEM_LOAD_MISC_RETIRED; however, this value matches with libpfm4 tests task_cpu.c and self_count.c. Further, perf_event_system_wide, perf_event_user_kernel, and nmi_watchdog all passed, the other perf_event tests do not run as on IceLake we do not have events defined for them.


## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
