### PR TITLE
nvml: resolve deprecation warnings

### DIFF
--- a/src/components/nvml/tests/Makefile
+++ b/src/components/nvml/tests/Makefile
@@ -11,6 +11,15 @@ NVCFLAGS = -I$(PAPI_NVML_INC) -ccbin='$(CC)' $(NVPPC64LEFLAGS)
 CUDALIBS = -L$(PAPI_NVML_LIB) -L$(PAPI_CUDA_ROOT)/lib64 -lcuda -lcudart -lnvidia-ml -lstdc++
 PAPILIB := ../../../libpapi.a  -ldl
 
+NVCC_VERSION := $(shell $(NVCC) --version | grep -oP '(?<=release )\d+\.\d+')
+
+# Check to see if the Cuda Toolkit version is either 12.8 or 12.9 such that
+# we can add -Wno-deprecated-gpu-targets to avoid compilation warning
+CUDA_TOOLKIT_EQUAL_TO_12_8_OR_12_9 := $(shell echo "$(NVCC_VERSION)" | awk '{print ($$1 == 12.8 || $$1 == 12.9)}')
+ifeq ($(CUDA_TOOLKIT_EQUAL_TO_12_8_OR_12_9), 1)
+    NVCFLAGS += -Wno-deprecated-gpu-targets
+endif
+
 %.o:%.cu
 	$(NVCC) $(NVCFLAGS) $(INCLUDE) -c -o $@ $<
 


### PR DESCRIPTION
## Pull Request Description

Resolve warnings from nvcc about support for offline compilation for certain architectures being removed in the future.

These changes have been tested on a system containing an NVIDIA GeForce RTX 5080 device (Blackwell architecture) using CUDA version 12.9.41.

This PR resolves Issue #610.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
