### PR TITLE
cuda: Use strcmp over strncmp to properly get the default statistic for ratio metrics

### DIFF
--- a/src/components/cuda/cupti_profiler.c
+++ b/src/components/cuda/cupti_profiler.c
@@ -2302,8 +2302,7 @@ static int evt_name_to_stat(const char *name, int *stat, const char *base)
         }
         int i;
         for (i = 0; i < NUM_STATS_QUALS; i++) {
-          size_t token_len = strlen(stats[i]);
-          if (strncmp(event->stat->arrayMetricStatistics[0], stats[i], token_len) == 0) {
+          if (strcmp(event->stat->arrayMetricStatistics[0], stats[i]) == 0) {
                 *stat = i;
                 return PAPI_OK;
           }


### PR DESCRIPTION
## Pull Request Description
In the master branch, if a user provides a ratio metric i.e. `cuda:::LTS.TriageCompute.lts__average_t_sector_aperture_device` without a statistic then the default statistic that is added internally ends up being `max` instead of `max_rate`.  This leads to the metric failing to be added to an EventSet:
```
[tburgess@hopper1 bin]$ ./papi_command_line cuda:::LTS.TriageCompute.lts__average_t_sector_aperture_device

This utility lets you add events from the command line interface to see if they work.

Failed adding: cuda:::LTS.TriageCompute.lts__average_t_sector_aperture_device
because: Unknown error code
No events specified!
Try running something like: ./papi_command_line PAPI_TOT_CYC
```

This PR resolves this behavior.

## Testing
Testing was done on Hopper1 at Oregon (1 * GH200) with Cuda Toolkit 12.8.1.

- PAPI build: ✅ 
- PAPI utilities*: ✅ 
- Cuda component tests: ✅ 

__*__ - `papi_component_avail`, `papi_command_line`, `papi_native_avail`

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
