### PR TITLE
cat compiler warn err

### DIFF
--- a/src/counter_analysis_toolkit/dcache.c
+++ b/src/counter_analysis_toolkit/dcache.c
@@ -353,7 +353,7 @@ int varyBufferSizes(long long *values, double **rslts, double **counter, cat_par
              * All other upper bounds are set to the capacity of the cache, as observed per core.
              */
             if( llc_idx+1 == j ) {
-                nextCacheSize = 16LL*(hw_desc->dcache_size[llc_idx])/hw_desc->mmsplit;
+                nextCacheSize = FACTOR*(hw_desc->dcache_size[llc_idx])/hw_desc->mmsplit;
                 ptsToNextCache = hw_desc->pts_per_mm+1;
             } else {
                 nextCacheSize = hw_desc->dcache_size[j]/hw_desc->split[j];

--- a/src/counter_analysis_toolkit/dcache.c
+++ b/src/counter_analysis_toolkit/dcache.c
@@ -378,7 +378,7 @@ int varyBufferSizes(long long *values, double **rslts, double **counter, cat_par
 
         cnt=0;
         for(j=0; j<len; j++){
-            char symbol[4] = "|/-\\";
+            char symbol[4] = {'|','/','-','\\'};
             active_buf_len = bufSizes[j]/sizeof(uintptr_t);
             if( params.show_progress ){
                 printf("%c\b",symbol[j%4]);

--- a/src/counter_analysis_toolkit/driver.h
+++ b/src/counter_analysis_toolkit/driver.h
@@ -28,7 +28,7 @@ void trav_evts(evstock* stock, int pk, int* cards, int nevts, int selexnsize, in
 int perm(int n, int k);
 int comb(int n, int k);
 void testbench(char** allevts, int cmbtotal, hw_desc_t *hw_desc, cat_params_t params, int myid, int nprocs);
-void print_usage();
+void print_usage(char *name);
 static int parse_line(FILE *input, char **key, long long *value);
 static void read_conf_file(char *conf_file, hw_desc_t *hw_desc);
 static hw_desc_t *obtain_hardware_description(char *conf_file_name);


### PR DESCRIPTION
## Pull Request Description
This pull request addresses a couple of compile-time warnings and errors, as well as a commit that makes consistent use of a macro. This addresses Issue #636.

- cat: fix compiler warning about string without NUL
- cat: replace hard-coded value with proper macro
- cat: add missing argument to function prototype

These changes have been tested on a system containing the Intel Granite Rapids architecture.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
