### PR TITLE
papi fortran: Add support for papif_get_component_index

### DIFF
--- a/src/papi_fwrappers.c
+++ b/src/papi_fwrappers.c
@@ -459,6 +459,30 @@ PAPI_FCALL( papif_get_virt_usec, PAPIF_GET_VIRT_USEC, ( long long *time ) )
 	*time = PAPI_get_virt_usec(  );
 }
 
+/** @class PAPIF_get_component_index
+ *      @ingroup PAPIF
+ *      @brief Return the component index for the named component.
+ *
+ *      @par Fortran Interface:
+ *      \#include "fpapi.h" @n
+ *      PAPIF_get_component_index( C_STRING component_name, C_INT component_index )
+ *
+ * @see PAPI_get_component_index
+ */
+#if defined(_FORTRAN_STRLEN_AT_END)
+PAPI_FCALL( papif_get_component_index, PAPIF_GET_COMPONENT_INDEX, ( char *component_name, int *component_index, int name_len) )
+{
+        char tmp[PAPI_MAX_STR_LEN];
+        Fortran2cstring( tmp, component_name, PAPI_MAX_STR_LEN, name_len );
+        *component_index = PAPI_get_component_index( tmp );
+}
+#else
+PAPI_FCALL( papif_get_component_index, PAPIF_GET_COMPONENT_INDEX, ( char *component_name, int *component_index ) )
+{
+        *component_index = PAPI_get_component_index( component_name );
+}
+#endif
+
 /** @class PAPIF_is_initialized
  *	@ingroup PAPIF
  *	@brief Check for initialization.


### PR DESCRIPTION
## Pull Request Description
This PR adds support for `PAPI_get_component_index` in the PAPI Fortran interface.

## Testing
Testing was done on Picard at Oregon (OS: RHEL 8.10 , CPU: Intel Xeon Gold 6430).

I modified `ftests/eventname.F`, to be as follows:
```fortran
#include "fpapi.h"

      program component_index
      INTEGER retval, cidx

      retval = PAPI_VER_CURRENT
      call PAPIf_library_init( retval )
      if (retval.NE.PAPI_VER_CURRENT) then
          print *, "Call to PAPIf_library_init failed."
          call exit(1)
      end if

      call PAPIf_get_component_index( "sysdetect", cidx )
      if (cidx.LT.0) then
          print *, "Call to PAPIf_get_component_index failed."
          call exit(1)
      end if
      write (*, 1) cidx
  1   format ("Call 1: The sysdetect component index is: ", Z10)

      call papif_get_component_index( "sysdetect", cidx )
      if (cidx.LT.0) then
          print *, "Call to papif_get_component_index failed."
          call exit(1)
      end if 
      write (*, 2) cidx
  2   format ("Call 2: The sysdetect component index is: ", Z10)

      end 
```

As I am on Linux, I always enter the `if defined(_FORTRAN_STRLEN_AT_END)` block of code. Therefore, to test the `else` block I changed `if defined(_FORTRAN_STRLEN_AT_END)` to `if 0`.  You then will need to use `iso_c_binding` and null terminate the string. Otherwise, junk will be placed at the end of the string.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
