### PR TITLE
framework: For cuda native events - extend the string length in PAPI_event_code_to_name to be PAPI_2MAX_STR_LEN

### DIFF
--- a/src/components/cuda/tests/cuda_tests_helper.c
+++ b/src/components/cuda/tests/cuda_tests_helper.c
@@ -121,7 +121,7 @@ void enumerate_and_store_cuda_native_events(char ***cuda_native_event_names, int
 
     // Convert the first cuda native event code to a name, the name will
     // be in the format of cuda:::basename with no qualifiers appended.
-    char basename[PAPI_MAX_STR_LEN];
+    char basename[PAPI_2MAX_STR_LEN];
     papi_errno = PAPI_event_code_to_name(cuda_eventcode, basename);
     if (papi_errno != PAPI_OK) {
         test_fail(__FILE__, __LINE__, "PAPI_event_code_to_name", papi_errno);

--- a/src/components/cuda/tests/test_2thr_1gpu_not_allowed.cu
+++ b/src/components/cuda/tests/test_2thr_1gpu_not_allowed.cu
@@ -238,7 +238,7 @@ int main(int argc, char **argv)
 
             // Convert the first cuda native event code to a name, the name will
             // be in the format of cuda:::basename with no qualifiers appended.
-            char basename[PAPI_MAX_STR_LEN];
+            char basename[PAPI_2MAX_STR_LEN];
             check_papi_api_call( PAPI_event_code_to_name(cuda_eventcode, basename) );
 
             // Begin reconstructing the Cuda native event name with qualifiers

--- a/src/papi.c
+++ b/src/papi.c
@@ -1494,13 +1494,14 @@ PAPI_event_code_to_name( int EventCode, char *out )
 	if ( out == NULL )
 		papi_return( PAPI_EINVAL );
 
+	int compIdx;
 	if ( IS_PRESET(EventCode) ) {
 		EventCode &= PAPI_PRESET_AND_MASK;
 		if ( EventCode < 0 || EventCode >= num_all_presets )
 			papi_return( PAPI_ENOTPRESET );
 
         int preset_index = EventCode;
-        int compIdx = get_preset_cmp(&preset_index);
+        compIdx = get_preset_cmp(&preset_index);
         if( compIdx < 0 ) {
             return PAPI_ENOEVNT;
         }
@@ -1519,8 +1520,18 @@ PAPI_event_code_to_name( int EventCode, char *out )
 	}
 
 	if ( IS_NATIVE(EventCode) ) {
+		compIdx = _papi_hwi_component_index(EventCode);
+		if (compIdx < 0 ) {
+			return PAPI_ENOCMP;
+		}
+
+		int stringLength = PAPI_MAX_STR_LEN;
+		if (strcmp(_papi_hwd[compIdx]->cmp_info.name, "cuda") == 0) {
+			stringLength = PAPI_2MAX_STR_LEN;
+		}
+
 		return ( _papi_hwi_native_code_to_name
-				 ( ( unsigned int ) EventCode, out, PAPI_MAX_STR_LEN ) );
+				 ( ( unsigned int ) EventCode, out, stringLength ) );
 	}
 
 	if ( IS_USER_DEFINED(EventCode) ) {


### PR DESCRIPTION
## Pull Request Description
The Perfworks Metrics API can have metrics that are greater than `PAPI_MAX_STR_LEN`. For example:
```
cuda:::TPC.TriageCompute.tpc__l1tex_sram_bytes_mem_untagged_data_shared_allocated_compute_realtime.peak_sustained_active.per_second - 131 characters
cuda:::TPC.TriageCompute.tpc__l1tex_sram_bytes_mem_untagged_data_shared_allocated_compute_realtime.peak_sustained_elapsed.per_second - 132 characters
```

This leads to `PAPI_event_code_to_name` returning `PAPI_ENOMEM`. This behavior can be seen on Hopper1 at Oregon (1 * GH200) with the test `test_multipass_event_fail.cu`. 

This PR resolves this behavior by using `PAPI_2MAX_STR_LEN` if the eventcode provided by the user is found to be associated with the `cuda` component.

## Testing
Testing was done on Hopper1 at Oregon (CPU: ARM Neoverse-V2 , GPU: 1 * GH200) with Cuda Toolkit 12.8.1.

- PAPI build: ✅ 
- PAPI utilities*: ✅ 
- `net` component tests: ✅ 
- `coretemp` component tests: ✅ 
- `cuda` component tests: ✅ 

__*__ - `papi_command_line`, `papi_component_avail`, `papi_native_avail`

I have also verified that the ctests and ftests that call `PAPI_event_code_to_name` do not use `cuda` component native events, rather they use the `perf_event`component native events.


Note: This is a temporary fix for this issue and a longer term fix will be applied at a later date.
## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
