### PR TITLE
framework: PAPI_DISABLE_COMPONENTS env var

### DIFF
--- a/src/papi.c
+++ b/src/papi.c
@@ -1049,6 +1049,18 @@ PAPI_library_init( int version )
 
 	int tmp = 0;
 
+    char *disabledComps = getenv("PAPI_DISABLE_COMPONENTS");
+    if (disabledComps != NULL) {
+        char *penv = strdup(disabledComps);
+        char *p;
+        for (p = strtok (penv, ",:"); p != NULL; p = strtok (NULL, ",:")) {
+            (void) PAPI_disable_component_by_name(p);
+        }
+        free(penv);
+    } else {
+        APIDBG("PAPI_library_init: getenv(PAPI_DISABLE_COMPONENTS) was not set.\n");
+    }
+
 	/* This is a poor attempt at a lock. 
 	   For 3.1 this should be replaced with a 
 	   true UNIX semaphore. We cannot use PAPI


### PR DESCRIPTION
## Pull Request Description

This change introduces an environment variable to allow the user to disable components at runtime.

Example Usage: export PAPI_DISABLE_COMPONENTS=rocm,rocm_smi

This PR was created to treat the two commits in PR #548 independently. While PR #548 will be closed, the discussion there can be accessed.

This PR addresses Issue #478.

These changes have been tested using ROCm 7.0.2 on the Frontier supercomputer, which contains the AMD MI250X architecture.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
