### PR TITLE
topdown: Add component name (topdown:::) to topdown native events found in topdown_L1.c and topdown_L2.c

### DIFF
--- a/src/components/topdown/tests/topdown_L1.c
+++ b/src/components/topdown/tests/topdown_L1.c
@@ -101,25 +101,25 @@ int main(int argc, char **argv)
 	}
 
 	/* Add the level 1 topdown metrics */
-	retval = PAPI_add_named_event(EventSet, "TOPDOWN_RETIRING_PERC");
+	retval = PAPI_add_named_event(EventSet, "topdown:::TOPDOWN_RETIRING_PERC");
 	if (retval != PAPI_OK)
 	{
 		test_fail(__FILE__, __LINE__,
 			"Error adding TOPDOWN_RETIRING_PERC", retval);
 	}
-	retval = PAPI_add_named_event(EventSet, "TOPDOWN_BAD_SPEC_PERC");
+	retval = PAPI_add_named_event(EventSet, "topdown:::TOPDOWN_BAD_SPEC_PERC");
 	if (retval != PAPI_OK)
 	{
 		test_fail(__FILE__, __LINE__,
 			"Error adding TOPDOWN_BAD_SPEC_PERC", retval);
 	}
-	retval = PAPI_add_named_event(EventSet, "TOPDOWN_FE_BOUND_PERC");
+	retval = PAPI_add_named_event(EventSet, "topdown:::TOPDOWN_FE_BOUND_PERC");
 	if (retval != PAPI_OK)
 	{
 		test_fail(__FILE__, __LINE__,
 			"Error adding TOPDOWN_FE_BOUND_PERC", retval);
 	}
-	retval = PAPI_add_named_event(EventSet, "TOPDOWN_BE_BOUND_PERC");
+	retval = PAPI_add_named_event(EventSet, "topdown:::TOPDOWN_BE_BOUND_PERC");
 	if (retval != PAPI_OK)
 	{
 		test_fail(__FILE__, __LINE__,

--- a/src/components/topdown/tests/topdown_L2.c
+++ b/src/components/topdown/tests/topdown_L2.c
@@ -102,13 +102,13 @@ int main(int argc, char **argv)
 
 	/* Add the level 2 topdown metrics */
 	/* if we can't, just skip because not all processors support level 2 */
-	retval = PAPI_add_named_event(EventSet, "TOPDOWN_HEAVY_OPS_PERC");
+	retval = PAPI_add_named_event(EventSet, "topdown:::TOPDOWN_HEAVY_OPS_PERC");
 	if (retval != PAPI_OK)
 	{
 		test_skip(__FILE__, __LINE__,
 			"Error adding TOPDOWN_HEAVY_OPS_PERC", retval);
 	}
-	retval = PAPI_add_named_event(EventSet, "TOPDOWN_LIGHT_OPS_PERC");
+	retval = PAPI_add_named_event(EventSet, "topdown:::TOPDOWN_LIGHT_OPS_PERC");
 	if (retval != PAPI_OK)
 	{
 		/* if the first L2 event was successfully added though, */
@@ -116,37 +116,37 @@ int main(int argc, char **argv)
 		test_fail(__FILE__, __LINE__,
 			"Error adding TOPDOWN_LIGHT_OPS_PERC", retval);
 	}
-	retval = PAPI_add_named_event(EventSet, "TOPDOWN_BR_MISPREDICT_PERC");
+	retval = PAPI_add_named_event(EventSet, "topdown:::TOPDOWN_BR_MISPREDICT_PERC");
 	if (retval != PAPI_OK)
 	{
 		test_fail(__FILE__, __LINE__,
 			"Error adding TOPDOWN_BR_MISPREDICT_PERC", retval);
 	}
-	retval = PAPI_add_named_event(EventSet, "TOPDOWN_MACHINE_CLEARS_PERC");
+	retval = PAPI_add_named_event(EventSet, "topdown:::TOPDOWN_MACHINE_CLEARS_PERC");
 	if (retval != PAPI_OK)
 	{
 		test_fail(__FILE__, __LINE__,
 			"Error adding TOPDOWN_MACHINE_CLEARS_PERC", retval);
 	}
-	retval = PAPI_add_named_event(EventSet, "TOPDOWN_FETCH_LAT_PERC");
+	retval = PAPI_add_named_event(EventSet, "topdown:::TOPDOWN_FETCH_LAT_PERC");
 	if (retval != PAPI_OK)
 	{
 		test_fail(__FILE__, __LINE__,
 			"Error adding TOPDOWN_FETCH_LAT_PERC", retval);
 	}
-	retval = PAPI_add_named_event(EventSet, "TOPDOWN_FETCH_BAND_PERC");
+	retval = PAPI_add_named_event(EventSet, "topdown:::TOPDOWN_FETCH_BAND_PERC");
 	if (retval != PAPI_OK)
 	{
 		test_fail(__FILE__, __LINE__,
 			"Error adding TOPDOWN_FETCH_BAND_PERC", retval);
 	}
-	retval = PAPI_add_named_event(EventSet, "TOPDOWN_MEM_BOUND_PERC");
+	retval = PAPI_add_named_event(EventSet, "topdown:::TOPDOWN_MEM_BOUND_PERC");
 	if (retval != PAPI_OK)
 	{
 		test_fail(__FILE__, __LINE__,
 			"Error adding TOPDOWN_MEM_BOUND_PERC", retval);
 	}
-	retval = PAPI_add_named_event(EventSet, "TOPDOWN_CORE_BOUND_PERC");
+	retval = PAPI_add_named_event(EventSet, "topdown:::TOPDOWN_CORE_BOUND_PERC");
 	if (retval != PAPI_OK)
 	{
 		test_fail(__FILE__, __LINE__,


### PR DESCRIPTION
## Pull Request Description
Currently in the master branch the `topdown` component tests `topdown_L1.c` and `topdown_L2.c` will not successfully run as the hardcoded native events lack the component name `topdown:::`.

This PR resolves this behavior by adding the component name `topdown:::` to each hardcoded native event.

### Testing
Testing was done on Headroom at Oregon (Intel(R) Xeon(R) Silver 4410T).

- PAPI build: ✅ 
- PAPI utilities*: ✅ 
- `topdown_L1.c`: ✅ 
- `topdown_L2.c`: ✅ 

__*__ - `papi_component_avail`, `papi_command_line`, `papi_native_avail`

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
