### PR TITLE
PAPI debug: Explicitly include unistd.h for getpid

### DIFF
--- a/src/papi_debug.h
+++ b/src/papi_debug.h
@@ -21,6 +21,7 @@
 #endif
 
 #include <stdio.h>
+#include <unistd.h>
 
 /* Debug Levels */
 


### PR DESCRIPTION
## Pull Request Description
During development of the `cuda_range` component, I encountered the below compilation error on Godzilla at Oregon (CPU: Intel Xeon CPU E5-2680, GPU: NVIDIA RTX PRO 6000 Blackwell, GCC 8.5.0):
```
components/cuda_range/cupti_range_profiler.cpp: In function ‘void* search_and_load_shared_objects(std::__cxx11::string, const char*, std::vector<std::__cxx11::basic_string<char> >)’:
./papi_debug.h:54:122: error: ‘getpid’ was not declared in this scope
 #define DEBUGLABEL(a) if (_papi_hwi_thread_id_fn) fprintf(stderr, "%s:%s:%s:%d:%d:%#lx ",a,__FILE__, FUNC, __LINE__,(int)getpid(),_papi_hwi_thread_id_fn()); else fprintf(stderr, "%s:%s:%s:%d:%d ",a,__FILE__, FUNC, __LINE__, (int)getpid())
```

To resolve this error, `unistd.h` must be included in `papi_debug.h` as the declaration of `getpid` lives there.

I did not encounter this behavior on Methane at ICL; however, this is most likely due to an implicit include for `unistd.h` occurring. It is considered best practice to be explicit about includes that are needed.

## Testing
After adding `#include <unistd.h>` to `papi_debug.h` the `cuda_range` component compiled fine.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
