### PR TITLE
cuda: Create a component test to enumerate all base native events and add them to an eventset

### DIFF
--- a/src/components/cuda/tests/Makefile
+++ b/src/components/cuda/tests/Makefile
@@ -6,7 +6,8 @@ PAPI_CUDA_ROOT ?= $(shell dirname $(shell dirname $(shell which nvcc)))
 TESTS = HelloWorld simpleMultiGPU \
 		pthreads cudaOpenMP concurrent_profiling \
 		test_multi_read_and_reset test_multipass_event_fail \
-		test_2thr_1gpu_not_allowed
+		test_2thr_1gpu_not_allowed \
+		cuda_add_all_events
 
 TESTS_NOCTX = concurrent_profiling_noCuCtx pthreads_noCuCtx \
 			  cudaOpenMP_noCuCtx HelloWorld_noCuCtx \
@@ -89,6 +90,9 @@ simpleMultiGPU: simpleMultiGPU.o cuda_tests_helper.o $(UTILOBJS)
 
 simpleMultiGPU_noCuCtx: simpleMultiGPU_noCuCtx.o cuda_tests_helper.o $(UTILOBJS)
 	$(CXX) $(CFLAGS) -o simpleMultiGPU_noCuCtx simpleMultiGPU_noCuCtx.o cuda_tests_helper.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
+
+cuda_add_all_events: cuda_add_all_events.o cuda_tests_helper.o $(UTILOBJS)
+	$(CXX) $(CFLAGS) -o cuda_add_all_events cuda_add_all_events.o cuda_tests_helper.o $(UTILOBJS) $(PAPILIB) $(CUDALIBS) $(LDFLAGS)
 
 clean:
 	rm -f *.o $(TESTS) $(TESTS_NOCTX)

--- a/src/components/cuda/tests/cuda_add_all_events.cu
+++ b/src/components/cuda/tests/cuda_add_all_events.cu
@@ -1,0 +1,148 @@
+/**
+* @file cuda_add_all_events.cu
+* @brief This test attempts to enumerate and add all base cuda native event names i.e cuda:::dram__bytes.
+*        To see cuda native events for specific NVIDIA GPUs use either the --device argument or set
+*        CUDA_VISIBLE_DEVICES.
+*
+*        Note 1: The cuda component supports being partially disabled, meaning that certain devices
+*        will not be "enabled" to profile on. If PAPI_CUDA_API is not set, then devices with
+*        CC's >= 7.0 will be used and if PAPI_CUDA_API is set to LEGACY then devices with
+*        CC's <= 7.0 will be used.
+*
+*        Note 2: If the Perfworks Metrics API is used (CC's >=7.0) this test may take 12 minutes of wall clock time to
+*        finish running.
+*/
+
+// Standard library headers
+#include <stdio.h>
+
+// Internal headers
+#include "cuda_tests_helper.h"
+#include "papi.h"
+#include "papi_test.h"
+
+static void print_help_message(void)
+{
+    printf("./cuda_add_all_events --devices [list of nvidia device indexes separated by a comma].\n"
+           "Notes:\n"
+           "1. CUDA_VISIBLE_DEVICES will be set IF device indexes have been provided to the arg --devices.\n");
+}
+
+static void parse_and_assign_args(int argc, char *argv[], char **device_indexes)
+{
+    int i;
+    for (i = 1; i < argc; ++i)
+    {
+        char *arg = argv[i];
+        if (strcmp(arg, "--help") == 0)
+        {
+            print_help_message();
+            exit(EXIT_SUCCESS);
+        }
+        else if (strcmp(arg, "--devices") == 0)
+        {
+            if (!argv[i + 1])
+            {
+                printf("ERROR!! Add a nvidia device index.\n");
+                exit(EXIT_FAILURE);
+            }
+            *device_indexes = argv[i + 1];
+            i++;
+        }
+        else
+        {
+            print_help_message();
+            exit(EXIT_FAILURE);
+        }
+    }
+}
+
+int main(int argc, char **argv)
+{
+    // Determine the number of Cuda capable devices
+    int num_devices = 0;
+    check_cuda_runtime_api_call( cudaGetDeviceCount(&num_devices) );
+
+    // No devices detected on the machine, exit
+    if (num_devices < 1) {
+        fprintf(stderr, "No NVIDIA devices found on the machine. This is required for the test to run. Exiting.\n");
+        exit(EXIT_FAILURE);
+    }
+
+    char *device_indexes = NULL;
+    parse_and_assign_args(argc, argv, &device_indexes);
+    if (device_indexes != NULL) {
+        int overwrite = 0;
+        int setenv_errno = setenv("CUDA_VISIBLE_DEVICES", device_indexes, overwrite);
+        if (setenv_errno == -1) {
+            fprintf(stderr, "Failed to set CUDA_VISIBLE_DEVICES to %s. Proceeding.\n", device_indexes);
+        }
+    }
+
+    int suppress_output = 0;
+    char *user_defined_suppress_output = getenv("PAPI_CUDA_TEST_QUIET");
+    if (user_defined_suppress_output) {
+        suppress_output = (int) strtol(user_defined_suppress_output, (char**) NULL, 10);
+    }
+    PRINT(suppress_output, "Running the cuda component test cudaOpenMP.cu\n");
+
+    // Initialize the PAPI library
+    int papi_errno = PAPI_library_init( PAPI_VER_CURRENT );
+    if( papi_errno != PAPI_VER_CURRENT ) {
+        test_fail(__FILE__,__LINE__, "PAPI_library_init()", papi_errno);
+    }
+    PRINT(suppress_output, "PAPI version being used for this test: %d.%d.%d\n",
+          PAPI_VERSION_MAJOR(PAPI_VERSION),
+          PAPI_VERSION_MINOR(PAPI_VERSION),
+          PAPI_VERSION_REVISION(PAPI_VERSION));
+
+    const char *component_name = "cuda";
+    int cidx = PAPI_get_component_index(component_name);
+    if (cidx < 0) {
+        test_fail(__FILE__, __LINE__, "PAPI_get_component_index()", PAPI_ENOCMP);
+    }
+
+    int eventCode = 0 | PAPI_NATIVE_MASK;
+    int modifier = PAPI_ENUM_FIRST;
+    check_papi_api_call( PAPI_enum_cmp_event(&eventCode, modifier, cidx) );
+
+    modifier = PAPI_ENUM_EVENTS;
+    int baseEventIndex = 0;
+    do {
+        long long counterValue = 0;
+        PAPI_event_info_t eventInfo;
+        check_papi_api_call( PAPI_get_event_info(eventCode, &eventInfo) );
+        int isWithoutSubmetric = verify_event_is_without_submetric(eventInfo.symbol);
+        // Skip native events that have submetrics appended to them
+        if (isWithoutSubmetric == 0) {
+            continue;
+        }
+
+        int eventSet = PAPI_NULL;
+        check_papi_api_call( PAPI_create_eventset(&eventSet) );
+
+        papi_errno = PAPI_add_named_event(eventSet, eventInfo.symbol);
+        if (papi_errno != PAPI_OK) {
+            // PAPI does not support multiple pass events. Skipping.
+            if (papi_errno == PAPI_EMULPASS) {
+                goto cleanup;
+            }
+        }
+
+        check_papi_api_call( PAPI_start(eventSet) );
+
+        check_papi_api_call( PAPI_stop(eventSet, &counterValue) );
+
+        printf("Base Event#: %d\n", baseEventIndex++);
+        printf("PAPI Eventcode: %#x\n", eventInfo.event_code);
+        printf("PAPI Eventname: %s\n", eventInfo.symbol);
+        printf("PAPI Longdescr: %s\n", eventInfo.long_descr);
+        printf("PAPI Countervalue: %lld\n\n", counterValue);
+
+      cleanup:
+        check_papi_api_call( PAPI_cleanup_eventset(eventSet) );
+        check_papi_api_call( PAPI_destroy_eventset(&eventSet) );
+    } while (PAPI_enum_cmp_event(&eventCode, modifier, cidx) == PAPI_OK);
+
+    return 0;
+}

--- a/src/components/cuda/tests/cuda_tests_helper.c
+++ b/src/components/cuda/tests/cuda_tests_helper.c
@@ -175,3 +175,46 @@ void enumerate_and_store_cuda_native_events(char ***cuda_native_event_names, int
 
     return;
 }
+
+/** @class verify_event_is_without_submetric
+  * @brief Verify that the provided eventname is without its submetric.
+  *
+  * @param *eventName
+  *   Cuda native event name.
+*/
+int  verify_event_is_without_submetric(const char *eventName)
+{
+    int currentNumberOfSubmetrics = 21;
+    char subMetricNamesArray[currentNumberOfSubmetrics][PAPI_MAX_STR_LEN] = {
+        "peak_sustained",
+        "peak_sustained_active",
+        "peak_sustained_active.per_second",
+        "peak_sustained_elapsed",
+        "peak_sustained_elapsed.per_second",
+        "peak_sustained_frame",
+        "peak_sustained_frame.per_second",
+        "peak_sustained_region",
+        "peak_sustained_region.per_second",
+        "per_cycle_active",
+        "per_cycle_elapsed",
+        "per_cycle_in_frame",
+        "per_cycle_in_region",
+        "per_second",
+        "pct_of_peak_sustained_active",
+        "pct_of_peak_sustained_elapsed",
+        "pct_of_peak_sustained_frame",
+        "pct_of_peak_sustained_region",
+        "max_rate",
+        "pct",
+        "ratio"
+    };
+
+    int entryIdx;
+    for (entryIdx = 0; entryIdx < currentNumberOfSubmetrics; entryIdx++) {
+        if (strstr(eventName, subMetricNamesArray[entryIdx])) {
+            return 0;
+        }
+    }
+
+    return 1;
+}

--- a/src/components/cuda/tests/cuda_tests_helper.h
+++ b/src/components/cuda/tests/cuda_tests_helper.h
@@ -6,6 +6,7 @@
 void add_cuda_native_events(int EventSet, const char *cuda_native_event_name, int *num_events_successfully_added, char **events_successfully_added, int *numMultipassEvents);
 int determine_if_device_is_enabled(int device_idx);
 void enumerate_and_store_cuda_native_events(char ***cuda_native_event_names, int *total_event_count, int *cuda_device_index);
+int  verify_event_is_without_submetric(const char *eventName);
 
 // Define to handle suppress print output for the cuda component tests
 #define PRINT(global_suppress_output, format, args...)                          \


### PR DESCRIPTION
## Pull Request Description
This new cuda component test will enumerate all events on the machine and attempt to add them to a PAPI Eventset one by one. For each added event, a `PAPI_start` and `PAPI_stop` call follows. Output is as follows:
```
Base Event#: 2875
PAPI Eventcode: 0x4000df5e
PAPI Eventname: cuda:::smsp__warp_issue_stalled_misc_per_warp_active
PAPI Longdescr: proportion of warps per cycle, waiting on a miscellaneous hardware reason. Units=(unitless). Numpass=1.
PAPI Countervalue: 1

Base Event#: 2876
PAPI Eventcode: 0x4000df60
PAPI Eventname: cuda:::smsp__warp_issue_stalled_no_instruction_per_warp_active
PAPI Longdescr: proportion of warps per cycle, waiting to be selected for instruction fetch, or waiting on an instruction cache miss. Units=(unitless). Numpass=1.
PAPI Countervalue: 1

```

Note: This test can take up to 12 minutes of wall clock time to complete; therefore, it will not be added to the `run_cuda_tests.sh` script.

## Testing

Testing was done on Voltar at Oregon (1 * A100, 1 * V100) with Cuda Toolkit 12.9.

- `cuda_add_all_events.cu`: ✅ 

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
