### PR TITLE
papi actions: Node.js 20 is deprecated, update actions to versions that support Node.js 24

### DIFF
--- a/.github/workflows/amd_smi_component_workflow.yml
+++ b/.github/workflows/amd_smi_component_workflow.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: [self-hosted, gpu_amd]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: amd_smi component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/appio_component_workflow.yml
+++ b/.github/workflows/appio_component_workflow.yml
@@ -23,6 +23,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: appio component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/cat_workflow.yml
+++ b/.github/workflows/cat_workflow.yml
@@ -21,6 +21,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: counter analysis toolkit tests
         run: .github/workflows_scripts/ci_cat.sh ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/coretemp_component_workflow.yml
+++ b/.github/workflows/coretemp_component_workflow.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: coretemp component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/cuda_component_workflow.yml
+++ b/.github/workflows/cuda_component_workflow.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: [self-hosted, gpu_nvidia]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: cuda component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/default_components_workflow.yml
+++ b/.github/workflows/default_components_workflow.yml
@@ -24,6 +24,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: default components tests
         run: .github/workflows_scripts/ci_default_components.sh ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/example_component_workflow.yml
+++ b/.github/workflows/example_component_workflow.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: example component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/intel_gpu_component_workflow.yml
+++ b/.github/workflows/intel_gpu_component_workflow.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: [self-hosted, gpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: intel_gpu component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/io_component_workflow.yml
+++ b/.github/workflows/io_component_workflow.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: io component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/lmsensors_component_workflow.yml
+++ b/.github/workflows/lmsensors_component_workflow.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: lmsensors component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/net_component_workflow.yml
+++ b/.github/workflows/net_component_workflow.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: net component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/nvml_component_workflow.yml
+++ b/.github/workflows/nvml_component_workflow.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: [self-hosted, gpu_nvidia]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: nvml component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/papi_framework_workflow.yml
+++ b/.github/workflows/papi_framework_workflow.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: [self-hosted, cpu_intel, gpu_nvidia]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: comprehensive component tests 
         run: .github/workflows_scripts/ci_papi_framework.sh "${{matrix.components}}" ${{matrix.debug}} ${{matrix.shlib}} ${{matrix.hardware}}
   # build PAPI only with rocp_sdk and amd_smi components, as they will not be active in the above comprehensive job
@@ -41,7 +41,7 @@ jobs:
     runs-on: [self-hosted, gpu_amd]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: rocp_sdk and amd_smi component tests
         run: .github/workflows_scripts/ci_papi_framework.sh "${{matrix.components}}" ${{matrix.debug}} ${{matrix.shlib}} ${{matrix.hardware}}
   # build PAPI only with the infiniband component, as it will not always be active in the above comrehensive job
@@ -56,24 +56,24 @@ jobs:
     runs-on: [self-hosted, infiniband]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: infiniband component tests
         run: .github/workflows_scripts/ci_papi_framework.sh ${{matrix.components}} ${{matrix.debug}} ${{matrix.shlib}} ${{matrix.hardware}}
   papi_spack:
     runs-on: cpu
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Build/Test/Install via Spack
         run: .github/workflows_scripts/spack.sh
   papi_clang_analysis:
     runs-on: cpu
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Run static analysis
         run: .github/workflows_scripts/clang_analysis.sh clang-analysis-output
       - name: Archive analysis results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: always()
         with:
           name: clang-analysis-output

--- a/.github/workflows/powercap_component_workflow.yml
+++ b/.github/workflows/powercap_component_workflow.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: powercap component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/rocm_component_workflow.yml
+++ b/.github/workflows/rocm_component_workflow.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: [self-hosted, gpu_amd]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: rocm component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/rocm_smi_component_workflow.yml
+++ b/.github/workflows/rocm_smi_component_workflow.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: [self-hosted, gpu_amd]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: rocm_smi component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/rocp_sdk_component_workflow.yml
+++ b/.github/workflows/rocp_sdk_component_workflow.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: [self-hosted, gpu_amd]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: rocp_sdk component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/sde_component_workflow.yml
+++ b/.github/workflows/sde_component_workflow.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: sde component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}

--- a/.github/workflows/stealtime_component_workflow.yml
+++ b/.github/workflows/stealtime_component_workflow.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: [self-hosted, cpu_intel]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: stealtime component tests
         run: .github/workflows_scripts/ci_individual_component.sh ${{matrix.component}} ${{matrix.debug}} ${{matrix.shlib}}


### PR DESCRIPTION
## Pull Request Description
Node20 will reach end-of-life in April of 2026 and thus has been [deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) by GitHub. Node24 will take its place.

This PR updates our workflows to use v6 of `actions/checkout` and `actions/upload-artifact` which both have support for Node24. 

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
