### PR TITLE
framework: resolve compiler warnings

### DIFF
--- a/src/papi.c
+++ b/src/papi.c
@@ -4062,7 +4062,6 @@ PAPI_set_multiplex( int EventSet )
 	PAPI_option_t mpx;
 	EventSetInfo_t *ESI;
 	int cidx;
-	int ret;
 
 	/* Is the EventSet already in existence? */
 

--- a/src/papi_preset.c
+++ b/src/papi_preset.c
@@ -1642,8 +1642,8 @@ papi_load_derived_events_component (char *comp_str, char *arch_str, int cidx) {
                     return PAPI_ENOMEM;
                 }
 
-                int component_prefix_offset = strlen(comp_str) + strlen(":::");
-                int pos;
+                size_t component_prefix_offset = strlen(comp_str) + strlen(":::");
+                size_t pos;
                 // Walk the string until we hit the first qualifier
                 for (pos = component_prefix_offset; pos < strlen(basename); pos++) {
                     // If we hit the first qualifier of the event name


### PR DESCRIPTION
## Pull Request Description

When a build is configured with --enable-warnings, there are unused-variable and sign-compare warnings:
```
papi.c: In function 'PAPI_set_multiplex':
papi.c:4065:13: warning: unused variable 'ret' [-Wunused-variable]
 4065 |         int ret;
           |              ^~~
papi_preset.c: In function 'papi_load_derived_events_component':
papi_preset.c:1648:57: warning: comparison of integer expressions of different signedness: 'int' and 'size_t' {aka 'long unsigned int'} [-Wsign-compare]
 1648 |                 for (pos = component_prefix_offset; pos < strlen(basename); pos++) {
           |                                                                                      ^
```
This PR resolves these warnings.

These changes have been tested on a system containing the ARM Neoverse-V2 CPU and the NVIDIA GH200 480GB GPU (Grace-Hopper architecture).

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
