### PR TITLE
intel_gpu: update README with Xe drivers

### DIFF
--- a/src/components/intel_gpu/README.md
+++ b/src/components/intel_gpu/README.md
@@ -15,7 +15,7 @@ To enable intel_gpu component, the PAPI library is built with configure option a
 * [oneAPI Level Zero loader (libze_loader.so)](https://github.com/oneapi-src/level-zero)
 * [Intel(R) Metrics Discovery Application Programming Interface (libigdmd.so)](https://github.com/intel/metrics-discovery)
 * [Intel(R) Metrics Library Application Programming Interface (libigdml.so)](https://github.com/intel/metrics-library)
-* /proc/sys/dev/i915/perf_stream_paranoid is set to `0`
+* `/proc/sys/dev/i915/perf_stream_paranoid` or `/proc/sys/dev/xe/observation_paranoid` is set to `0`
 * User needs to be added into Linux render/video groups
 
 ## Environment Variables


### PR DESCRIPTION
## Pull Request Description
Update the README to include the paranoid flag for the Xe drivers in addition to the i915 drivers.

Reference: [Intel Documentation](https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2025-1/set-up-system-gpu-analysis.html)

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
