### PR TITLE
framework and perf_event: resolve compilation warnings

### DIFF
--- a/src/components/perf_event/pe_libpfm4_events.c
+++ b/src/components/perf_event/pe_libpfm4_events.c
@@ -405,9 +405,9 @@ static struct native_event_t *allocate_native_event(
 
 			/* See if we had a mask that wasn't found */
 			if (!mask_found) {
+            SUBDBG("EXIT: error libpfm4 find event: Mask not found: %s.\n", ptr);
             free(msk_ptr);
             free(pmu_name);
-            SUBDBG("EXIT: error libpfm4 find event: Mask not found: %s.\n", ptr);
             _papi_hwi_unlock( NAMELIB_LOCK );
 				return NULL;
 			}

--- a/src/papi_internal.c
+++ b/src/papi_internal.c
@@ -2818,8 +2818,8 @@ _papi_hwi_native_name_to_code( const char *in, int *out )
 		retval = _papi_hwd[cidx]->ntv_name_to_code( event_name_to_code_input, ( unsigned * ) out );
 		if (retval == PAPI_OK) {
 			*out = _papi_hwi_native_to_eventcode(cidx, *out, -1, event_name_to_code_input);
-			free (full_event_name);
 			INTDBG("EXIT: PAPI_OK  event: %s code: %#x\n", event_name_to_code_input, *out);
+			free (full_event_name);
 			return PAPI_OK;
 		}
 	}
@@ -2849,8 +2849,8 @@ _papi_hwi_native_name_to_code( const char *in, int *out )
 			if ( retval == PAPI_OK && event_name_to_code_input != NULL) {
 				if ( strcasecmp( name, event_name_to_code_input ) == 0 ) {
 					*out = _papi_hwi_native_to_eventcode(cidx, i, -1, name);
-					free (full_event_name);
 					INTDBG("EXIT: PAPI_OK, event: %s, code: %#x\n", event_name_to_code_input, *out);
+					free (full_event_name);
 					return PAPI_OK;
 				}
 				retval = PAPI_ENOEVNT;


### PR DESCRIPTION
## Pull Request Description
On Heimdall at Oregon (CPU: AMD Ryzen 9 9950X, GPU: NVIDIA GeForce RTX 5080), configuring PAPI with `--enable-warnings` and `--with-debug=yes` will produce the following compilation warnings:
```
papi_internal.c: In function ‘_papi_hwi_native_name_to_code’:
papi_debug.h:61:100: warning: pointer ‘event_name_to_code_input’ may be used after ‘free’ [-Wuse-after-free]
   61 | #define PAPIDEBUG(level,format, args...) { if(_papi_hwi_debug&level){DEBUGLABEL(DEBUGLEVEL(level));fprintf(stderr,format, ## args);}}
      |                                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
papi_debug.h:67:34: note: in expansion of macro ‘PAPIDEBUG’
   67 | #define INTDBG(format, args...) (PAPIDEBUG(DEBUG_INTERNAL,format, ## args))
      |                                  ^~~~~~~~~
papi_internal.c:2822:25: note: in expansion of macro ‘INTDBG’
 2822 |                         INTDBG("EXIT: PAPI_OK  event: %s code: %#x\n", event_name_to_code_input, *out);
      |                         ^~~~~~
papi_internal.c:2821:25: note: call to ‘free’ here
 2821 |                         free (full_event_name);
      |                         ^~~~~~~~~~~~~~~~~~~~~~
papi_debug.h:61:100: warning: pointer ‘event_name_to_code_input’ may be used after ‘free’ [-Wuse-after-free]
   61 | #define PAPIDEBUG(level,format, args...) { if(_papi_hwi_debug&level){DEBUGLABEL(DEBUGLEVEL(level));fprintf(stderr,format, ## args);}}
      |                                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
papi_debug.h:67:34: note: in expansion of macro ‘PAPIDEBUG’
   67 | #define INTDBG(format, args...) (PAPIDEBUG(DEBUG_INTERNAL,format, ## args))
      |                                  ^~~~~~~~~
papi_internal.c:2853:41: note: in expansion of macro ‘INTDBG’
 2853 |                                         INTDBG("EXIT: PAPI_OK, event: %s, code: %#x\n", event_name_to_code_input, *out);
      |                                         ^~~~~~
papi_internal.c:2852:41: note: call to ‘free’ here
 2852 |                                         free (full_event_name);
      |                                         ^~~~~~~~~~~~~~~~~~~~~~
In file included from ./papi_internal.h:24,
                 from components/perf_event/pe_libpfm4_events.c:19:
components/perf_event/pe_libpfm4_events.c: In function ‘allocate_native_event’:
./papi_debug.h:61:100: warning: pointer ‘ptr’ may be used after ‘free’ [-Wuse-after-free]
   61 | #define PAPIDEBUG(level,format, args...) { if(_papi_hwi_debug&level){DEBUGLABEL(DEBUGLEVEL(level));fprintf(stderr,format, ## args);}}
      |                                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./papi_debug.h:65:34: note: in expansion of macro ‘PAPIDEBUG’
   65 | #define SUBDBG(format, args...) (PAPIDEBUG(DEBUG_SUBSTRATE,format, ## args))
      |                                  ^~~~~~~~~
components/perf_event/pe_libpfm4_events.c:410:13: note: in expansion of macro ‘SUBDBG’
  410 |             SUBDBG("EXIT: error libpfm4 find event: Mask not found: %s.\n", ptr);
      |             ^~~~~~
components/perf_event/pe_libpfm4_events.c:408:13: note: call to ‘free’ here
  408 |             free(msk_ptr);
```

The workflows causing the compilation warnings are:
```
// perf_event
char *msk_ptr = strdup(masks);
char *ptr = msk_ptr;
.
.
.
free(msk_ptr);
SUBDBG("EXIT: error libpfm4 find event: Mask not found: %s.\n", ptr);

// framework
char *full_event_name = strdup(in);

const char *event_name_to_code_input;
if (strstr(full_event_name, ":::") != NULL) {
    event_name_to_code_input= varname + strlen(component_prefix_name) + strlen(":::");
}
else if (strstr(full_event_name, "::") != NULL) {
    event_name_to_code_input = varname;
}
else {
    event_name_to_code_input = varname;
}
.
.
.
free(full_event_name);
INTDBG("EXIT: PAPI_OK  event: %s code: %#x\n", event_name_to_code_input, *out);
```

In both cases, we call `free` on the memory allocation we work off of. This can lead to a segmentation fault for the respective `SUBDBG` and `INTDBG` calls.

## Testing
Testing was done on Heimdall at Oregon (CPU: AMD Ryzen 9 9950X, GPU: NVIDIA GeForce RTX 5080).

The aforementioned compilation warnings now do not occur and `papi_component_avail`, `papi_command_line`, and `papi_native_avail` function as expected.

Furthermore, output from `PAPI_DEBUG` is below for three cases:
```
// Case 1: export PAPI_DEBUG=ALL for ./papi_command_line perf::CYCLES:random=0
SUBSTRATE:components/perf_event/pe_libpfm4_events.c:allocate_native_event:408:3019616 EXIT: error libpfm4 find event: Mask not found: random=0.

// Case 2: export PAPI_DEBUG=ALL for ./papi_command_line perf::CYCLES
INTERNAL:papi_internal.c:_papi_hwi_native_name_to_code:2727:3019563 ENTER: in: RETIRED_UNCONDITIONAL_BRANCH_INSTRUCTIONS, out: 0x5f874acc6f10

// Case 3: export PAPI_DEBUG=ALL for ./papi_command_line
INTERNAL:papi_internal.c:_papi_hwi_native_name_to_code:2852:3022460 EXIT: PAPI_OK, event: EXAMPLE_ZERO, code: 0x40000020
```

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
