### PR TITLE
cuda: Resolve compilation warnings

### DIFF
--- a/src/components/cuda/papi_cupti_common.c
+++ b/src/components/cuda/papi_cupti_common.c
@@ -961,7 +961,7 @@ int verify_driver_branch_supports_legacy_apis(sys_compute_capabilities_e ccs_on_
     long int driverBranchDecimal = strtol(driverBranch, NULL, base);
     if (driverBranchDecimal >= 580) {
         char errorMessage[PAPI_HUGE_STR_LEN] = { 0 };
-        int strLen = snprintf(errorMessage, sizeof(errorMessage), "The Legacy APIs (Event and Metric) are not supported with driver branchs >= 580 (detected driver branch is %d)."
+        int strLen = snprintf(errorMessage, sizeof(errorMessage), "The Legacy APIs (Event and Metric) are not supported with driver branchs >= 580 (detected driver branch is %ld)."
                              " To use the Legacy APIs you must use a driver branch <= 575.", driverBranchDecimal);
         if (strLen < 0 || (size_t) strLen >= sizeof(errorMessage)) {
             SUBDBG("Failed to fully store string into buffer. Proceeding, but the sring has been truncated.\n");

--- a/src/components/cuda/tests/concurrent_profiling.cu
+++ b/src/components/cuda/tests/concurrent_profiling.cu
@@ -128,7 +128,7 @@ static void add_cuda_native_events_concurrent(int EventSet, string cuda_native_e
    int papi_errno = PAPI_add_named_event(EventSet, cuda_native_event_name.c_str());
    if (papi_errno != PAPI_OK) {
        if (papi_errno != PAPI_EMULPASS) {
-           fprintf(stderr, "Unable to add event %s to the EventSet with error code %d.\n", cuda_native_event_name, papi_errno);
+           fprintf(stderr, "Unable to add event %s to the EventSet with error code %d.\n", cuda_native_event_name.c_str(), papi_errno);
            exit(EXIT_FAILURE);
        }
        
@@ -404,13 +404,13 @@ int main(int argc, char **argv)
     profileKernels(device_data[0], base_cuda_native_event_names_with_stat_qual, "single_device_serial", true);
 
     auto end_time = ::std::chrono::high_resolution_clock::now();
-    auto elapsed_serial_ms = ::std::chrono::duration_cast<::std::chrono::milliseconds>(end_time - begin_time).count();
+    long elapsed_serial_ms = ::std::chrono::duration_cast<::std::chrono::milliseconds>(end_time - begin_time).count();
     int numBlocks = 0;
     for (i = 1; i <= numKernels; i++)
     {
         numBlocks += i;
     }
-    PRINT(global_suppress_output, "It took %d ms on the host to profile %d kernels in serial.\n", elapsed_serial_ms, numKernels);
+    PRINT(global_suppress_output, "It took %ld ms on the host to profile %d kernels in serial.\n", elapsed_serial_ms, numKernels);
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Second version - same kernel calls as before on the same device, but now using separate streams for concurrency, //
@@ -424,8 +424,8 @@ int main(int argc, char **argv)
     profileKernels(device_data[0], base_cuda_native_event_names_with_stat_qual, "single_device_async", false);
 
     end_time = ::std::chrono::high_resolution_clock::now();
-    int elapsed_single_device_ms = ::std::chrono::duration_cast<::std::chrono::milliseconds>(end_time - begin_time).count();
-    PRINT(global_suppress_output, "It took %d ms on the host to profile %d kernels on a single device on separate streams.\n", elapsed_single_device_ms, numKernels);
+    long elapsed_single_device_ms = ::std::chrono::duration_cast<::std::chrono::milliseconds>(end_time - begin_time).count();
+    PRINT(global_suppress_output, "It took %ld ms on the host to profile %d kernels on a single device on separate streams.\n", elapsed_single_device_ms, numKernels);
     PRINT(global_suppress_output, "--> If the separate stream wallclock time is less than the serial version, the streams were profiling concurrently.\n");
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -500,7 +500,7 @@ int main(int argc, char **argv)
 
     for (i = 1; i < num_devices; i++)
     {
-        PRINT(global_suppress_output, "\nMetrics for device #%d:\n", i);
+        PRINT(global_suppress_output, "\nMetrics for device #%zu:\n", i);
         print_measured_values(device_data[i]);
     }
 

--- a/src/components/cuda/tests/concurrent_profiling_noCuCtx.cu
+++ b/src/components/cuda/tests/concurrent_profiling_noCuCtx.cu
@@ -127,7 +127,7 @@ static void add_cuda_native_events_concurrent(int EventSet, string cuda_native_e
    int papi_errno = PAPI_add_named_event(EventSet, cuda_native_event_name.c_str());
    if (papi_errno != PAPI_OK) {
        if (papi_errno != PAPI_EMULPASS) {
-           fprintf(stderr, "Unable to add event %s to the EventSet with error code %d.\n", cuda_native_event_name, papi_errno);
+           fprintf(stderr, "Unable to add event %s to the EventSet with error code %d.\n", cuda_native_event_name.c_str(), papi_errno);
            exit(EXIT_FAILURE);
        }   
     
@@ -393,13 +393,13 @@ int main(int argc, char **argv)
     profileKernels(device_data[0], base_cuda_native_event_names_with_stat_qual, "single_device_serial", true);
 
     auto end_time = ::std::chrono::high_resolution_clock::now();
-    auto elapsed_serial_ms = ::std::chrono::duration_cast<::std::chrono::milliseconds>(end_time - begin_time).count();
+    long elapsed_serial_ms = ::std::chrono::duration_cast<::std::chrono::milliseconds>(end_time - begin_time).count();
     int numBlocks = 0;
     for (i = 1; i <= numKernels; i++)
     {   
         numBlocks += i;
     }   
-    PRINT(global_suppress_output, "It took %d ms on the host to profile %d kernels in serial.\n", elapsed_serial_ms, numKernels);
+    PRINT(global_suppress_output, "It took %ld ms on the host to profile %d kernels in serial.\n", elapsed_serial_ms, numKernels);
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Second version - same kernel calls as before on the same device, but now using separate streams for concurrency, //
@@ -413,8 +413,8 @@ int main(int argc, char **argv)
     profileKernels(device_data[0], base_cuda_native_event_names_with_stat_qual, "single_device_async", false);
 
     end_time = ::std::chrono::high_resolution_clock::now();
-    int elapsed_single_device_ms = ::std::chrono::duration_cast<::std::chrono::milliseconds>(end_time - begin_time).count();
-    PRINT(global_suppress_output, "It took %d ms on the host to profile %d kernels on a single device on separate streams.\n", elapsed_single_device_ms, numKernels);
+    long elapsed_single_device_ms = ::std::chrono::duration_cast<::std::chrono::milliseconds>(end_time - begin_time).count();
+    PRINT(global_suppress_output, "It took %ld ms on the host to profile %d kernels on a single device on separate streams.\n", elapsed_single_device_ms, numKernels);
     PRINT(global_suppress_output, "--> If the separate stream wallclock time is less than the serial version, the streams were profiling concurrently.\n");
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -489,7 +489,7 @@ int main(int argc, char **argv)
 
     for (i = 1; i < num_devices; i++)
     {   
-        PRINT(global_suppress_output, "\nMetrics for device #%d:\n", i); 
+        PRINT(global_suppress_output, "\nMetrics for device #%zu:\n", i);
         print_measured_values(device_data[i]);
     }   
 


### PR DESCRIPTION
## Pull Request Description
This PR resolves Issue #604.

## Testing
Testing was done on Heimdall at Oregon (1 * RTX 5080) with Cuda Toolkit 12.9.

- Compilation warnings from Issue #604 gone: ✅ 
- PAPI build: ✅ 
- PAPI utilities*: ✅ 
- Cuda component tests: ✅

__*__ - `papi_component_avail`, `papi_native_avail`, `papi_command_line`


## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
