### PR TITLE
Update papi_events.csv - Granite Rapids

### DIFF
--- a/src/papi_events.csv
+++ b/src/papi_events.csv
@@ -1033,6 +1033,7 @@ PRESET,PAPI_VEC_INS,DERIVED_POSTFIX,N0|N1|N2|N3|N4|N5|+|+|+|+|+|,FP_ARITH_INST_R
 # End of icx, icl list
 
 # Intel Sapphire Rapids and Emerald Rapids events
+CPU,gnr
 CPU,emr
 CPU,spr
 PRESET,PAPI_TOT_CYC,NOT_DERIVED,CPU_CLK_UNHALTED:THREAD_P


### PR DESCRIPTION
- [ ] **Description**
Events available for spr, emr and gnr are the same as far as I can tell. So the PAPI presets for spr and emr will work well for gnr too. There are some differences in libpfm4 as to uncore events, that may need some further attention, but this at least makes PAPI recognize the architecture and provide a decent set of basic preset events.

- [ ] **Tests**
papi_avail and friends appear to work fine on gnr when this commit is applied.
