### PR TITLE
intel_gpu: Add component prefix for default native events in intel_gpu/tests

### DIFF
--- a/src/components/intel_gpu/tests/gpu_common_utils.c
+++ b/src/components/intel_gpu/tests/gpu_common_utils.c
@@ -37,9 +37,9 @@ extern "C" {
 #endif
 
 const char *default_metrics[] = {
-				"ComputeBasic.GpuTime",
-				"ComputeBasic.GpuCoreClocks",
-				"ComputeBasic.AvgGpuCoreFrequencyMHz",
+				"intel_gpu:::ComputeBasic.GpuTime",
+				"intel_gpu:::ComputeBasic.GpuCoreClocks",
+				"intel_gpu:::ComputeBasic.AvgGpuCoreFrequencyMHz",
 };
 
 int	num_default_metrics = 3;


### PR DESCRIPTION
## Pull Request Description
PR #528  introduced the requirement of appending a component prefix name (i.e. `cuda`, `rocm`, etc.) to a native event. Therefore, a native event name passed to `PAPI_add_named_event` without a component prefix name will result in `PAPI_ENOEVNT`.

Currently in the master branch, the default native event names for the `intel_gpu` component tests are:
```
const char *default_metrics[] = { 
                                "ComputeBasic.GpuTime",
                                "ComputeBasic.GpuCoreClocks",
                                "ComputeBasic.AvgGpuCoreFrequencyMHz",
};
```
These native event names are lacking the `intel_gpu` component prefix leading to the component tests failing:
```
tburgess@headroom:~/papi_fork/papi/src/components/intel_gpu/tests$ ./gpu_query_gemm
Error on PAPI_add_named_event ComputeBasic.GpuTime,  retVal -7
```

This PR resolves this issue.

## Testing
Testing was done on Headroom at Oregon (Intel Data Center Max 1100), the results are as follows:
- PAPI build: ✅ 
- PAPI utilities*: ✅ 
- `gpu_metric_read`: ✅ 
- `gpu_query_gemm`: ✅ 

__*__ - `papi_component_avail`, `papi_native_avail`, and `papi_command_line`



## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
