### PR TITLE
cuda: Add cuptiFinalize call for Cuda Toolkits >= 13.0 && Cuda Toolkits  < 13.2 to avoid seg fault

### DIFF
--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -1247,6 +1247,12 @@ int cuptip_shutdown(void)
         return papi_errno;
     }
 
+    int runtimeVersion = 0;
+    cudaArtCheckErrors( cudaRuntimeGetVersionPtr(&runtimeVersion), return PAPI_EMISC );
+    if (runtimeVersion >= 13000 && runtimeVersion < 13020) {
+       cuptiCheckErrors( cuptiFinalizePtr(), return PAPI_EMISC );
+    }
+
     papi_errno = unload_nvpw_sym();
     if (papi_errno != PAPI_OK) {
         return papi_errno;

--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -1261,6 +1261,12 @@ int cuptip_shutdown(void)
         return papi_errno;
     }
 
+    int runtimeVersion = 0;
+    cudaArtCheckErrors( cudaRuntimeGetVersionPtr(&runtimeVersion), return PAPI_EMISC );
+    if (runtimeVersion >= 13000 && runtimeVersion < 13020) {
+       cuptiCheckErrors( cuptiFinalizePtr(), return PAPI_EMISC );
+    }
+
     papi_errno = unload_nvpw_sym();
     if (papi_errno != PAPI_OK) {
         return papi_errno;


### PR DESCRIPTION
## Pull Request Description
Starting in Cuda Toolkit 13.0.0 a segmentation fault would occur when running the test `simpleMultiGPU.cu`, i.e.
```
Running the Cuda component test simpleMultiGPU.cu
PAPI version being used for this test: 7.3.0
The cuda component is assigned to component index: 2
Process GPU results...
Event cuda:::FBSP.TriageCompute.dramc__cycles_elapsed:device=0 produced the value:		180501
  GPU Processing time: 13.801000 (ms)
Computing the same result with Host CPU...
  CPU Processing time: 3.754000 (ms) (speedup 0.27X)
Comparing GPU and Host CPU results...
  GPU sum: 777238.875000
  CPU sum: 777239.896331
  Relative difference: 1.314048E-06 
Segmentation fault
```

The root cause of this segmentation fault was calling `PAPI_shutdown` as the CUPTI dynamic shared library was closed and a regression in Cuda Toolkit 13.0.0 leaving dangling pointer paths. Starting in Cuda Toolkit 13.2, this behavior is resolved per an NVIDIA engineer.

To resolve this behavior in Cuda Toolkits >= 13 and < 13.2 a call to `cuptiFinalize` will be placed in `cuptip_shutdown`.

## Testing
Testing was done on Hopper1 at Oregon (1 * GH200) with Cuda Toolkit 13.0.0:

- PAPI build: ✅ 
- PAPI utilities*: ✅ 
- Cuda component tests: ✅ 

__*__ - `papi_component_avail`, `papi_native_avail`, and `papi_command_line`

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
