### PR TITLE
06 16 2026 resolve issue 87

### DIFF
--- a/src/components/host_micpower/utils/Makefile
+++ b/src/components/host_micpower/utils/Makefile
@@ -1,4 +1,4 @@
-CC = gcc
+CC ?= gcc
 CFLAGS = -O2 -Wall
 LFLAGS = 
 PAPI_INCLUDE = ../../..

--- a/src/components/powercap/utils/Makefile
+++ b/src/components/powercap/utils/Makefile
@@ -1,4 +1,4 @@
-CC = gcc
+CC ?= gcc
 CFLAGS = -O2 -Wall -fopenmp
 LFLAGS = 
 PAPI_INCLUDE = ../../.. 
@@ -14,4 +14,3 @@ powercap_plot.o:	powercap_plot.c
 
 clean:	
 	rm -f *~ *.o powercap_plot results*
-

--- a/src/components/rapl/utils/Makefile
+++ b/src/components/rapl/utils/Makefile
@@ -1,4 +1,4 @@
-CC = gcc
+CC ?= gcc
 CFLAGS = -O2 -Wall
 LFLAGS = 
 PAPI_INCLUDE = ../../..

--- a/src/examples/Makefile
+++ b/src/examples/Makefile
@@ -1,6 +1,6 @@
 PAPIINC = ..
 PAPILIB = ../libpapi.a
-CC = gcc
+CC ?= gcc
 CFLAGS += -I$(PAPIINC)
 OS = $(shell uname)
 


### PR DESCRIPTION
## Pull Request Description
This PR closes #87  by updating the following Makefiles to use `CC ?=` instead of `CC=`:
```
components/host_micpower/utils/Makefile
components/powercap/utils/Makefile
components/rapl/utils/Makefile
examples/Makefile
```

## Testing
For `examples/Makefile` and `components/powercap/utils/Makefile`, testing took place on Picard at Oregon (Intel Xeon Gold 6430). In both cases, respective source code was successfully compiled and ran when exporting CC to an LLVM compiler (14.0.6) on the command line. 

For `components/rapl/utils/Makefile`, testing took place on Hexane at ICL (Intel Xeon Silver 4309Y). In this single case, the respective source code was successfully compiled and ran when exporting CC to an LLVM compiler (14.0.6) on the command line.

`components/host_micpower/utils/Makefile` was unable to be tested.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
