### PR TITLE
nvml: Update the search logic to honor PAPI_NVML_MAIN, README.md, and Rules.nvml

### DIFF
--- a/src/components/nvml/README.md
+++ b/src/components/nvml/README.md
@@ -5,43 +5,36 @@ counters and controls for NVIDIA GPUs, such as power consumption, fan speed and
 temperature readings; it also allows capping of power consumption.
 
 * [Enabling the NVML Component](#enabling-the-nvml-component)
-* [Environment Variables](#environment-variables)
 * [Known Limitations](#known-limitations)
 * [FAQ](#faq)
 ***
 ## Enabling the NVML Component
 
 To enable reading or writing of NVML counters the user needs to link
-against a PAPI library that was configured with the NVML component enabled.
-As an example the following command: `./configure --with-components="nvml"`
-is sufficient to enable the component.
+against a PAPI library that was configured with the `nvml` component. As an example:
+```
+./configure --with-components="nvml"
+```
 
-Typically, the utility `papi_components_avail` (available in
-`papi/src/utils/papi_components_avail`) will display the components available
-to the user, and whether they are disabled, and when they are disabled why.
+For the component to be active, PAPI requires one environment variable to be set: `PAPI_CUDA_ROOT` (exact same environment variable as the `cuda` component). This environment variable **must** be set to the root of the
+Cuda Toolkit that is desired to be used. As as example:
+```
+export PAPI_CUDA_ROOT=/packages/cuda/#.#.#
+```
 
-## Environment Variables
-NVML uses the same Environment variable as the CUDA component; `PAPI_CUDA_ROOT`.
+Within `PAPI_CUDA_ROOT`, we expect the following standard directory for building:
+```
+PAPI_CUDA_ROOT/include
+```
 
-Example:
+For the `nvml` component to be operational at runtime it must find the following dynamic shared library:
+```
+libnvidia-ml.so
+```
 
-    export PAPI_CUDA_ROOT=/usr/local/cuda-10.1
-
-Within PAPI_CUDA_ROOT, we expect the following standard directories:
-
-    PAPI_CUDA_ROOT/include
-    PAPI_CUDA_ROOT/lib64
-    PAPI_CUDA_ROOT/extras/CUPTI/include
-    PAPI_CUDA_ROOT/extras/CUPTI/lib64
-
-For the NVML component to be operational at runtime, it must find the following dynamic library:
-
-    libnvidia-ml.so
-
-If this library cannot be found or is a stub library in the standard `PAPI_CUDA_ROOT` subdirectories, you have to add the correct path, e.g. `/usr/lib64` or `/usr/lib` to `LD_LIBRARY_PATH`, separated by colons `:`. This can be set using export; e.g. 
-
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/WhereLibCanBeFound
-
+To verify the `nvml` component was configured with your PAPI build and is active, run `papi_component_avail` (available in `utils/papi_component_avail`).
+This PAPI utility will display the components configured in your PAPI build and whether they are active or disabled. If the component is the latter a disabled
+reason will be provided.
 
 ## Known Limitations
 
@@ -54,15 +47,19 @@ power limits; such permissions are typically granted by your sysadmin.
 1. [Unusual installations](#unusual-installations)
 
 ## Unusual installations
-One library is required for the PAPI NVML component: `libnvidia-ml.so`.  
+The dynamic shared library `libnvidia-ml` is commonly found under `/lib` or `/usr/lib` rather than the Cuda Toolkit installation. Therefore, by default `dlopen` is used to search `/lib` and `/usr/lib`.
+If the dynamic shared library is not found, then two other options remain:
 
-For the NVML component to be operational, it must find the dynamic library
-mentioned above. If it is not found in the standard `PAPI_CUDA_ROOT`
-subdirectories mentioned above, the component looks in the Linux default
-directories listed by `/etc/ld.so.conf`, usually `/usr/lib64`, `/lib64`,
-`/usr/lib` and `/lib`. 
+1. Setting the dynamic shared libraries corresponding environment variable:
+   ```
+   export PAPI_NVML_MAIN=/your/path/to/libnvidia-ml.so
+   ```
 
-The system will also search the directories listed in `LD_LIBRARY_PATH`,
-separated by colons `:`. This can be set using export; e.g. 
+   Note, that if using this option:
+     * You must set the environment variable directly to the dynamic shared library as shown above.
+     * If the set path fails to open a dynamic shared library then the `nvml` component will be disabled.
 
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/WhereLibCanBeFound
+2. `dlopen` follows the search logic of the dynamic shared linker and so you can set `LD_LIBRARY_PATH` to the directory containing your `libnvidia-ml` dynamic shared library, i.e.
+   ```
+   export LD_LIBRARY_PATH=/your/path/to/WhereLibCanBeFound:$LD_LIBRARY_PATH
+   ```

--- a/src/components/nvml/Rules.nvml
+++ b/src/components/nvml/Rules.nvml
@@ -4,99 +4,10 @@
 # settings are optional.
 PAPI_CUDA_ROOT ?= /opt/cuda
 
-# For non-typical system configurations, the following 'runtime overrides' can
-# be set, as just a library name, or a full path and name. There cannot be any
-# spaces between the double quotes (which must be escaped as \"). An example:
-
-# PAPI_CUDA_CUPTI = \"$(PAPI_CUDA_ROOT)/extras/CUPTI/lib64/libcupti.so\"
-
-# By default, all overrides are empty strings.
-
-# If an override is not an empty string, it must work, or the component will be
-# disabled. 
-
-# Both at compile time and run time, the software depends on PAPI_CUDA_ROOT.
-# There are three libraries used by the NVML component, they are 
-# A variation of the shared object libcuda (e.g. libcuda.so or libcuda.so.1)
-# A variation of the shared object libcudart (e.g. libcudart.so or libcudart.so.12)
-# A variation of the shared object libnvidia-ml (e.g libnvidia-ml.so or libnvidia-ml.so.1)
-
-# The standard installed locations for these libraries, with overrides:
-# $(PAPI_CUDA_ROOT)/lib64/libcuda.so (or libcuda.so.1)            #O.R. PAPI_CUDA_MAIN
-# $(PAPI_CUDA_ROOT)/lib64/libcudart.so (or libcudart.so.12)       #O.R. PAPI_CUDA_RUNTIME
-# $(PAPI_CUDA_ROOT)/lib64/libnvidia-ml.so (or libnvidia-ml.so.1)  #O.R. PAPI_NVML_MAIN
-# 
-# There are many ways to cause these paths to be known. 
-# Spack is a package manager used on supercomputers, Linux and MacOS. If Spack
-# is aware of CUDA or NVML, it encodes the paths to the necessary libraries.
-
-# The environment variable LD_LIBRARY_PATH encodes a list of paths to search for
-# libraries; separated by a colon (:). These paths could be added to
-# LD_LIBRARY_PATH. 
-#
-# Warning: LD_LIBRARY_PATH often contains a list of directories that are
-# searched for libraries, some of these may be needed by other packages you are
-# using. Always add to LD_LIBRARY_PATH recursively; for example: 
-# >export LD_LIBRARY_PATH=someNewLibraryDirectory:$LD_LIBRARY_PATH 
-# which would append the existing LD_LIBRARY_PATH to the new directory you wish
-# to add.  Alternatively, you can prepend it: 
-# >export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:someNewLibraryDirectory 
-# Which will search the existing libraries first, then your new directory.
-
-# You can check on the value of LD_LIBRARY_PATH with 
-# >echo $LD_LIBRARY_PATH
-
-# There may be other package managers or utilities, for example on a system with
-# modules; the command 'module load cuda' may modify LD_LIBRARY_PATH.
-
-# A Linux system will also search for libraries by default in the directories
-# listed by /etc/ld.so.conf, and /usr/lib64, /lib64, /usr/lib, /lib. 
-
-# OVERRIDES: These are by default empty strings (""), if set they must work.
-PAPI_CUDA_MAIN = \"\"
-PAPI_CUDA_RUNTIME = \"\"
-PAPI_NVML_MAIN = \"\"
-
-# An example of an override:
-# PAPI_NVML_MAIN = \"$(PAPI_CUDA_ROOT)/lib64/libnvidia-ml.so\"
-# NOTE: libnvidia-ml.so was replaced with libnvidia-ml.so.1 with drivers
-# 560+ see: https://github.com/NVIDIA/yum-packaging-nvidia-driver/issues/9.
-
-# Note:  PAPI_CUDA_MAIN and PAPI_CUDA_RUNTIME, if set, will also apply to the
-#        CUDA component, which uses the same libraries.
-
-# Note:  If you change these overrides, PAPI should be rebuilt from scratch.
-#        From papi/src/
-#        make clobber
-#        ./configure --with-components="nvml"
-#        make  
-
-# OPERATION, per library:
-# 1) If an override string is not empty, we will use it explicitly and fail if
-# it does not work. This means disabling the component; a reason for disabling
-# is shown using the papi utility, papi/src/utils/papi_component_avail
-
-# 2) We will attempt to open the library using the normal system library search
-# paths; if Spack is present and configured correctly it should deliver the
-# proper library. A failure here will be silent; we will proceed to (3).
-
-# 3) If that fails, we will try to find the library in the standard installed
-# locations listed above. If this fails, we disable the component, the reason
-# for disabling is shown using the papi utility,
-# papi/src/utils/papi_component_avail. 
-
-# DEFFLAGS is the macro defines for the three overrides. In the code we convert
-# these to string variables with the following lines:
-# static char cuda_main[]=PAPI_CUDA_MAIN;
-# static char cuda_runtime[]=PAPI_CUDA_RUNTIME;
-# static char nvml_main[]=PAPI_NVML_MAIN;
-
-NVML_MACS = -DPAPI_CUDA_MAIN=$(PAPI_CUDA_MAIN) -DPAPI_CUDA_RUNTIME=$(PAPI_CUDA_RUNTIME) -DPAPI_NVML_MAIN=$(PAPI_NVML_MAIN)
-
 COMPSRCS += components/nvml/linux-nvml.c
 COMPOBJS += linux-nvml.o
-# CFLAGS specifies compile flags; need include files here, and macro defines.
-CFLAGS += -I$(PAPI_CUDA_ROOT)/include -g $(NVML_MACS)
+# CFLAGS specifies compile flags; need include files here
+CFLAGS += -I$(PAPI_CUDA_ROOT)/include -g
 LDFLAGS += $(LDL) -g
 
 linux-nvml.o: components/nvml/linux-nvml.c $(HEADERS)

--- a/src/components/nvml/linux-nvml.c
+++ b/src/components/nvml/linux-nvml.c
@@ -115,9 +115,7 @@ static nvmlReturn_t (*nvmlDeviceGetPowerManagementLimitConstraintsPtr)(nvmlDevic
 // file handles used to access NVML libraries with dlopen
 static void* dl3 = NULL;
 
-static char nvml_main[]=PAPI_NVML_MAIN;
-
-static int linkCudaLibraries();
+static int load_nvml_sym(void);
 
 /* Declare our vector in advance */
 papi_vector_t _nvml_vector;
@@ -1246,7 +1244,7 @@ int _papi_nvml_init_private(void)
 
     SUBDBG("Private init with component idx: %d\n", _nvml_vector.cmp_info.CmpIdx);
     /* link in the NVML libraries and resolve the symbols we need to use */
-    if (linkCudaLibraries() != PAPI_OK) {
+    if (load_nvml_sym() != PAPI_OK) {
         SUBDBG("Dynamic link of CUDA libraries failed, component will be disabled.\n");
         SUBDBG("See disable reason in papi_component_avail output for more details.\n");
         _papi_nvml_shutdown_component();                          // clean up any open dynLibs, mallocs, etc.
@@ -1353,94 +1351,6 @@ nvml_init_private_exit:
     return err;
 }
 
-/**@class nvml_search_and_load_shared_objects
- * @brief Search and load Cuda shared objects.
- *
- * @param *parentPath
- *   The main path we will use to search for the shared objects. 
- * @param *soMainName
- *   The name of the shared object e.g. libnvidia. This is used
- *   to select the standardSubPaths to use.
- * @param *soNamesToSearchFor[]
- *   Varying names of the shared object we want to search for.
- * @param soNamesToSearchCount
- *   Total number of names in soNamesToSearchFor.
- */
-static void *nvml_search_and_load_shared_objects(const char *parentPath, const char *soMainName, const char *soNamesToSearchFor[], int soNamesToSearchCount)
-{
-    const char *standardSubPaths[3];
-    // Case for when we want to search explicit subpaths for a shared object 
-    if (soMainName != NULL) {
-        if (strcmp(soMainName, "libnvidia-ml") == 0) {
-            standardSubPaths[0] = "%s/lib64/";
-            standardSubPaths[1] = "%s/";
-            standardSubPaths[2] = NULL;
-        }
-    }
-    // Case for when a user provides an exact path e.g. PAPI_NVML_MAIN
-    // and we do not want to search subpaths
-    else{
-        standardSubPaths[0] = "%s/";
-        standardSubPaths[1] = NULL;
-    }
-
-    char pathToSharedLibrary[PAPI_HUGE_STR_LEN], directoryPathToSearch[PAPI_HUGE_STR_LEN];
-    void *so = NULL;
-    char *soNameFound;
-    int i, strLen;
-    for (i = 0; standardSubPaths[i] != NULL; i++) {
-        // Create path to search for dl names
-        int strLen = snprintf(directoryPathToSearch, PAPI_HUGE_STR_LEN, standardSubPaths[i], parentPath);
-        if (strLen < 0 || strLen >= PAPI_HUGE_STR_LEN) {
-            SUBDBG("Failed to fully write path to search for dlnames.\n");
-            return NULL;
-        }
-
-        DIR *dir = opendir(directoryPathToSearch);
-        if (dir == NULL) {
-            SUBDBG("Directory path could not be opened.\n");
-            continue;
-        }
-
-        int j;
-        for (j = 0; j < soNamesToSearchCount; j++) {
-            struct dirent *dirEntry;
-            while( ( dirEntry = readdir(dir) ) != NULL ) {
-                int result;
-                char *p = strstr(soNamesToSearchFor[j], "so");
-                // Check for an exact match of a shared object name (.so and .so.1 case)
-                if (p) {
-                    result = strcmp(dirEntry->d_name, soNamesToSearchFor[j]);
-                }
-                // Check for any match of a shared object name (we could not find .so and .so.1)
-                else {
-                    result = strncmp(dirEntry->d_name, soNamesToSearchFor[j], strlen(soNamesToSearchFor[j]));
-                }
-
-                if (result == 0) {
-                    soNameFound = dirEntry->d_name;
-                    goto found;
-                }
-            }
-            // Reset the position of the directory stream
-            rewinddir(dir);
-        }
-    }
-
-  exit:
-    return so;
-  found:
-    // Construct path to shared library
-    strLen = snprintf(pathToSharedLibrary, PAPI_HUGE_STR_LEN, "%s%s", directoryPathToSearch, soNameFound);
-    if (strLen < 0 || strLen >= PAPI_HUGE_STR_LEN) {
-        SUBDBG("Failed to fully write constructed path to shared library.\n");
-        return NULL;
-    }
-    so = dlopen(pathToSharedLibrary, RTLD_NOW | RTLD_GLOBAL);
-
-    goto exit;
-}
-
 /**@class nvml_search_and_load_from_system_paths
  * @brief A simple wrapper to try and search and load
  *        Cuda shared objects from system paths.
@@ -1464,59 +1374,62 @@ static void *nvml_search_and_load_from_system_paths(const char *soNamesToSearchF
     return so;
 }
 
-/*
- * Link the necessary CUDA libraries to use the NVML component.  If any of them can not be found, then
- * the NVML component will just be disabled.  This is done at runtime so that a version of PAPI built
- * with the NVML component can be installed and used on systems which have the CUDA libraries installed
- * and on systems where these libraries are not installed.
- */
-static int
-linkCudaLibraries()
+/**@class load nvml_sym
+ * @brief Search for a variation of the shared object libnvidia-ml and once found
+ *        load the function pointers.
+ *        Order of search is outlined below.
+ *
+ * 1. If a user sets PAPI_NVML_MAIN, this will take precedent over
+ *    the options listed below to be searched. Note, if a user sets this environment
+ *    variable and we do not successfully load the shared object then we error.
+ * 2. If PAPI_NVML_MAIN is not set then we use dlopen and follow the search logic
+ *    used by the dynamic linker. As a note, updating the LD_LIBRARY_PATH is advised
+ *    for this option.
+ * */
+
+static int load_nvml_sym(void)
 {
-    char path_lib[1024];
     /* Attempt to guess if we were statically linked to libc, if so bail */
     if (_dl_non_dynamic_init != NULL) {
         strncpy(_nvml_vector.cmp_info.disabled_reason, "NVML component does not support statically linking of libc.", PAPI_MAX_STR_LEN);
         return PAPI_ENOSUPP;
     }
 
-    // Need to link in the NVML libraries, if any not found disable the component.
-    // getenv returns NULL if environment variable is not found.
-    char *cuda_root = getenv("PAPI_CUDA_ROOT");
-
-    // We need the NVML main library, normally libnvidia-ml.so or libnvidia-ml.so.1.
-    dl3 = NULL;                                                 // Ensure reset to NULL.
-
-    int soNamesToSearchCount = 3; 
-    const char *soNamesToSearchFor[] = {"libnvidia-ml.so", "libnvidia-ml.so.1", "libnvidia"};
-    // Step 1: Process override if given.   
-    if (strlen(nvml_main) > 0) {                                        // If override given, it MUST work.
-        dl3 = nvml_search_and_load_shared_objects(nvml_main, NULL, soNamesToSearchFor, soNamesToSearchCount); // Try to open that path
-        if (dl3 == NULL) {
-            snprintf(_nvml_vector.cmp_info.disabled_reason, PAPI_MAX_STR_LEN, "PAPI_NVML_MAIN override '%s' given in Rules.nvml not found.", nvml_main);
-            return(PAPI_ENOSUPP);   // Override given but not found.
+    int strLen;
+    char *papi_nvml_main = getenv("PAPI_NVML_MAIN");
+    if (papi_nvml_main) {
+        dl3 = dlopen(papi_nvml_main, RTLD_NOW | RTLD_GLOBAL);
+        if (dl3 != NULL) {
+            goto load_functions;
+        }
+        else {
+            strLen = snprintf(_nvml_vector.cmp_info.disabled_reason, sizeof(_nvml_vector.cmp_info.disabled_reason), "%s",
+                              "PAPI_NVML_MAIN was set, but did not result in successfully loading the libnvidia-ml shared object."
+                              " Set PAPI_NVML_MAIN to a valid libnvidia-ml shared object.");
+            if (strLen < 0 || (size_t) strLen >= sizeof(_nvml_vector.cmp_info.disabled_reason)) {
+                SUBDBG("The NVML disabled reason has been truncated. Proceeding.\n");
+            }
+            return PAPI_ESYS;
         }
     }
-
-    char *soMainName = "libnvidia-ml";
-    // Step 2: Try the explicit install default. 
-    if (dl3 == NULL && cuda_root != NULL) {                                         // If ROOT given, it doesn't HAVE to work.
-        dl3 = nvml_search_and_load_shared_objects(cuda_root, soMainName, soNamesToSearchFor, soNamesToSearchCount); // Try to open that path.
-    } 
-
-    // Step 3: Try system paths, will work with Spack, LD_LIBRARY_PATH, default paths.
-    if (dl3 == NULL) {                                              // If no override,
-        dl3 = nvml_search_and_load_from_system_paths(soNamesToSearchFor, soNamesToSearchCount); // Try system paths.
+    else {
+        SUBDBG("PAPI_NVML_MAIN was not set. Falling back to dlopen to search for the libnvidia-ml shared object.\n");
     }
 
-    // Check for failure.
+    int soNamesToSearchCount = 3;
+    const char *soNamesToSearchFor[] = {"libnvidia-ml.so", "libnvidia-ml.so.1", "libnvidia"};
+    // If PAPI_NVML_MAIN was not set then use dlopen and follow the search logic used by the dynamic linker
+    dl3 = nvml_search_and_load_from_system_paths(soNamesToSearchFor, soNamesToSearchCount);
     if (dl3 == NULL) {
-        snprintf(_nvml_vector.cmp_info.disabled_reason, PAPI_MAX_STR_LEN, "libnvidia-ml.so not found.");
-        return(PAPI_ENOSUPP);   // Not found on default paths.
+        strLen = snprintf(_nvml_vector.cmp_info.disabled_reason, sizeof(_nvml_vector.cmp_info.disabled_reason), "%s",
+                          "The shared object libnvidia-ml was unable to be found. Try setting PAPI_NVML_MAIN.");
+        if (strLen < 0 || (size_t) strLen >= sizeof(_nvml_vector.cmp_info.disabled_reason)) {
+            SUBDBG("The NVML disabled reason has been truncated. Proceeding.\n");
+        }
+        return PAPI_ESYS;
     }
 
-    // We have a dl3. (libnvidia-ml.so).
-
+  load_functions:
     nvmlDeviceGetClockInfoPtr = dlsym(dl3, "nvmlDeviceGetClockInfo");
     if (dlerror() != NULL) {
         strncpy(_nvml_vector.cmp_info.disabled_reason, "NVML function nvmlDeviceGetClockInfo not found.", PAPI_MAX_STR_LEN);

--- a/src/components/nvml/linux-nvml.c
+++ b/src/components/nvml/linux-nvml.c
@@ -115,9 +115,7 @@ static nvmlReturn_t (*nvmlDeviceGetPowerManagementLimitConstraintsPtr)(nvmlDevic
 // file handles used to access NVML libraries with dlopen
 static void* dl3 = NULL;
 
-static char nvml_main[]=PAPI_NVML_MAIN;
-
-static int linkCudaLibraries();
+static int load_nvml_sym(void);
 
 /* Declare our vector in advance */
 papi_vector_t _nvml_vector;
@@ -1296,7 +1294,7 @@ int _papi_nvml_init_private(void)
 
     SUBDBG("Private init with component idx: %d\n", _nvml_vector.cmp_info.CmpIdx);
     /* link in the NVML libraries and resolve the symbols we need to use */
-    if (linkCudaLibraries() != PAPI_OK) {
+    if (load_nvml_sym() != PAPI_OK) {
         SUBDBG("Dynamic link of CUDA libraries failed, component will be disabled.\n");
         SUBDBG("See disable reason in papi_component_avail output for more details.\n");
         _papi_nvml_shutdown_component();                          // clean up any open dynLibs, mallocs, etc.
@@ -1403,94 +1401,6 @@ nvml_init_private_exit:
     return err;
 }
 
-/**@class nvml_search_and_load_shared_objects
- * @brief Search and load Cuda shared objects.
- *
- * @param *parentPath
- *   The main path we will use to search for the shared objects. 
- * @param *soMainName
- *   The name of the shared object e.g. libnvidia. This is used
- *   to select the standardSubPaths to use.
- * @param *soNamesToSearchFor[]
- *   Varying names of the shared object we want to search for.
- * @param soNamesToSearchCount
- *   Total number of names in soNamesToSearchFor.
- */
-static void *nvml_search_and_load_shared_objects(const char *parentPath, const char *soMainName, const char *soNamesToSearchFor[], int soNamesToSearchCount)
-{
-    const char *standardSubPaths[3];
-    // Case for when we want to search explicit subpaths for a shared object 
-    if (soMainName != NULL) {
-        if (strcmp(soMainName, "libnvidia-ml") == 0) {
-            standardSubPaths[0] = "%s/lib64/";
-            standardSubPaths[1] = "%s/";
-            standardSubPaths[2] = NULL;
-        }
-    }
-    // Case for when a user provides an exact path e.g. PAPI_NVML_MAIN
-    // and we do not want to search subpaths
-    else{
-        standardSubPaths[0] = "%s/";
-        standardSubPaths[1] = NULL;
-    }
-
-    char pathToSharedLibrary[PAPI_HUGE_STR_LEN], directoryPathToSearch[PAPI_HUGE_STR_LEN];
-    void *so = NULL;
-    char *soNameFound;
-    int i, strLen;
-    for (i = 0; standardSubPaths[i] != NULL; i++) {
-        // Create path to search for dl names
-        int strLen = snprintf(directoryPathToSearch, PAPI_HUGE_STR_LEN, standardSubPaths[i], parentPath);
-        if (strLen < 0 || strLen >= PAPI_HUGE_STR_LEN) {
-            SUBDBG("Failed to fully write path to search for dlnames.\n");
-            return NULL;
-        }
-
-        DIR *dir = opendir(directoryPathToSearch);
-        if (dir == NULL) {
-            SUBDBG("Directory path could not be opened.\n");
-            continue;
-        }
-
-        int j;
-        for (j = 0; j < soNamesToSearchCount; j++) {
-            struct dirent *dirEntry;
-            while( ( dirEntry = readdir(dir) ) != NULL ) {
-                int result;
-                char *p = strstr(soNamesToSearchFor[j], "so");
-                // Check for an exact match of a shared object name (.so and .so.1 case)
-                if (p) {
-                    result = strcmp(dirEntry->d_name, soNamesToSearchFor[j]);
-                }
-                // Check for any match of a shared object name (we could not find .so and .so.1)
-                else {
-                    result = strncmp(dirEntry->d_name, soNamesToSearchFor[j], strlen(soNamesToSearchFor[j]));
-                }
-
-                if (result == 0) {
-                    soNameFound = dirEntry->d_name;
-                    goto found;
-                }
-            }
-            // Reset the position of the directory stream
-            rewinddir(dir);
-        }
-    }
-
-  exit:
-    return so;
-  found:
-    // Construct path to shared library
-    strLen = snprintf(pathToSharedLibrary, PAPI_HUGE_STR_LEN, "%s%s", directoryPathToSearch, soNameFound);
-    if (strLen < 0 || strLen >= PAPI_HUGE_STR_LEN) {
-        SUBDBG("Failed to fully write constructed path to shared library.\n");
-        return NULL;
-    }
-    so = dlopen(pathToSharedLibrary, RTLD_NOW | RTLD_GLOBAL);
-
-    goto exit;
-}
-
 /**@class nvml_search_and_load_from_system_paths
  * @brief A simple wrapper to try and search and load
  *        Cuda shared objects from system paths.
@@ -1514,59 +1424,62 @@ static void *nvml_search_and_load_from_system_paths(const char *soNamesToSearchF
     return so;
 }
 
-/*
- * Link the necessary CUDA libraries to use the NVML component.  If any of them can not be found, then
- * the NVML component will just be disabled.  This is done at runtime so that a version of PAPI built
- * with the NVML component can be installed and used on systems which have the CUDA libraries installed
- * and on systems where these libraries are not installed.
- */
-static int
-linkCudaLibraries()
+/**@class load nvml_sym
+ * @brief Search for a variation of the shared object libnvidia-ml and once found
+ *        load the function pointers.
+ *        Order of search is outlined below.
+ *
+ * 1. If a user sets PAPI_NVML_MAIN, this will take precedent over
+ *    the options listed below to be searched. Note, if a user sets this environment
+ *    variable and we do not successfully load the shared object then we error.
+ * 2. If PAPI_NVML_MAIN is not set then we use dlopen and follow the search logic
+ *    used by the dynamic linker. As a note, updating the LD_LIBRARY_PATH is advised
+ *    for this option.
+ * */
+
+static int load_nvml_sym(void)
 {
-    char path_lib[1024];
     /* Attempt to guess if we were statically linked to libc, if so bail */
     if (_dl_non_dynamic_init != NULL) {
         strncpy(_nvml_vector.cmp_info.disabled_reason, "NVML component does not support statically linking of libc.", PAPI_MAX_STR_LEN);
         return PAPI_ENOSUPP;
     }
 
-    // Need to link in the NVML libraries, if any not found disable the component.
-    // getenv returns NULL if environment variable is not found.
-    char *cuda_root = getenv("PAPI_CUDA_ROOT");
-
-    // We need the NVML main library, normally libnvidia-ml.so or libnvidia-ml.so.1.
-    dl3 = NULL;                                                 // Ensure reset to NULL.
-
-    int soNamesToSearchCount = 3; 
-    const char *soNamesToSearchFor[] = {"libnvidia-ml.so", "libnvidia-ml.so.1", "libnvidia"};
-    // Step 1: Process override if given.   
-    if (strlen(nvml_main) > 0) {                                        // If override given, it MUST work.
-        dl3 = nvml_search_and_load_shared_objects(nvml_main, NULL, soNamesToSearchFor, soNamesToSearchCount); // Try to open that path
-        if (dl3 == NULL) {
-            snprintf(_nvml_vector.cmp_info.disabled_reason, PAPI_MAX_STR_LEN, "PAPI_NVML_MAIN override '%s' given in Rules.nvml not found.", nvml_main);
-            return(PAPI_ENOSUPP);   // Override given but not found.
+    int strLen;
+    char *papi_nvml_main = getenv("PAPI_NVML_MAIN");
+    if (papi_nvml_main) {
+        dl3 = dlopen(papi_nvml_main, RTLD_NOW | RTLD_GLOBAL);
+        if (dl3 != NULL) {
+            goto load_functions;
+        }
+        else {
+            strLen = snprintf(_nvml_vector.cmp_info.disabled_reason, sizeof(_nvml_vector.cmp_info.disabled_reason), "%s",
+                              "PAPI_NVML_MAIN was set, but did not result in successfully loading the libnvidia-ml shared object."
+                              " Set PAPI_NVML_MAIN to a valid libnvidia-ml shared object.");
+            if (strLen < 0 || (size_t) strLen >= sizeof(_nvml_vector.cmp_info.disabled_reason)) {
+                SUBDBG("The NVML disabled reason has been truncated. Proceeding.\n");
+            }
+            return PAPI_ESYS;
         }
     }
-
-    char *soMainName = "libnvidia-ml";
-    // Step 2: Try the explicit install default. 
-    if (dl3 == NULL && cuda_root != NULL) {                                         // If ROOT given, it doesn't HAVE to work.
-        dl3 = nvml_search_and_load_shared_objects(cuda_root, soMainName, soNamesToSearchFor, soNamesToSearchCount); // Try to open that path.
-    } 
-
-    // Step 3: Try system paths, will work with Spack, LD_LIBRARY_PATH, default paths.
-    if (dl3 == NULL) {                                              // If no override,
-        dl3 = nvml_search_and_load_from_system_paths(soNamesToSearchFor, soNamesToSearchCount); // Try system paths.
+    else {
+        SUBDBG("PAPI_NVML_MAIN was not set. Falling back to dlopen to search for the libnvidia-ml shared object.\n");
     }
 
-    // Check for failure.
+    int soNamesToSearchCount = 3;
+    const char *soNamesToSearchFor[] = {"libnvidia-ml.so", "libnvidia-ml.so.1", "libnvidia"};
+    // If PAPI_NVML_MAIN was not set then use dlopen and follow the search logic used by the dynamic linker
+    dl3 = nvml_search_and_load_from_system_paths(soNamesToSearchFor, soNamesToSearchCount);
     if (dl3 == NULL) {
-        snprintf(_nvml_vector.cmp_info.disabled_reason, PAPI_MAX_STR_LEN, "libnvidia-ml.so not found.");
-        return(PAPI_ENOSUPP);   // Not found on default paths.
+        strLen = snprintf(_nvml_vector.cmp_info.disabled_reason, sizeof(_nvml_vector.cmp_info.disabled_reason), "%s",
+                          "The shared object libnvidia-ml was unable to be found. Try setting PAPI_NVML_MAIN.");
+        if (strLen < 0 || (size_t) strLen >= sizeof(_nvml_vector.cmp_info.disabled_reason)) {
+            SUBDBG("The NVML disabled reason has been truncated. Proceeding.\n");
+        }
+        return PAPI_ESYS;
     }
 
-    // We have a dl3. (libnvidia-ml.so).
-
+  load_functions:
     nvmlDeviceGetClockInfoPtr = dlsym(dl3, "nvmlDeviceGetClockInfo");
     if (dlerror() != NULL) {
         strncpy(_nvml_vector.cmp_info.disabled_reason, "NVML function nvmlDeviceGetClockInfo not found.", PAPI_MAX_STR_LEN);


### PR DESCRIPTION
## Pull Request Description
This PR updates the `nvml` component to honor `PAPI_NVML_MAIN` as an environment variable rather than a user needing to set the variable in `Rules.nvml`. This makes the `nvml` component more in line with other components.

Along with this, two other changes occur:
* The `README.md` was updated to reflect this aforementioned change.
* `Rules.nvml` has `PAPI_CUDA_MAIN`, `PAPI_CUDA_RUNTIME`, and `PAPI_NVML_MAIN` removed along with text that should have been placed in the  `README.md`. Note that, `PAPI_CUDA_MAIN` and `PAPI_CUDA_RUNTIME` do not have an equivalent environment variable added as did `PAPI_NVML_MAIN`. As these two environment variables are not used throughout the `nvml` component codebase.

## Testing
Testing was done on Methane at ICL (1 * A100) with Cuda Toolkit 12.9.

- PAPI build: ✅ 
- PAPI utilities*: ✅ 
- `HelloWorld.cu`: ✅ 

__*__  -`papi_component_avail`, `papi_native_avail`, and `papi_command_line`

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
