### PR TITLE
rocp_sdk: guard against no devices due to driver

### DIFF
--- a/src/components/rocp_sdk/sdk_class.cpp
+++ b/src/components/rocp_sdk/sdk_class.cpp
@@ -1185,6 +1185,13 @@ rocprofiler_sdk_init(void)
         goto fn_fail;
     }
 
+    if( papi_rocpsdk::gpu_agents.empty() ) {
+        if( papi_rocpsdk::get_error_string().empty() ){
+            papi_rocpsdk::set_error_string("No compatible devices detected. Please ensure that the driver is active.");
+        }
+        papi_errno = PAPI_ECMP;
+        goto fn_fail;
+    }
     papi_rocpsdk::populate_event_list();
 
   fn_exit:


### PR DESCRIPTION
## Pull Request Description
If the driver is not active, then no devices will be detected. This leads to an invalid reference, which results in a segmentation fault. This PR remedies this issue by checking for how many agents the ROCProfiler-SDK detected.

This PR addresses Issue #643.

These changes have been tested using ROCm 7.14.0 on a system containing the MI300X GPU architecture.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
