### PR TITLE
libpfm4: fix const-correctness with strpbrk()

### DIFF
--- a/src/libpfm4/lib/pfmlib_common.c
+++ b/src/libpfm4/lib/pfmlib_common.c
@@ -1893,8 +1893,7 @@ pfmlib_parse_event(const char *event, pfmlib_event_desc_t *d)
 	/*
 	 * support only one event at a time.
 	 */
-	p = strpbrk(event, PFMLIB_EVENT_DELIM);
-	if (p)
+	if (strpbrk(event, PFMLIB_EVENT_DELIM))
 		return PFM_ERR_INVAL;
 	/*
 	 * create copy because string is const


### PR DESCRIPTION
Newer glibc headers provide const-correct overloads for strpbrk(). In pfmlib_parse_event(), the return value was assigned to a char * even though it was only used to test for NULL, causing a build failure with recent GCC/glibc versions. This change removes the unnecessary assignment while preserving the existing behavior.