### PR TITLE
rapl: Add support for Intel Granite Rapids

### DIFF
--- a/src/components/rapl/linux-rapl.c
+++ b/src/components/rapl/linux-rapl.c
@@ -479,6 +479,7 @@ _rapl_init_component( int cidx )
 			break;
 			
 		case 143:      /* Sapphire Rapids-SP */
+		case 173:      /* Granite Rapids */
 		case 207:      /* Emerald Rapids */
 		        package_avail=1;
 			pp0_avail=0;


### PR DESCRIPTION
## Pull Request Description
Currently in the master branch, if a user configures PAPI with the `rapl` component on an Intel Granite Rapids then `papi_component_avail` shows:
```
Name:   rapl                    Linux RAPL energy measurements
   \-> Disabled: CPU model not supported
```

This PR adds support for Intel Granite Rapids in the `rapl` component by adding the model number 173 as a case in the `switch` statement. For documentation purposes, see the below output of `papi_component_avail` which showcases the Family/Model/Stepping for an Intel Xeon 6767P (Granite Rapids):
```
CPUID                    : Family/Model/Stepping 6/173/1, 0x06/0xad/0x01
```

## Testing
Testing was done on Stravinsky at Oregon (CPU: Intel Xeon 6767P).

- `papi_component_avail`: ✅ 
```
Name:   rapl                    Linux RAPL energy measurements
                                Native: 24, Preset: 0, Counters: 24
```

- `papi_native_avail`: ✅ 
- `papi_command_line`: ✅ 
```
tburgess@stravinsky:~/treece_backup_fork/src/test-install/bin$ sudo ./papi_command_line rapl:::THERMAL_SPEC_CNT:PACKAGE0

This utility lets you add events from the command line interface to see if they work.

Successfully added: rapl:::THERMAL_SPEC_CNT:PACKAGE0

rapl:::THERMAL_SPEC_CNT:PACKAGE0 : 	2800(u) 

----------------------------------
```
- `rapl` component tests: ✅ (note: `rapl_overflow.c` did not run successfully unless commenting out blocks of code that used PAPI presets `PAPI_TOT_INS` and `PAPI_TOT_CYC`. Upon running `./papi_avail` no presets showed as available and this is expected as Granite Rapid preset support has yet to be merged into master.)



## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
