### PR TITLE
cuda: Remove unformatted args from SUBDBG calls

### DIFF
--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -320,7 +320,7 @@ static int load_nvpw_sym(void)
         }
         else {
             SUBDBG("PAPI_CUDA_PERFWORKS was set, but did not result in successfully loading the libnvperf_host shared object."
-                   " Set PAPI_CUDA_PERFWORKS to a valid libnvperf_host shared object.\n", papi_cuda_perfworks);
+                   " Set PAPI_CUDA_PERFWORKS to a valid libnvperf_host shared object.\n");
             return PAPI_ESYS;
         }
     }

--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -323,7 +323,7 @@ static int load_nvpw_sym(void)
         }
         else {
             SUBDBG("PAPI_CUDA_PERFWORKS was set, but did not result in successfully loading the libnvperf_host shared object."
-                   " Set PAPI_CUDA_PERFWORKS to a valid libnvperf_host shared object.\n", papi_cuda_perfworks);
+                   " Set PAPI_CUDA_PERFWORKS to a valid libnvperf_host shared object.\n");
             return PAPI_ESYS;
         }
     }

--- a/src/components/cuda/papi_cupti_common.c
+++ b/src/components/cuda/papi_cupti_common.c
@@ -394,7 +394,7 @@ int load_cudart_sym(void)
         }
         else {
             SUBDBG("PAPI_CUDA_RUNTIME was set, but did not result in successfully loading the libcudart shared object."
-                   " Set PAPI_CUDA_RUNTIME to a valid libcudart shared object.\n", papi_cuda_runtime);
+                   " Set PAPI_CUDA_RUNTIME to a valid libcudart shared object.\n");
             return PAPI_ESYS;
         }
     }
@@ -486,7 +486,7 @@ int load_cupti_common_sym(void)
         }
         else {
             SUBDBG("PAPI_CUDA_CUPTI was set, but did not result in successfully loading the libcupti shared object."
-                   " Set PAPI_CUDA_CUPTI to a valid libcupti shared object.\n", papi_cuda_cupti);
+                   " Set PAPI_CUDA_CUPTI to a valid libcupti shared object.\n");
             return PAPI_ESYS;
         }
     }

--- a/src/components/cuda/papi_cupti_common.c
+++ b/src/components/cuda/papi_cupti_common.c
@@ -393,7 +393,7 @@ int load_cudart_sym(void)
         }
         else {
             SUBDBG("PAPI_CUDA_RUNTIME was set, but did not result in successfully loading the libcudart shared object."
-                   " Set PAPI_CUDA_RUNTIME to a valid libcudart shared object.\n", papi_cuda_runtime);
+                   " Set PAPI_CUDA_RUNTIME to a valid libcudart shared object.\n");
             return PAPI_ESYS;
         }
     }
@@ -485,7 +485,7 @@ int load_cupti_common_sym(void)
         }
         else {
             SUBDBG("PAPI_CUDA_CUPTI was set, but did not result in successfully loading the libcupti shared object."
-                   " Set PAPI_CUDA_CUPTI to a valid libcupti shared object.\n", papi_cuda_cupti);
+                   " Set PAPI_CUDA_CUPTI to a valid libcupti shared object.\n");
             return PAPI_ESYS;
         }
     }


### PR DESCRIPTION
## Pull Request Description
PR #585 updated the handling of `PAPI_CUDA_RUNTIME`, `PAPI_CUDA_PERFWORKS`, and `PAPI_CUDA_CUPTI`. With the update more `SUBDBG` messages were added. Specifically for each of the aforementioned env's a `SUBDBG` was added in the format of:
```
SUBDBG("PAPI_CUDA_PERFWORKS was set, but did not result in successfully loading the libnvperf_host shared object."
               " Set PAPI_CUDA_PERFWORKS to a valid libnvperf_host shared object.\n", papi_cuda_perfworks);
```

There is an issue with the above `SUBDBG` which is the second argument `papi_cuda_perfworks` as it needs a format specifier that is not present. To rectify this, the second argument for all three of the aforementioned env's has been removed in this PR.

## Testing
Testing was done on Hopper1 at Oregon (1 * GH200) with Cuda Toolkit 12.8.1.

- PAPI Build: ✅ 
- PAPI Utilities*: ✅ 
- Cuda tests: ✅ 

__*__ - `papi_component_avail`, `papi_native_avail`, and `papi_command_line`

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
