### PR TITLE
rocp_sdk: honor ROCTX pause & resume

### DIFF
--- a/src/components/rocp_sdk/sdk_class.cpp
+++ b/src/components/rocp_sdk/sdk_class.cpp
@@ -57,6 +57,8 @@ static std::condition_variable agent_cond_var = {};
 static bool data_is_ready = false;
 static std::string _rocp_sdk_error_string;
 static long long int *_counter_values = NULL;
+static long long int *_counter_values_savestate = NULL;
+static int _num_events_internal = 0;
 static int rpsdk_profiling_mode = RPSDK_MODE_DEVICE_SAMPLING;
 
 static agent_map_t gpu_agents = agent_map_t{};
@@ -100,6 +102,7 @@ typedef rocprofiler_status_t (* rocprofiler_flush_buffer_t) (rocprofiler_buffer_
         rocprofiler_device_counting_service_callback_t cb, void *user_data);
 #endif
 
+typedef rocprofiler_status_t (*rocprofiler_configure_callback_tracing_service_t)(rocprofiler_context_id_t, rocprofiler_callback_tracing_kind_t kind, rocprofiler_tracing_operation_t* operations, size_t operations_count, rocprofiler_callback_tracing_cb_t callback, void* callback_args);
 
 typedef rocprofiler_status_t (* rocprofiler_create_buffer_t) (rocprofiler_context_id_t context, unsigned long size, unsigned long watermark, rocprofiler_buffer_policy_t policy, rocprofiler_buffer_tracing_cb_t callback, void *callback_data, rocprofiler_buffer_id_t *buffer_id);
 
@@ -144,6 +147,7 @@ typedef rocprofiler_status_t (* rocprofiler_query_record_dimension_position_t) (
 rocprofiler_flush_buffer_t rocprofiler_flush_buffer_FPTR;
 rocprofiler_sample_device_counting_service_t rocprofiler_sample_device_counting_service_FPTR;
 rocprofiler_configure_callback_dispatch_counting_service_t rocprofiler_configure_callback_dispatch_counting_service_FPTR;
+rocprofiler_configure_callback_tracing_service_t rocprofiler_configure_callback_tracing_service_FPTR;
 rocprofiler_configure_device_counting_service_t rocprofiler_configure_device_counting_service_FPTR;
 rocprofiler_create_buffer_t rocprofiler_create_buffer_FPTR;
 rocprofiler_create_context_t rocprofiler_create_context_FPTR;
@@ -264,6 +268,7 @@ obtain_function_pointers()
     DLL_SYM_CHECK(rocprofiler_flush_buffer, rocprofiler_flush_buffer_t);
     DLL_SYM_CHECK(rocprofiler_sample_device_counting_service, rocprofiler_sample_device_counting_service_t);
     DLL_SYM_CHECK(rocprofiler_configure_callback_dispatch_counting_service, rocprofiler_configure_callback_dispatch_counting_service_t);
+    DLL_SYM_CHECK(rocprofiler_configure_callback_tracing_service, rocprofiler_configure_callback_tracing_service_t);
     DLL_SYM_CHECK(rocprofiler_configure_device_counting_service, rocprofiler_configure_device_counting_service_t);
     DLL_SYM_CHECK(rocprofiler_create_context, rocprofiler_create_context_t);
     DLL_SYM_CHECK(rocprofiler_create_buffer, rocprofiler_create_buffer_t);
@@ -443,7 +448,7 @@ record_callback(rocprofiler_dispatch_counting_service_data_t dispatch_data,
         // PAPI semantics dictate that counter values are only reset by
         // PAPI_reset(), etc, not by kernel invocations. Therefore, we must
         // accumulate the counter values (+=), not overwrite the previous one.
-	_counter_values[ei] += counter_value_sum;
+        _counter_values[ei] += counter_value_sum;
     }
 
     _papi_hwi_unlock(_rocp_sdk_lock);
@@ -530,7 +535,39 @@ buffered_callback(rocprofiler_context_id_t,
                   void*                         user_data,
                   uint64_t)
 {
-	return;
+    return;
+}
+
+/* ** */
+// Only listen for the ROCTX Pause and Resume calls.
+void
+tool_tracing_callback(rocprofiler_callback_tracing_record_t record,
+                      rocprofiler_user_data_t*,
+                      void* client_data) {
+    rocprofiler_context_id_t *ctx = static_cast<rocprofiler_context_id_t*>(client_data);
+
+    if(record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER &&
+       record.kind == ROCPROFILER_CALLBACK_TRACING_MARKER_CONTROL_API &&
+       record.operation == ROCPROFILER_MARKER_CONTROL_API_ID_roctxProfilerPause)
+    {
+        for(int i = 0; i < _num_events_internal; ++i) {
+            _counter_values_savestate[i] = _counter_values[i];
+        }
+        ROCPROFILER_CALL(rocprofiler_stop_context_FPTR(*ctx), "pausing profiling context");
+        SUBDBG("Received ROCTX call to pause context.\n");
+        active_event_set_ctx->state = RPSDK_AES_PAUSED;
+    }
+    else if(record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT &&
+            record.kind == ROCPROFILER_CALLBACK_TRACING_MARKER_CONTROL_API &&
+            record.operation == ROCPROFILER_MARKER_CONTROL_API_ID_roctxProfilerResume)
+    {
+        ROCPROFILER_CALL(rocprofiler_start_context_FPTR(*ctx), "resuming profiling context");
+        SUBDBG("Received ROCTX call to resume context.\n");
+        active_event_set_ctx->state = RPSDK_AES_RUNNING;
+        for(int i = 0; i < _num_events_internal; ++i) {
+            _counter_values[i] = _counter_values_savestate[i];
+        }
+    }
 }
 
 /* ** */
@@ -570,6 +607,22 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
                          "Could not setup callback dispatch");
     }
 
+    // Configure tracing service.
+    rocprofiler_context_id_t _control_ctx_;
+    ROCPROFILER_CALL(rocprofiler_create_context_FPTR(&_control_ctx_), "control context creation");
+
+    ROCPROFILER_CALL(rocprofiler_configure_callback_tracing_service_FPTR(
+                         _control_ctx_,
+                         ROCPROFILER_CALLBACK_TRACING_MARKER_CONTROL_API,
+                         nullptr,
+                         0,
+                         &tool_tracing_callback,
+                         &get_client_ctx()),
+                     "Could not setup callback tracing");
+
+    // start the context so that it is always active
+    ROCPROFILER_CALL(rocprofiler_start_context_FPTR(_control_ctx_), "start control context");
+
     return 0;
 }
 
@@ -584,7 +637,7 @@ static int
 assign_id_to_event(std::string event_name, event_instance_info_t ev_inst_info){
     int papi_event_id = -1;
 
-    // Note: _global_papi_event_count is std::atomic, so the followign line is thread safe.
+    // Note: _global_papi_event_count is std::atomic, so the following line is thread safe.
     papi_event_id = _global_papi_event_count++;
     papi_id_to_event_instance[ papi_event_id ] = ev_inst_info;
     event_instance_name_to_papi_id[ event_name ] = papi_event_id;
@@ -666,6 +719,8 @@ void stop_counting(void){
         return;
     }
     ROCPROFILER_CALL(rocprofiler_stop_context_FPTR(get_client_ctx()), "stop context");
+    free(_counter_values_savestate);
+    _counter_values_savestate = NULL;
 }
 
 /* ** */
@@ -688,18 +743,22 @@ read_sample(){
     size_t rec_count = 1024;
     rocprofiler_record_counter_t output_records[1024];
 
-    if( (NULL == _counter_values) || (NULL == active_event_set_ctx) || (0 == (active_event_set_ctx->state & RPSDK_AES_RUNNING)) ){
+    if( (NULL == _counter_values) || (NULL == active_event_set_ctx) || \
+        (0 == (active_event_set_ctx->state & (RPSDK_AES_RUNNING|RPSDK_AES_PAUSED))) ){
         papi_errno = PAPI_ENOTRUN;
         goto fn_fail;
     }
 
-    ret_val = rocprofiler_sample_device_counting_service_FPTR(
+    // Only update the counters if the profiling context is running, not paused.
+    if( 0 != (active_event_set_ctx->state & RPSDK_AES_RUNNING) ){
+        ret_val = rocprofiler_sample_device_counting_service_FPTR(
                 get_client_ctx(), {}, ROCPROFILER_COUNTER_FLAG_NONE,
                 output_records, &rec_count);
 
-    if( ret_val != ROCPROFILER_STATUS_SUCCESS ){
-        papi_errno = PAPI_ECMP;
-        goto fn_fail;
+        if( ret_val != ROCPROFILER_STATUS_SUCCESS ){
+            papi_errno = PAPI_ECMP;
+            goto fn_fail;
+        }
     }
 
     // Create the mapping from events in the eventset (passed by the user) to entries (samples) in the "output_records" array.
@@ -763,13 +822,15 @@ read_sample(){
 
     // Traverse all events in the active event set and find which entry in the sample matches each one of them.
     for( int ei=0; ei<active_event_set_ctx->num_events; ei++ ){
-        double counter_value_sum = 0.0;
+        double counter_value_sum = _counter_values_savestate[ei];
 
-        for(int i=0; i<rec_count; ++i){
-            // All counters in the sample whose dimemsions match the qualifers of the event instance
-            // will be added. This means that if a qualifier is missing, we will get the sum.
-            if( true == index_mapping[ei*rec_count+i] ){
-                counter_value_sum += output_records[i].counter_value;
+        if( 0 != (active_event_set_ctx->state & RPSDK_AES_RUNNING) ){
+            for(int i=0; i<rec_count; ++i){
+                // All counters in the sample whose dimemsions match the qualifers of the event instance
+                // will be added. This means that if a qualifier is missing, we will get the sum.
+                if( true == index_mapping[ei*rec_count+i] ){
+                    counter_value_sum += output_records[i].counter_value;
+                }
             }
         }
         _counter_values[ei] = counter_value_sum;
@@ -1194,6 +1255,12 @@ rocprofiler_sdk_ctx_open(int *event_ids, int num_events, vendorp_ctx_t *ctx)
         return PAPI_ENOMEM;
     }
 
+    // Dynamically allocate and init to zero
+    size_t savestate_size = num_events*sizeof(long long);
+    papi_rocpsdk::_num_events_internal = num_events;
+    papi_rocpsdk::_counter_values_savestate = (long long *)papi_realloc(papi_rocpsdk::_counter_values_savestate, savestate_size);
+    memset(papi_rocpsdk::_counter_values_savestate, 0, savestate_size);
+
     _papi_hwi_lock(_rocp_sdk_lock);
 
     papi_rocpsdk::empty_active_event_set();
@@ -1222,6 +1289,9 @@ rocprofiler_sdk_ctx_read(vendorp_ctx_t ctx, long long **counters)
     // If the collection mode is DEVICE_SAMPLING get an explicit sample.
     if( RPSDK_MODE_DEVICE_SAMPLING == papi_rocpsdk::get_profiling_mode() ){
         papi_errno = papi_rocpsdk::read_sample();
+        if (papi_errno != PAPI_OK) {
+            return papi_errno;
+        }
     }
 
     // If the mode is not sampling the counter data should already be in

--- a/src/components/rocp_sdk/sdk_class.hpp
+++ b/src/components/rocp_sdk/sdk_class.hpp
@@ -115,6 +115,7 @@ do {                                                               \
 #define RPSDK_AES_STOPPED (0x0)
 #define RPSDK_AES_OPEN    (0x1)
 #define RPSDK_AES_RUNNING (0x2)
+#define RPSDK_AES_PAUSED  (0x4)
 
 typedef struct {
     char name[PAPI_MAX_STR_LEN];

--- a/src/components/rocp_sdk/tests/Makefile
+++ b/src/components/rocp_sdk/tests/Makefile
@@ -3,7 +3,8 @@ include ../../Makefile_comp_tests.target
 
 ROCP_SDK_INCL=-I$(PAPI_ROCP_SDK_ROOT)/include     \
               -I$(PAPI_ROCP_SDK_ROOT)/include/hsa \
-              -I$(PAPI_ROCP_SDK_ROOT)/hsa/include
+              -I$(PAPI_ROCP_SDK_ROOT)/hsa/include \
+			  -I$(PAPI_ROCP_SDK_ROOT)/include/rocprofiler-sdk
 
 # If ROCprofiler_SDK is installed at a different
 # path than the rest of ROCm, then the path to
@@ -11,13 +12,16 @@ ROCP_SDK_INCL=-I$(PAPI_ROCP_SDK_ROOT)/include     \
 ifneq ($(PAPI_ROCM_ROOT),)
 ROCP_SDK_INCL+=-I$(PAPI_ROCM_ROOT)/include     \
               -I$(PAPI_ROCM_ROOT)/include/hsa \
-              -I$(PAPI_ROCM_ROOT)/hsa/include
+              -I$(PAPI_ROCM_ROOT)/hsa/include \
+              -I$(PAPI_ROCM_ROOT)/include/rocprofiler-sdk
 endif
 
 AMDCXX   ?= amdclang++
 CFLAGS    = $(OPTFLAGS)
-CPPFLAGS += $(INCLUDE) $(ROCP_SDK_INCL)
+INCFLAGS += $(INCLUDE) $(ROCP_SDK_INCL)
+CPPFLAGS += $(INCFLAGS)
 LDFLAGS  += $(PAPILIB) $(TESTLIB) $(UTILOBJS)
+LDFLAGS  += -L$(PAPI_ROCP_SDK_ROOT)/lib -lrocprofiler-sdk-roctx
 
 GPUARCH = $(shell rocm_agent_enumerator 2>/dev/null | grep -v "gfx000" | head -1)
 ifneq ($(GPUARCH),)
@@ -25,14 +29,14 @@ ifneq ($(GPUARCH),)
 endif
 GPUFLAGS=$(ARCHFLAG) --hip-link --rtlib=compiler-rt -unwindlib=libgcc
 
-TESTS = simple advanced two_eventsets simple_sampling
+TESTS = simple advanced two_eventsets simple_sampling roctx_pause_resume
 template_tests: $(TESTS)
 
 %.o: %.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(OPTFLAGS) -D__HIP_PLATFORM_AMD__ -c -o $@ $<
 
 kernel.o: kernel.cpp
-	$(AMDCXX) -D__HIP_ROCclr__=1 -O2 -g -DNDEBUG $(ARCHFLAG) -W -Wall -Wextra -Wshadow -o kernel.o -x hip -c kernel.cpp
+	$(AMDCXX) -D__HIP_ROCclr__=1 -O2 -g -DNDEBUG $(INCFLAGS) $(ARCHFLAG) -W -Wall -Wextra -Wshadow -o kernel.o -x hip -c kernel.cpp
 
 helper_rocp_sdk.o: helper_rocp_sdk.c
 	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $^
@@ -48,6 +52,12 @@ two_eventsets: two_eventsets.o kernel.o helper_rocp_sdk.o
 
 simple_sampling: simple_sampling.o kernel.o helper_rocp_sdk.o
 	$(AMDCXX) -O2 -g -DNDEBUG $(GPUFLAGS) simple_sampling.o kernel.o helper_rocp_sdk.o -o simple_sampling $(LDFLAGS) -pthread
+
+roctx_pause_resume.o: roctx_pause_resume.cpp
+	$(AMDCXX) -O2 -g -DNDEBUG $(INCFLAGS) -x hip -D__HIP_PLATFORM_AMD__ -c roctx_pause_resume.cpp
+
+roctx_pause_resume: roctx_pause_resume.o kernel.o helper_rocp_sdk.o
+	$(AMDCXX) -O2 -g -DNDEBUG $(GPUFLAGS) roctx_pause_resume.o kernel.o helper_rocp_sdk.o -o roctx_pause_resume $(LDFLAGS)
 
 clean:
 	rm -f $(TESTS) *.o

--- a/src/components/rocp_sdk/tests/kernel.cpp
+++ b/src/components/rocp_sdk/tests/kernel.cpp
@@ -1,18 +1,19 @@
-#include <iostream>
-#include <hip/hip_runtime.h>
+#include "kernel.h"
 
 extern "C" int launch_kernel(int device_id);
 
-#define HIP_CALL(call)                                                                             \
-    do                                                                                             \
-    {                                                                                              \
-        hipError_t err = call;                                                                     \
-        if(err != hipSuccess)                                                                      \
-        {                                                                                          \
-            std::cerr << hipGetErrorString(err) << std::endl;                                      \
-            return(-1);                                                                            \
-        }                                                                                          \
-    } while(0)
+__global__ void
+gemm(double *A, double *B, double *C, int N)
+{
+    int colIdx = blockDim.x*blockIdx.x + threadIdx.x;
+    int rowIdx = blockDim.y*blockIdx.y + threadIdx.y;
+
+    if( rowIdx < N && colIdx < N ) {
+        for(int k = 0; k < N; ++k) {
+            C[rowIdx*N + colIdx] += A[rowIdx*N + k] * B[k*N + colIdx];
+        }
+    }
+}
 
 __global__ void
 kernelA(int x, int y)

--- a/src/components/rocp_sdk/tests/kernel.h
+++ b/src/components/rocp_sdk/tests/kernel.h
@@ -1,0 +1,29 @@
+#include <papi.h>
+#include <papi_test.h>
+#include <hip/hip_runtime.h>
+
+#define PAPI_CALL(call)                                                        \
+do {                                                                           \
+    int _status = call;                                                        \
+    if (_status != PAPI_OK) {                                                  \
+        test_fail(__FILE__, __LINE__, #call, _status);                         \
+    }                                                                          \
+} while (0)
+
+#define HIP_CALL(call)                                                         \
+do {                                                                           \
+    hipError_t err = call;                                                     \
+    if(err != hipSuccess) {                                                    \
+        test_fail(__FILE__, __LINE__, hipGetErrorString(err), PAPI_EMISC);     \
+    }                                                                          \
+} while(0)
+
+#define ROCTX_CALL(call)                                                       \
+do {                                                                           \
+    int _status = call;                                                        \
+    if(_status != 0) {                                                         \
+        test_fail(__FILE__, __LINE__, #call, _status);                         \
+    }                                                                          \
+} while(0)
+
+__global__ void gemm(double *A, double *B, double *C, int N);

--- a/src/components/rocp_sdk/tests/roctx_pause_resume.cpp
+++ b/src/components/rocp_sdk/tests/roctx_pause_resume.cpp
@@ -1,0 +1,296 @@
+// Standard library headers
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h> 
+
+// ROCm headers
+#include <rocprofiler-sdk-roctx/roctx.h>
+
+// Internal headers
+#include "kernel.h"
+
+int pauseResume = 0;
+
+extern "C" void enumerate_and_store_rocp_sdk_native_events(char ***rocp_sdk_native_event_names, int *total_event_count);
+extern "C" void add_rocp_sdk_native_events(int eventSet, int maxNativeEventsToAdd, char **nativeEventsToAdd);
+
+static void print_help_message(char *argv[])
+{
+    fprintf(stdout, "%s --rocp-sdk-native-event-names [list of rocp_sdk native event names separated by a comma]\n" \
+                       "--pause                       [enable ROCTX pause and resume calls (optional)]\n", argv[0]);
+}
+
+static void parse_and_assign_args(int argc, char *argv[], char ***rocp_sdk_native_event_names, int *total_event_count)
+{
+    int i;
+    for (i = 1; i < argc; ++i)
+    {
+        char *arg = argv[i];
+        if (strcmp(arg, "--help") == 0)
+        {
+            print_help_message(argv);
+            exit(EXIT_SUCCESS);
+        }
+        else if (strcmp(arg, "--rocp-sdk-native-event-names") == 0)
+        {
+            if (!argv[i + 1])
+            {
+                printf("ERROR!! --rocp-sdk-event-names given, but no events listed.\n");
+                exit(EXIT_FAILURE);
+            }
+
+            char **cmd_line_native_event_names = NULL;
+            const char *rocp_sdk_native_event_name = strtok(argv[i+1], ",");
+            while (rocp_sdk_native_event_name != NULL)
+            {
+                cmd_line_native_event_names = (char **) realloc(cmd_line_native_event_names, ((*total_event_count) + 1) * sizeof(char *));
+                if (cmd_line_native_event_names == NULL) {
+                    fprintf(stderr, "%s:%d: Error: Memory allocation failed.\n", __FILE__, __LINE__);
+                    exit(EXIT_FAILURE);
+                }
+
+                cmd_line_native_event_names[(*total_event_count)] = (char *) malloc(PAPI_MAX_STR_LEN * sizeof(char));
+                if (cmd_line_native_event_names[(*total_event_count)] == NULL) {
+                    fprintf(stderr, "Failed to allocate memory for index %d in rocp_sdk_native_event_names.\n", (*total_event_count));
+                    exit(EXIT_FAILURE);
+                }
+
+                int strLen = snprintf(cmd_line_native_event_names[(*total_event_count)], PAPI_MAX_STR_LEN, "%s", rocp_sdk_native_event_name);
+                if (strLen < 0 || strLen >= PAPI_MAX_STR_LEN) {
+                    fprintf(stderr, "Failed to fully write rocp_sdk native event name.\n");
+                    exit(EXIT_FAILURE);
+                }
+
+                (*total_event_count)++;
+                rocp_sdk_native_event_name = strtok(NULL, ",");
+            }
+            *rocp_sdk_native_event_names = cmd_line_native_event_names;
+            i++;
+        }
+        else if (strcmp(arg, "--pause") == 0) {
+            pauseResume = 1;
+        }
+        else if (strcmp(arg, "TESTS_QUIET") == 0) {
+            // TESTS_QUIET comes from running run_tests.sh.
+            // As stands, we do not silence any printf's in
+            // this application code. Therefore we acknowledge the case
+            // and continue.
+            continue;
+        }
+        else
+        {
+            print_help_message(argv);
+            exit(EXIT_FAILURE);
+        }
+    }
+}
+
+void copy_vals(long long *out, long long *in, int size);
+
+int main(int argc, char *argv[]) {
+
+    // Parse command-line arguments.
+    int total_event_count = 0;
+    char **rocp_sdk_native_event_names = NULL;
+    if (argc > 1) {
+        parse_and_assign_args(argc, argv, &rocp_sdk_native_event_names, &total_event_count);
+    }
+
+    // PAPI front matter.
+    int retval = PAPI_library_init(PAPI_VER_CURRENT);
+    if( retval != PAPI_VER_CURRENT ) {
+        test_fail(__FILE__, __LINE__, "PAPI_library_init() failed.", retval);
+    }
+
+    // If a user does not provide events, add them by enumerating available ones.
+    if (total_event_count == 0) {
+        enumerate_and_store_rocp_sdk_native_events(&rocp_sdk_native_event_names, &total_event_count);
+    }
+
+    int EventSet = PAPI_NULL;
+    long long *values = (long long*)malloc(total_event_count*sizeof(long long));
+    long long *prevValues = (long long*)malloc(total_event_count*sizeof(long long));
+    if( NULL == values || NULL == prevValues ) {
+        test_fail(__FILE__, __LINE__, "Failed to allocate memory for counter values.", PAPI_ENOMEM);
+    }
+    PAPI_CALL(PAPI_create_eventset(&EventSet));
+    add_rocp_sdk_native_events(EventSet, total_event_count, rocp_sdk_native_event_names);
+    PAPI_CALL(PAPI_start(EventSet));
+
+    // HIP front matter.
+    int N = 16;
+    dim3 threads_per_block( 1, 1, 1 );
+    dim3 blocks_in_grid( ceil( float(N) / threads_per_block.x ), ceil( float(N) / threads_per_block.y ), 1 );
+    hipError_t status;
+    size_t probSize = N*N*sizeof(double);
+
+    double *hostA=NULL,  *hostB=NULL,  *hostC=NULL;
+    double  *devA=NULL,   *devB=NULL,   *devC=NULL;
+
+    // Allocate host arrays.
+    HIP_CALL(hipHostMalloc(&hostA, probSize, 0));
+    HIP_CALL(hipHostMalloc(&hostB, probSize, 0));
+    HIP_CALL(hipHostMalloc(&hostC, probSize, 0));
+
+    // Allocate device arrays.
+    HIP_CALL(hipMalloc(&devA, probSize));
+    HIP_CALL(hipMalloc(&devB, probSize));
+    HIP_CALL(hipMalloc(&devC, probSize));
+
+    // Initialize arrays.
+    int i, j;
+    srandom(1);
+    for( i = 0; i < N; i++ ) {
+        for( j = 0; j < N; j++ ) {
+            hostA[i*N + j] = ((double)random())/RAND_MAX + 1.1;
+            hostB[i*N + j] = ((double)random())/RAND_MAX + 1.1;
+            devC[i*N + j] = 0.0;
+        }
+    }
+
+    // Data transfer from host to device.
+    HIP_CALL(hipMemcpy(devA, hostA, probSize, hipMemcpyHostToDevice));
+    HIP_CALL(hipMemcpy(devB, hostB, probSize, hipMemcpyHostToDevice));
+    HIP_CALL(hipMemcpy(devC, hostC, probSize, hipMemcpyHostToDevice));
+
+    // Launch the GEMM once.
+    hipLaunchKernelGGL(gemm, blocks_in_grid, threads_per_block, 0, 0, devA, devB, devC, N);
+    HIP_CALL(hipGetLastError());
+    HIP_CALL(hipDeviceSynchronize());
+
+    // Call PAPI_read() after the 1st GEMM.
+    PAPI_CALL(PAPI_read(EventSet, values));
+    fprintf(stdout, "---------------------  PAPI_read()\n");
+    for(i = 0; i < total_event_count; ++i) {
+        fprintf(stdout, "%s : %lld\n", rocp_sdk_native_event_names[i], values[i]);
+    }
+
+    // Pause the profiler for the 2nd GEMM.
+    roctx_thread_id_t tid;
+    if( pauseResume ) {
+        fprintf(stdout, "---------------------  roctxProfilerPause()\n");
+        ROCTX_CALL(roctxGetThreadId(&tid));
+        ROCTX_CALL(roctxProfilerPause(tid));
+        copy_vals(prevValues, values, total_event_count);
+    }
+
+    // Launch the GEMM again.
+    hipLaunchKernelGGL(gemm, blocks_in_grid, threads_per_block, 0, 0, devA, devB, devC, N);
+    HIP_CALL(hipGetLastError());
+    HIP_CALL(hipDeviceSynchronize());
+
+    // Call PAPI_read() while the profiler is paused.
+    PAPI_CALL(PAPI_read(EventSet, values));
+    fprintf(stdout, "---------------------  PAPI_read()\n");
+    if( pauseResume ) {
+        for(i = 0; i < total_event_count; ++i) {
+            fprintf(stdout, "%s : %lld (expected %lld)\n", rocp_sdk_native_event_names[i], values[i], prevValues[i]);
+            if( values[i] != prevValues[i] ) {
+                test_fail(__FILE__, __LINE__, "Counting did not stop after roctxProfilerPause()!", PAPI_EMISC);
+            }
+        }
+    } else {
+        for(i = 0; i < total_event_count; ++i) {
+            fprintf(stdout, "%s : %lld\n", rocp_sdk_native_event_names[i], values[i]);
+        }
+    }
+
+    // Resume the profiler.
+    if( pauseResume ) {
+        fprintf(stdout, "---------------------  roctxProfilerResume()\n");
+        ROCTX_CALL(roctxProfilerResume(tid));
+    }
+
+    // Launch the GEMM again.
+    hipLaunchKernelGGL(gemm, blocks_in_grid, threads_per_block, 0, 0, devA, devB, devC, N);
+    HIP_CALL(hipGetLastError());
+    HIP_CALL(hipDeviceSynchronize());
+
+    // Call PAPI_read() after the 3rd GEMM.
+    PAPI_CALL(PAPI_read(EventSet, values));
+    fprintf(stdout, "---------------------  PAPI_read()\n");
+    for(i = 0; i < total_event_count; ++i) {
+        fprintf(stdout, "%s : %lld\n", rocp_sdk_native_event_names[i], values[i]);
+    }
+
+    // Pause the profiler for the 4th GEMM.
+    if( pauseResume ) {
+        fprintf(stdout, "---------------------  roctxProfilerPause()\n");
+        ROCTX_CALL(roctxProfilerPause(tid));
+        copy_vals(prevValues, values, total_event_count);
+    }
+
+    // Launch the GEMM again.
+    hipLaunchKernelGGL(gemm, blocks_in_grid, threads_per_block, 0, 0, devA, devB, devC, N);
+    HIP_CALL(hipGetLastError());
+    HIP_CALL(hipDeviceSynchronize());
+
+    // Call PAPI_read() while the profiler is paused.
+    PAPI_CALL(PAPI_read(EventSet, values));
+    fprintf(stdout, "---------------------  PAPI_read()\n");
+    if( pauseResume ) {
+        for(i = 0; i < total_event_count; ++i) {
+            fprintf(stdout, "%s : %lld (expected %lld)\n", rocp_sdk_native_event_names[i], values[i], prevValues[i]);
+            if( values[i] != prevValues[i] ) {
+                test_fail(__FILE__, __LINE__, "Counting did not stop after roctxProfilerPause()!", PAPI_EMISC);
+            }
+        }
+    } else {
+        for(i = 0; i < total_event_count; ++i) {
+            fprintf(stdout, "%s : %lld\n", rocp_sdk_native_event_names[i], values[i]);
+        }
+    }
+
+    // Resume the profiler.
+    if( pauseResume ) {
+        fprintf(stdout, "---------------------  roctxProfilerResume()\n");
+        ROCTX_CALL(roctxProfilerResume(tid));
+    }
+
+    // Launch the GEMM again.
+    hipLaunchKernelGGL(gemm, blocks_in_grid, threads_per_block, 0, 0, devA, devB, devC, N);
+    HIP_CALL(hipGetLastError());
+    HIP_CALL(hipDeviceSynchronize());
+
+    // Call PAPI_stop() for final counter reading.
+    PAPI_CALL(PAPI_stop(EventSet, values));
+    fprintf(stdout, "---------------------  PAPI_read()\n");
+    for(i = 0; i < total_event_count; ++i) {
+        fprintf(stdout, "%s : %lld\n", rocp_sdk_native_event_names[i], values[i]);
+    }
+
+    // HIP back matter.
+    HIP_CALL(hipMemcpy(hostC, devC, probSize, hipMemcpyDeviceToHost));
+    HIP_CALL(hipFree(devA));
+    HIP_CALL(hipFree(devB));
+    HIP_CALL(hipFree(devC));
+    HIP_CALL(hipFree(hostA));
+    HIP_CALL(hipFree(hostB));
+    HIP_CALL(hipFree(hostC));
+
+    // Free other dynamically allocated memory.
+    free(values);
+    free(prevValues);
+    for (i = 0; i < total_event_count; i++) {
+        free(rocp_sdk_native_event_names[i]);
+    }
+    free(rocp_sdk_native_event_names);
+
+    // PAPI back matter.
+    PAPI_CALL(PAPI_cleanup_eventset( EventSet ));
+    PAPI_CALL(PAPI_destroy_eventset( &EventSet ));
+    PAPI_shutdown();
+    test_pass(__FILE__);
+    return 0;
+}
+
+void copy_vals(long long *out, long long *in, int size) {
+
+    int i;
+    for(i = 0; i < size; ++i) {
+        out[i] = in[i];
+    }
+
+    return;
+}

--- a/src/components/rocp_sdk/tests/run_rocp_sdk_tests.sh
+++ b/src/components/rocp_sdk/tests/run_rocp_sdk_tests.sh
@@ -94,3 +94,23 @@ else
     echo "Running: ./two_eventsets"
     ./two_eventsets
 fi
+echo "-------------------------------------"
+
+roctx_pause_resume_desired_events="rocp_sdk:::SQ_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=3,\
+rocp_sdk:::TCC_CYCLE:device=0:DIMENSION_INSTANCE=2,\
+rocp_sdk:::SQ_INSTS:device=0:DIMENSION_INSTANCE=0,\
+rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=0,\
+rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=1,\
+rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0:DIMENSION_SHADER_ENGINE=2,\
+rocp_sdk:::SQ_BUSY_CYCLES:device=0:DIMENSION_INSTANCE=0"
+
+echo "make roctx_pause_resume:"
+make roctx_pause_resume
+if [ "$1" = "--with-desired-events" ]; then
+    echo "Running: ./roctx_pause_resume --pause --rocp-sdk-native-event-names ${roctx_pause_resume_desired_events[@]}"
+    ./roctx_pause_resume --pause --rocp-sdk-native-event-names "${roctx_pause_resume_desired_events[@]}"
+else
+    echo "Running ./roctx_pause_resume --pause"
+    ./roctx_pause_resume --pause
+fi
+echo -e "-------------------------------------"


### PR DESCRIPTION
## Pull Request Description

Prior to these changes, calls to roctxProfilerPause() and roctxProfilerResume() would be ignored by the rocp_sdk component. These changes acknowledge these calls by stopping counting on an event set following a pause and resuming counting following a resume.

These changes have been tested with the AMD MI250X and MI300A devices using ROCm 7.2.0.

Thank you to @adanalis-amd for his extensive help on this.

Useful Reference Materials:
- https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-sdk-roctx.html
- https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/api-reference/rocprofiler-sdk-roctx_api_reference.html
- https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/api-reference/callback_services.html

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
