### PR TITLE
framework: fix data race and double free in PAPI_event_name_to_code

### DIFF
--- a/src/papi.c
+++ b/src/papi.c
@@ -1675,19 +1675,27 @@ PAPI_event_name_to_code( const char *in, int *out )
        /* User may have provided an invalid event name. */
        if( NULL != _papi_hwi_list ) {
 
-           /* Keep track of all qualifiers provided by the user. */
+           /* Keep track of all qualifiers provided by the user.
+            *
+            * overwrite_qualifiers() and construct_qualified_event() free() and
+            * strdup() the quals[] and name[] of the shared global preset entry,
+            * so concurrent resolution of the same preset would double-free.
+            * Serialize under PRESET_LOCK; INTERNAL_LOCK cannot be used because
+            * construct_qualified_event() reaches _papi_hwi_add_native_event(),
+            * which already takes it, and PAPI locks are not recursive. */
            hwi_presets_t *prstPtr = &_papi_hwi_list[preset_idx];
-           int status = overwrite_qualifiers(prstPtr, in, 1);
-           if( status < 0 ) {
-               papi_return( PAPI_ENOMEM );
-           }
+           int status;
 
-           status = construct_qualified_event(prstPtr);
+           _papi_hwi_lock( PRESET_LOCK );
+           status = overwrite_qualifiers(prstPtr, in, 1);
            if( status < 0 ) {
-               papi_return( status );
+               status = PAPI_ENOMEM;
+           } else {
+               status = construct_qualified_event(prstPtr);
            }
+           _papi_hwi_unlock( PRESET_LOCK );
 
-           papi_return( PAPI_OK );
+           papi_return( ( status < 0 ) ? status : PAPI_OK );
        }
     }
 

--- a/src/papi_lock.h
+++ b/src/papi_lock.h
@@ -12,9 +12,10 @@
 #define GLOBAL_LOCK             PAPI_NUM_LOCK+6 /* papi.c for global variable (static and non) initialization/shutdown */
 #define CPUS_LOCK               PAPI_NUM_LOCK+7 /* cpus.c */
 #define NAMELIB_LOCK            PAPI_NUM_LOCK+8 /* papi_pfm4_events.c */
+#define PRESET_LOCK             PAPI_NUM_LOCK+9 /* papi.c preset name resolution */
 
 
-#define NUM_INNER_LOCK  9
+#define NUM_INNER_LOCK  10
 #define PAPI_MAX_LOCK   (NUM_INNER_LOCK + PAPI_NUM_LOCK + PAPI_NUM_COMP)
 
 #include OSLOCK


### PR DESCRIPTION
overwrite_qualifiers() and construct_qualified_event() free() and strdup() the name[] and quals[] of the shared global preset table entry, so threads concurrently resolving the same preset name can free the same pointer and corrupt the heap.

Serialize these calls under a new PRESET_LOCK.  INTERNAL_LOCK cannot be reused because construct_qualified_event() reaches _papi_hwi_add_native_event(), which takes it, and PAPI locks are not recursive.

Verified with AddressSanitizer on x86_64 and ppc64le: concurrent resolution double-frees in 20/20 runs unpatched, 0/20 patched.
