### PR TITLE
intel_gpu: update API calls

### DIFF
--- a/src/components/intel_gpu/README.md
+++ b/src/components/intel_gpu/README.md
@@ -39,12 +39,12 @@ at runtime (for libraries).
     ```
 * To enable metrics
     ```sh
-    ZET_ENABLE_METRICS=1
+    export ZET_ENABLE_METRICS=1
     ```
   Note that the component sets this automatically.
 * To change the sampling period from default 400000
     ```sh
-    METRICS_SAMPLING_PERIOD=value
+    export METRICS_SAMPLING_PERIOD=value
     ```
 
 ## Counter Collection Modes
@@ -52,11 +52,12 @@ at runtime (for libraries).
 Two metrics collection modes are supported.
 * Time-based sampling. In this mode, data collection and app can run in separate processes. To enable time-based event monitoring:
     ```sh
-    ZE_ENABLE_TRACING_LAYER=0
+    export PAPI_INTEL_GPU_SAMPLING_MODE=TIME
     ```
-* Query-based sampling. In this mode, PAPI_start() must be called before kernel launch and PAPI_stop() must be called after kernel execution completes. To enable query-based event monitoring:
+* Query-based sampling. In this mode, PAPI_start() must be called before kernel launch and PAPI_stop() must be called after kernel execution completes.
+  To enable query-based event monitoring:
     ```sh
-    ZE_ENABLE_TRACING_LAYER=1
+    export PAPI_INTEL_GPU_SAMPLING_MODE=QUERY
     ```
 
 ## Metrics:

--- a/src/components/intel_gpu/Rules.intel_gpu
+++ b/src/components/intel_gpu/Rules.intel_gpu
@@ -4,7 +4,7 @@
 PAPI_INTEL_GPU_ROOT ?= /usr
 
 ## the following set are used to define oneAPI Level Zero Metric API based implementation
-INTEL_L0_HEADERS = $(PAPI_INTEL_GPU_ROOT)/include
+INTEL_L0_HEADERS = $(PAPI_INTEL_GPU_ROOT)/include/level_zero
 INTEL_L0_LIB64   = $(PAPI_INTEL_GPU_ROOT)/lib
 
 GPUCOMP = components/intel_gpu
@@ -18,7 +18,7 @@ COMPSRCS += $(GPUSRCS) $(GPULIBSRCS)
 GPUOBJS = GPUMetricInterface.o GPUMetricHandler.o linux_intel_gpu_metrics.o
 COMPOBJS += $(GPUOBJS)
 
-CFLAGS += $(LDL) -g -I$(GPU_INTERNAL) -I$(GPU_INTERNAL)/inc -D_GLIBCXX_USE_CXX11_ABI=1
+CFLAGS += $(LDL) -g -I$(INTEL_L0_HEADERS) -I$(GPU_INTERNAL) -I$(GPU_INTERNAL)/inc -D_GLIBCXX_USE_CXX11_ABI=1
 LDFLAGS += -ldl
 
 GPUMetricInterface.o:  $(GPU_INTERNAL)/src/GPUMetricInterface.cpp $(GPUHEADER)

--- a/src/components/intel_gpu/internal/inc/GPUMetricHandler.h
+++ b/src/components/intel_gpu/internal/inc/GPUMetricHandler.h
@@ -37,7 +37,10 @@
 #include <map>
 #include <mutex>
 
-#include "level_zero/zet_api.h"
+#include <level_zero/zet_api.h>
+#if !defined(USE_ZET_EXP_API)
+#include <level_zero/layers/zel_tracing_api.h>
+#endif
 
 #include "GPUMetricInterface.h"
 
@@ -172,7 +175,11 @@ private: // Fields
 
 	zet_metric_streamer_handle_t m_metricStreamer;
 	zet_metric_query_pool_handle_t m_queryPool;
-	zet_tracer_exp_handle_t	m_tracer;
+	#if defined(USE_ZET_EXP_API)
+	zet_tracer_exp_handle_t m_tracer;
+	#else
+	zel_tracer_handle_t m_tracer;
+	#endif
 
 	volatile int	m_status;
 	uint32_t		m_numDevices;

--- a/src/components/intel_gpu/internal/src/GPUMetricHandler.cpp
+++ b/src/components/intel_gpu/internal/src/GPUMetricHandler.cpp
@@ -44,6 +44,10 @@
 #include <level_zero/zet_api.h>
 #include <level_zero/ze_ddi.h>
 #include <level_zero/zet_ddi.h>
+#if !defined(USE_ZET_EXP_API)
+#include <level_zero/layers/zel_tracing_api.h>
+#include <level_zero/layers/zel_tracing_ddi.h>
+#endif
 
 #include "GPUMetricHandler.h"
 
@@ -108,6 +112,14 @@ zet_pfnTracerExpSetEnabled_t				zetTracerExpSetEnabledFunc;
 zet_pfnCommandListAppendMetricQueryBegin_t  zetCommandListAppendMetricQueryBeginFunc;
 zet_pfnCommandListAppendMetricQueryEnd_t	zetCommandListAppendMetricQueryEndFunc;
 
+#if !defined(USE_ZET_EXP_API)
+zel_pfnTracerCreate_t					    zelTracerCreateFunc;
+zel_pfnTracerDestroy_t  					zelTracerDestroyFunc;
+zel_pfnTracerSetPrologues_t				    zelTracerSetProloguesFunc;
+zel_pfnTracerSetEpilogues_t				    zelTracerSetEpiloguesFunc;
+zel_pfnTracerSetEnabled_t   				zelTracerSetEnabledFunc;
+#endif
+
 #define DLL_SYM_CHECK(handle, name, type)				\
 	do {												\
 		name##Func = (type) dlsym(handle, #name);		\
@@ -138,6 +150,7 @@ functionInit(void *dllHandle)
 	DLL_SYM_CHECK(dllHandle, zeEventCreate, ze_pfnEventCreate_t);
 	DLL_SYM_CHECK(dllHandle, zeEventDestroy, ze_pfnEventDestroy_t);
 	DLL_SYM_CHECK(dllHandle, zeEventHostSynchronize, ze_pfnEventHostSynchronize_t);
+
 	DLL_SYM_CHECK(dllHandle, zetMetricStreamerOpen, zet_pfnMetricStreamerOpen_t);
 	DLL_SYM_CHECK(dllHandle, zetMetricStreamerClose, zet_pfnMetricStreamerClose_t);
 	DLL_SYM_CHECK(dllHandle, zetMetricStreamerReadData, zet_pfnMetricStreamerReadData_t);
@@ -159,6 +172,14 @@ functionInit(void *dllHandle)
 				zet_pfnCommandListAppendMetricQueryBegin_t);
 	DLL_SYM_CHECK(dllHandle, zetCommandListAppendMetricQueryEnd, 
 				zet_pfnCommandListAppendMetricQueryEnd_t);
+
+	#if !defined(USE_ZET_EXP_API)
+	DLL_SYM_CHECK(dllHandle, zelTracerCreate, zel_pfnTracerCreate_t);
+	DLL_SYM_CHECK(dllHandle, zelTracerDestroy, zel_pfnTracerDestroy_t);
+	DLL_SYM_CHECK(dllHandle, zelTracerSetPrologues, zel_pfnTracerSetPrologues_t);
+	DLL_SYM_CHECK(dllHandle, zelTracerSetEpilogues, zel_pfnTracerSetEpilogues_t);
+	DLL_SYM_CHECK(dllHandle, zelTracerSetEnabled, zel_pfnTracerSetEnabled_t);
+	#endif
 	return ret;
 }
 
@@ -624,6 +645,7 @@ int GPUMetricHandler::InitMetricDevices(DeviceInfo **deviceInfo,  uint32_t *numD
 			ze_device_properties_t props;
 			status = zeDeviceGetPropertiesFunc(deviceList[j], &props);
 			CHECK_N_RETURN_STATUS((status!=ZE_RESULT_SUCCESS), 1);
+
 			if ((props.type != ZE_DEVICE_TYPE_GPU) || (strstr(props.name, "Intel") == nullptr)) {
 				continue;
 			}
@@ -738,7 +760,11 @@ void GPUMetricHandler::DestroyMetricDevice()
 		zetMetricStreamerCloseFunc(m_metricStreamer);
 	}
 	if (m_tracer) {
+		#if defined(USE_ZET_EXP_API)
 		zetTracerExpDestroyFunc(m_tracer);
+		#else
+		zelTracerDestroyFunc(m_tracer);
+		#endif
 	}
 	if (m_queryPool) {
 		zetMetricQueryPoolDestroyFunc(m_queryPool);
@@ -1289,13 +1315,22 @@ int GPUMetricHandler::EnableEventBasedQuery()
 		// create event to wait
 		status = zeEventPoolCreateFunc(m_context, &eventPoolDesc, 1, &m_device, &m_eventPool);
 	}
+	#if defined(USE_ZET_EXP_API)
 	zet_tracer_exp_desc_t tracerDesc;
 	tracerDesc.stype = ZET_STRUCTURE_TYPE_TRACER_EXP_DESC;
+	#else
+	zel_tracer_desc_t tracerDesc;
+	tracerDesc.stype = ZEL_STRUCTURE_TYPE_TRACER_DESC;
+	#endif
 	if (status == ZE_RESULT_SUCCESS) {
 		m_queryState->eventPool = m_eventPool;
 		m_queryState->handle = this;
 		tracerDesc.pUserData = m_queryState;
+		#if defined(USE_ZET_EXP_API)
 		status = zetTracerExpCreateFunc(m_context, &tracerDesc, &m_tracer);
+		#else
+		status = zelTracerCreateFunc(&tracerDesc, &m_tracer);
+		#endif
 	}
 	zet_core_callbacks_t prologCB = {};
 	zet_core_callbacks_t epilogCB = {};
@@ -1306,13 +1341,25 @@ int GPUMetricHandler::EnableEventBasedQuery()
 		prologCB.CommandList.pfnAppendLaunchKernelCb = metricQueryBeginCB;
 		epilogCB.CommandList.pfnAppendLaunchKernelCb = metricQueryEndCB;
 
+		#if defined(USE_ZET_EXP_API)
 		status = zetTracerExpSetProloguesFunc(m_tracer, &prologCB);
+		#else
+		status = zelTracerSetProloguesFunc(m_tracer, &prologCB);
+		#endif
 	}
 	if (status == ZE_RESULT_SUCCESS) {
+		#if defined(USE_ZET_EXP_API)
 		status = zetTracerExpSetEpiloguesFunc(m_tracer, &epilogCB);
+		#else
+		status = zelTracerSetEpiloguesFunc(m_tracer, &epilogCB);
+		#endif
 	}
 	if (status == ZE_RESULT_SUCCESS) {
+		#if defined(USE_ZET_EXP_API)
 		status = zetTracerExpSetEnabledFunc(m_tracer, true);
+		#else
+		status = zelTracerSetEnabledFunc(m_tracer, true);
+		#endif
 	}
 	if (status == ZE_RESULT_SUCCESS) {
 		m_status = COLLECTION_ENABLED;

--- a/src/components/intel_gpu/linux_intel_gpu_metrics.c
+++ b/src/components/intel_gpu/linux_intel_gpu_metrics.c
@@ -190,7 +190,8 @@ intel_gpu_init_component(int cidx)
 	char *errStr = NULL;
 	memset(_intel_gpu_vector.cmp_info.disabled_reason, 0, PAPI_MAX_STR_LEN);
 
-	if (putenv("ZET_ENABLE_METRICS=1")) {
+	int envStat = setenv("ZET_ENABLE_METRICS", "1", 1);
+	if (envStat) {
 		errStr = "Set ZET_ENABLE_METRICS=1 failed. Cannot access GPU metrics. ";
 		strncpy_se(_intel_gpu_vector.cmp_info.disabled_reason, PAPI_MAX_STR_LEN,
 				   errStr, strlen(errStr));
@@ -216,12 +217,37 @@ intel_gpu_init_component(int cidx)
 
 	DEVICE_HANDLE handle = avail_devices[0];
 
-	char *envStr = NULL;
-	envStr =  getenv(ENABLE_API_TRACING);
+	// Get variable setting from the environment.
+	char *envStr = getenv("PAPI_INTEL_GPU_SAMPLING_MODE");
 	if (envStr != NULL) {
-	   if (atoi(envStr) == 1) {
+	   if (strcmp(envStr,"QUERY") == 0) {
 		   global_metrics_type = EVENT_BASED;
 	   }
+	}
+
+	// Track env. variable's value as a char for string manipulation purposes.
+	char varValue = '0'+global_metrics_type;
+
+	// If the setenv() fails, fallback by checking if the variable is already set to proper value.
+	envStat = setenv(ACTIVE_L0_API, &varValue, 1);
+	if (envStat) {
+		envStr = getenv(ACTIVE_L0_API);
+		if (envStr == NULL || strcmp(envStr, &varValue) != 0) {
+			errStr = (char*)malloc(PAPI_MAX_STR_LEN);
+			if( NULL == errStr ) {
+				SUBDBG("Failed to allocate memory for environment variable name plus value.\n");
+				return PAPI_ESYS;
+			}
+			retval = snprintf(errStr, PAPI_MAX_STR_LEN, "Set %s=%s failed. Cannot set sampling mode.", ACTIVE_L0_API, &varValue);
+			if( retval < 0 || retval >= PAPI_MAX_STR_LEN ) {
+				SUBDBG("Failed to write sampling mode error message.\n");
+				return PAPI_ESYS;
+			}
+			strncpy_se(_intel_gpu_vector.cmp_info.disabled_reason, PAPI_MAX_STR_LEN, errStr, strlen(errStr));
+			retval = PAPI_ENOSUPP;
+			free(errStr);
+			goto fn_fail;
+		}
 	}
 
 	metricInfoList.numEntries = 0;

--- a/src/components/intel_gpu/linux_intel_gpu_metrics.h
+++ b/src/components/intel_gpu/linux_intel_gpu_metrics.h
@@ -33,7 +33,11 @@
 
 /* environment varaiable for changing the control */
 #define METRICS_SAMPLING_PERIOD   "METRICS_SAMPLING_PERIOD"	   // setting sampling period
-#define ENABLE_API_TRACING		"ZE_ENABLE_TRACING_LAYER"	// for oneAPI Level0 V1.0 +
+#if defined(USE_ZET_EXP_API)
+#define ACTIVE_L0_API			"ZET_ENABLE_API_TRACING_EXP"	// for oneAPI Level0 < V1.0
+#else
+#define ACTIVE_L0_API			"ZE_ENABLE_TRACING_LAYER"		// for oneAPI Level0 V1.0 +
+#endif
 #define ENABLE_SUB_DEVICE		 "ENABLE_SUB_DEVICE"
 
 #define MINIMUM_SAMPLING_PERIOD  100000

--- a/src/components/intel_gpu/tests/gpu_metric_read.c
+++ b/src/components/intel_gpu/tests/gpu_metric_read.c
@@ -60,12 +60,11 @@ main(int argc, char ** argv) {
         return 0;
     }
 
-    retVal = putenv("ZE_ENABLE_TRACING_LAYER=0");
-    if (retVal) {
-        fprintf(stderr, "Failed to set ZE_ENABLE_TRACING_LAYER=0.\n");
-        fprintf(stderr, "Unset variable ZE_ENABLE_TRACING_LAYER to enable time-based collection.\n");
-        return 1;
-    }
+	retVal = setenv("PAPI_INTEL_GPU_SAMPLING_MODE", "TIME", 1);
+	if (retVal) {
+		fprintf(stderr, "Failed to set variable PAPI_INTEL_GPU_SAMPLING_MODE=TIME to enable time-based collection.\n");
+		return 1;
+	}
 
     retVal = parseInputParam(argc, argv, &param);
     if (retVal) {

--- a/src/components/intel_gpu/tests/gpu_query_gemm.cc
+++ b/src/components/intel_gpu/tests/gpu_query_gemm.cc
@@ -45,9 +45,7 @@
 
 #if defined(ENABLE_PAPI)
 #include "papi.h" 
-const char *env_str = "ZE_ENABLE_TRACING_LAYER=1";
 #endif
-
 
 #define A_VALUE 0.128f
 #define B_VALUE 0.256f
@@ -391,13 +389,13 @@ main(int argc, char* argv[]) {
     int    num_metrics    = 0;
     char **metric_names   = NULL;
 
-    int cid         = -1;
-    retVal = putenv((char *)env_str);
-    if (retVal) {
-        cerr << "Failed to set ZE_ENABLE_TRACING_LAYER=1."
-             << "Set variable ZE_ENABLE_TRACING_LAYER=1 to enable query-based collection." << endl;
+	retVal = setenv("PAPI_INTEL_GPU_SAMPLING_MODE", "QUERY", 1);
+	if (retVal) {
+		fprintf(stderr, "Failed to set variable PAPI_INTEL_GPU_SAMPLING_MODE=QUERY to enable query-based collection.\n");
 		return 1;
-    }
+	}
+
+    int cid         = -1;
     cid = initPAPIGPUComp();
     if (cid < 0) {
        return 1;

--- a/src/components/intel_gpu/tests/readme.txt
+++ b/src/components/intel_gpu/tests/readme.txt
@@ -1,6 +1,7 @@
 Test examples:
 To collect metrics, set ZET_ENABLE_METRICS=1
-To collect metrics in query mode, set ZE_ENABLE_TRACING_LAYER=1
+To collect metrics in query mode with the Experimental API Tracing, set ZET_ENABLE_API_TRACING_EXP=1
+To collect metrics in query mode with the Loader Tracing Layer, set ZE_ENABLE_TRACING_LAYER=1
 
 ---------------------------
 gpu_metric_list:

--- a/src/configure
+++ b/src/configure
@@ -6923,6 +6923,30 @@ for comp in $components; do
     fi
   fi
 
+  # Check version of Intel Level-Zero API.
+  if (test "x$comp" = "xintel_gpu"); then
+    for root in "$PAPI_INTEL_GPU_ROOT" "/usr"
+    do
+      if test "x$root" != "x"; then
+        for probe in "$root/include/level_zero/ze_api.h"
+        do
+          if test -f "$probe"; then
+            level_zero_ver=`grep ZE_API_VERSION_CURRENT.*[0-9] $probe | head -1 | grep -o [0-9].*[0-9] | sed 's/,//g'`
+            level_zero_maj=`echo $level_zero_ver | awk '{print $1}'`
+
+            if test $level_zero_maj -le 1; then
+                echo "INFO: Detected Intel Level Zero major version $level_zero_maj. Proceeding with Experimental API Tracing."
+                CFLAGS="$CFLAGS -DUSE_ZET_EXP_API"
+            else
+                echo "INFO: Detected Intel Level Zero major version $level_zero_maj. Proceeding with Loader Tracing Layer."
+            fi
+            break 2
+          fi
+        done
+      fi
+    done
+  fi
+
   # check for intel_gpu or rocp_sdk component to determine if we need -lstdc++ in LDFLAGS
   if (test "x$comp" = "xintel_gpu" || test "x$comp" = "xrocp_sdk"); then
     LDFLAGS="$LDFLAGS -lstdc++ -pthread"

--- a/src/configure.in
+++ b/src/configure.in
@@ -2083,6 +2083,30 @@ for comp in $components; do
     fi
   fi
 
+  # Check version of Intel Level-Zero API.
+  if (test "x$comp" = "xintel_gpu"); then
+    for root in "$PAPI_INTEL_GPU_ROOT" "/usr"
+    do
+      if test "x$root" != "x"; then
+        for probe in "$root/include/level_zero/ze_api.h"
+        do
+          if test -f "$probe"; then
+            level_zero_ver=`grep ZE_API_VERSION_CURRENT.*[[0-9]] $probe | head -1 | grep -o [[0-9]].*[[0-9]] | sed 's/,//g'`
+            level_zero_maj=`echo $level_zero_ver | awk '{print $1}'`
+
+            if test $level_zero_maj -le 1; then
+                echo "INFO: Detected Intel Level Zero major version $level_zero_maj. Proceeding with Experimental API Tracing."
+                CFLAGS="$CFLAGS -DUSE_ZET_EXP_API"
+            else
+                echo "INFO: Detected Intel Level Zero major version $level_zero_maj. Proceeding with Loader Tracing Layer."
+            fi
+            break 2
+          fi
+        done
+      fi
+    done
+  fi
+
   # check for intel_gpu or rocp_sdk component to determine if we need -lstdc++ in LDFLAGS
   if (test "x$comp" = "xintel_gpu" || test "x$comp" = "xrocp_sdk"); then
     LDFLAGS="$LDFLAGS -lstdc++ -pthread"


### PR DESCRIPTION
## Pull Request Description

The Experimental API Tracing in Level Zero has been deprecated, and the Level Zero drivers now support only the Loader Tracing Layer.

Failing to use the Loader Tracing Layer with newer drivers results in error code 0x78000001 (ZE_RESULT_ERROR_UNINITIALIZED -- "driver is not initialized").

These changes have been tested on the Intel Data Center Max 1100 (Ponte Vecchio architecture) with driver version 1.6.

This PR resolves Issue #523.

Thank you to Treece Burgess for suggesting this solution methodology!

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
