### PR TITLE
PAPI examples: Update src/examples to remove compilation warnings and properly run

### DIFF
--- a/src/examples/PAPI_get_opt.c
+++ b/src/examples/PAPI_get_opt.c
@@ -55,6 +55,16 @@ int main()
    if ((retval=PAPI_create_eventset(&EventSet)) != PAPI_OK)
       ERROR_RETURN(retval);
 
+   /* NOTE: For some options, PAPI_set_opt requires the EventSet be bound to a
+      component */
+   /* Add Total Instructions Executed event to the EventSet */
+   if ( (retval = PAPI_add_event(EventSet, PAPI_TOT_INS)) != PAPI_OK)
+      ERROR_RETURN(retval);
+
+   /* Add Total Cycles Executed event to the EventSet */
+   if ( (retval = PAPI_add_event(EventSet, PAPI_TOT_CYC)) != PAPI_OK)
+      ERROR_RETURN(retval);
+
    /* Set the domain of this EventSet to counter user and 
       kernel modes for this process.                      */
         
@@ -65,13 +75,6 @@ int main()
    options.domain.domain = PAPI_DOM_ALL;
    /* this sets the options for the domain */
    if ((retval=PAPI_set_opt(PAPI_DOMAIN, &options)) != PAPI_OK)
-      ERROR_RETURN(retval);
-   /* Add Total Instructions Executed event to the EventSet */
-   if ( (retval = PAPI_add_event(EventSet, PAPI_TOT_INS)) != PAPI_OK)
-      ERROR_RETURN(retval);
-
-   /* Add Total Cycles Executed event to the EventSet */
-   if ( (retval = PAPI_add_event(EventSet, PAPI_TOT_CYC)) != PAPI_OK)
       ERROR_RETURN(retval);
 
    /* Start counting */

--- a/src/examples/PAPI_reset.c
+++ b/src/examples/PAPI_reset.c
@@ -58,29 +58,31 @@ int main()
       ERROR_RETURN(retval);
 
    poorly_tuned_function();
- 
-   /* Stop counting */
-   if((retval=PAPI_stop(EventSet, values)) != PAPI_OK)
-      ERROR_RETURN(retval);
 
+   /* Perform first read */
+   if((retval=PAPI_read(EventSet, values)) != PAPI_OK)
+      ERROR_RETURN(retval);
 
    printf("The first time read value is %lld\n",values[0]);
 
+   poorly_tuned_function();
+
+   /* Perform second read */
+   if((retval=PAPI_read(EventSet, values)) != PAPI_OK)
+      ERROR_RETURN(retval);
+
+   printf("The second time read value is %lld\n",values[0]);
+
+   printf("---Resetting the counter values---\n");
    /* This zeroes out the counters on the eventset that was created */
    if((retval=PAPI_reset(EventSet)) != PAPI_OK)
       ERROR_RETURN(retval);
 
-      /* Start counting */
-   if((retval=PAPI_start(EventSet)) != PAPI_OK)
-      ERROR_RETURN(retval);
-
-   poorly_tuned_function();
- 
    /* Stop counting */
    if((retval=PAPI_stop(EventSet, values)) != PAPI_OK)
       ERROR_RETURN(retval);
 
-   printf("The second time read value is %lld\n",values[0]);
+   printf("The final read value (via PAPI_stop) after PAPI_reset is %lld\n",values[0]);
    
    /* free the resources used by PAPI */
    PAPI_shutdown();

--- a/src/examples/PAPI_set_domain.c
+++ b/src/examples/PAPI_set_domain.c
@@ -7,6 +7,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 #include "papi.h" /* This needs to be included every time you use PAPI */
 

--- a/src/examples/PAPI_state.c
+++ b/src/examples/PAPI_state.c
@@ -11,6 +11,24 @@
 
 #define ERROR_RETURN(retval) { fprintf(stderr, "Error %d %s:line %d: \n", retval,__FILE__,__LINE__);  exit(retval); }
 
+int printstate(int status)
+{
+   if(status & PAPI_STOPPED)
+      printf("Eventset is currently stopped or inactive \n");
+   if(status & PAPI_RUNNING)
+      printf("Eventset is currently running \n");
+   if(status & PAPI_PAUSED)
+      printf("Eventset is currently Paused \n");
+   if(status & PAPI_NOT_INIT)
+      printf(" Eventset defined but not initialized \n");
+   if(status & PAPI_OVERFLOWING)
+      printf(" Eventset has overflowing enabled \n");
+   if(status & PAPI_PROFILING)
+      printf(" Eventset has profiling enabled \n");
+   if(status & PAPI_MULTIPLEXING)
+      printf(" Eventset has multiplexing enabled \n");
+   return 0;
+}
 
 int main()
 {
@@ -58,23 +76,4 @@ int main()
    PAPI_shutdown();
 
    exit(0);
-}
-
-int printstate(int status)
-{
-   if(status & PAPI_STOPPED)
-      printf("Eventset is currently stopped or inactive \n");
-   if(status & PAPI_RUNNING)
-      printf("Eventset is currently running \n");
-   if(status & PAPI_PAUSED)
-      printf("Eventset is currently Paused \n");
-   if(status & PAPI_NOT_INIT) 
-      printf(" Eventset defined but not initialized \n");
-   if(status & PAPI_OVERFLOWING)
-      printf(" Eventset has overflowing enabled \n");
-   if(status & PAPI_PROFILING)
-      printf(" Eventset has profiling enabled \n"); 
-   if(status & PAPI_MULTIPLEXING)
-      printf(" Eventset has multiplexing enabled \n"); 
-   return 0;
 }

--- a/src/examples/locks_pthreads.c
+++ b/src/examples/locks_pthreads.c
@@ -8,6 +8,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>
+#include <unistd.h>
+
 #include "papi.h" /* This needs to be included every time you use PAPI */
 
 #define ERROR_RETURN(retval) { fprintf(stderr, "Error %d %s:line %d: \n", retval,__FILE__,__LINE__);  exit(retval); }

--- a/src/examples/multiplex.c
+++ b/src/examples/multiplex.c
@@ -56,16 +56,23 @@ int multiplex(void)
    if (retval != PAPI_OK)
       ERROR_RETURN(retval);
 
+   const char *component_name = "perf_event";
+   int cidx = PAPI_get_component_index(component_name);
+   if (cidx < 0) {
+       printf("PAPI_get_component_index failed (%d) to get the component index for %s", component_name);
+       exit(1);
+   }
+
+   /* EventSet must be bound to a component before calling PAPI_set_multiplex( ... ) */
+   retval = PAPI_assign_eventset_component(EventSet, cidx);
+   if (retval != PAPI_OK) {
+       ERROR_RETURN(retval);
+   }
+
    /* convert the event set to a multiplex event set */
    retval = PAPI_set_multiplex(EventSet);
    if (retval != PAPI_OK)
       ERROR_RETURN(retval);
-/*
-   retval = PAPI_add_event(EventSet, PAPI_TOT_INS);
-   if ((retval != PAPI_OK) && (retval != PAPI_ECNFLCT))
-      ERROR_RETURN(retval);
-   printf("Adding %s\n", "PAPI_TOT_INS");
-*/
 
    for (i = 0; i < PAPI_MAX_PRESET_EVENTS; i++) 
    {


### PR DESCRIPTION
## Pull Request Description
A user would encounter the following if running `make` under `src/examples`:
```
PAPI_state.c:46:4: warning: implicit declaration of function ‘printstate’; did you mean ‘initstate’? [-Wimplicit-function-declaration]
   46 |    printstate(status);
      |    ^~~~~~~~~~
      |    initstate
PAPI_set_domain.c: In function ‘main’:
PAPI_set_domain.c:78:4: warning: implicit declaration of function ‘close’; did you mean ‘pclose’? [-Wimplicit-function-declaration]
   78 |    close(fd);
      |    ^~~~~
      |    pclose
locks_pthreads.c:39:4: warning: implicit declaration of function ‘usleep’ [-Wimplicit-function-declaration]
   39 |    usleep(SLEEP_VALUE);
      |    ^~~~~~
```

Furthermore, a user would encounter errors/incorrect behavior with the following tests:
1. `PAPI_get_opt.c` - the EventSet was not bound to a component before calling `PAPI_set_opt( ... )`
2. `multiplex.c` - the EventSet was not bound to a component before calling `PAPI_set_multiplex( ... )`
3. `PAPI_reset.c` - did not properly show an EventSet's counter values being reset as the `perf_event` component resets counter values upon the call to `PAPI_start`

All of the above is resolved in this PR.

## Testing
Testing was done on Godzilla at Oregon (Intel Xeon Gold E5-2680 v4) and from testing the aforementioned compilation warnings are resolved and the updated examples run successfully.



## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
