### PR TITLE
framework: Properly handle the case of no components configured

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -6891,8 +6891,13 @@ if test "$with_sysdetect" = "yes"; then
     fi
 fi
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $components" >&5
+if test "x$components" != "x"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $components" >&5
 $as_echo "$components" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: No components configured" >&5
+$as_echo "No components configured" >&6; }
+fi
 
 # Check whether rocm and rocp_sdk were configured together
 rocm_found=0

--- a/src/configure
+++ b/src/configure
@@ -6538,8 +6538,13 @@ if test "x$enable_sysdetect" = "xyes" && test "x$perf_events" != "xno"; then :
   components="$components sysdetect"
 fi
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $components" >&5
+if test "x$components" != "x"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $components" >&5
 $as_echo "$components" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: No components configured" >&5
+$as_echo "No components configured" >&6; }
+fi
 
 # Check whether rocm and rocp_sdk were configured together
 rocm_found=0

--- a/src/configure.in
+++ b/src/configure.in
@@ -1883,7 +1883,7 @@ if test "$with_sysdetect" = "yes"; then
     fi
 fi
 
-AC_MSG_RESULT($components)
+AS_IF([test "x$components" != "x"], [AC_MSG_RESULT($components)], [AC_MSG_RESULT(No components configured)])
 
 # Check whether rocm and rocp_sdk were configured together
 rocm_found=0

--- a/src/configure.in
+++ b/src/configure.in
@@ -1715,7 +1715,7 @@ AC_ARG_WITH([components],
 
 AS_IF([test "x$enable_sysdetect" = "xyes" && test "x$perf_events" != "xno"], [components="$components sysdetect"], [])
 
-AC_MSG_RESULT($components)
+AS_IF([test "x$components" != "x"], [AC_MSG_RESULT($components)], [AC_MSG_RESULT(No components configured)])
 
 # Check whether rocm and rocp_sdk were configured together
 rocm_found=0

--- a/src/utils/papi_component_avail.c
+++ b/src/utils/papi_component_avail.c
@@ -116,7 +116,13 @@ main( int argc, char **argv )
 	for ( cid = 0; cid < numcmp; cid++ ) {
 	  cmpinfo = PAPI_get_component_info( cid );
 
-	  printf( "Name:   %-23s %s\n", cmpinfo->name ,cmpinfo->description);
+	  if (strcasecmp(cmpinfo->name, "No Components Configured. ") != 0) {
+		printf( "Name:   %-23s %s\n", cmpinfo->name ,cmpinfo->description);
+	  }
+	  else {
+                printf( "Name:   %-23s\n", cmpinfo->name);
+                continue;
+	  }
 
 	  if (cmpinfo->disabled == PAPI_EDELAY_INIT) {
 	      force_cmp_init(cid);
@@ -144,9 +150,15 @@ main( int argc, char **argv )
 	  cmpinfo = PAPI_get_component_info( cid );
 	  if (cmpinfo->disabled) continue;
 
-	  printf( "Name:   %-23s %s\n", cmpinfo->name ,cmpinfo->description);
-	  printf( "        %-23s Native: %d, Preset: %d, Counters: %d\n",
-		  " ", cmpinfo->num_native_events, cmpinfo->num_preset_events, cmpinfo->num_cntrs);
+          if (strcasecmp(cmpinfo->name, "No Components Configured. ") != 0) {
+		printf( "Name:   %-23s %s\n", cmpinfo->name ,cmpinfo->description);
+		printf( "        %-23s Native: %d, Preset: %d, Counters: %d\n",
+			" ", cmpinfo->num_native_events, cmpinfo->num_preset_events, cmpinfo->num_cntrs);
+          }
+          else {
+                printf( "Name:   %-23s\n", cmpinfo->name);
+                continue;
+          }
 
      int pmus=0;
      for (i=0; i<PAPI_PMU_MAX; i++) {                          // Count pmus to print.

--- a/src/utils/papi_component_avail.c
+++ b/src/utils/papi_component_avail.c
@@ -116,7 +116,13 @@ main( int argc, char **argv )
 	for ( cid = 0; cid < numcmp; cid++ ) {
 	  cmpinfo = PAPI_get_component_info( cid );
 
-	  printf( "Name:   %-23s %s\n", cmpinfo->name ,cmpinfo->description);
+	  if (strcasecmp(cmpinfo->name, "No Components Configured. ") != 0) {
+	      printf( "Name:   %-23s %s\n", cmpinfo->name ,cmpinfo->description);
+	  }
+	  else {
+	      printf( "Name:   %-23s\n", cmpinfo->name);
+	      continue;
+	  }
 
 	  if (cmpinfo->disabled == PAPI_EDELAY_INIT) {
 	      force_cmp_init(cid);
@@ -147,11 +153,17 @@ main( int argc, char **argv )
 	  cmpinfo = PAPI_get_component_info( cid );
 	  if (cmpinfo->disabled) continue;
 
-	  printf( "Name:   %-23s %s\n", cmpinfo->name ,cmpinfo->description);
-	  is_utility_cmp = check_for_utility_components(cmpinfo->name);
-	  if (!is_utility_cmp) {
-		printf( "        %-23s Native: %d, Preset: %d, Counters: %d\n",
-			" ", cmpinfo->num_native_events, cmpinfo->num_preset_events, cmpinfo->num_cntrs);
+	  if (strcasecmp(cmpinfo->name, "No Components Configured. ") != 0) {
+		printf( "Name:   %-23s %s\n", cmpinfo->name ,cmpinfo->description);
+		is_utility_cmp = check_for_utility_components(cmpinfo->name);
+		if (!is_utility_cmp) {
+			printf( "        %-23s Native: %d, Preset: %d, Counters: %d\n",
+				" ", cmpinfo->num_native_events, cmpinfo->num_preset_events, cmpinfo->num_cntrs);
+		}
+	  }
+	  else {
+		printf( "Name:   %-23s\n", cmpinfo->name);
+		continue;
 	  }
 
      int pmus=0;


### PR DESCRIPTION
## Pull Request Description
In the master branch, if you configure PAPI as follows:
```
./configure --prefix=$PWD/test-install --disable-cpu
```

No components will be configured and this is indeed correct behavior. However, configure does not output anything for "checking for components to build..." and `papi_component_avail` shows `Native: 0, Preset: 0, Counters: 0`, i.e.
```
configure:

checking for components to build...

papi_component_avail:

Compiled-in components:
Name:   No Components Configured.  

Active components:
Name:   No Components Configured.  
                                Native: 0, Preset: 0, Counters: 0


--------------------------------------------------------------------------------
```

This PR updates this behavior as follows:
1. If no components are configured, configure will now output:
```
checking for components to build... No components configured
```
2. If no components are configured, papi_component_avail will output:
```
Compiled-in components:
Name:   No Components Configured. 

Active components:
Name:   No Components Configured. 

--------------------------------------------------------------------------------
```

## Testing
These changes were verified on Methane at ICL (CPU: Intel Xeon Gold 6140, OS: Rocky Linux 9.6 )

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
