### PR TITLE
amd_smi: Resolve compilation warnings

### DIFF
--- a/src/components/amd_smi/amds.c
+++ b/src/components/amd_smi/amds.c
@@ -35,7 +35,7 @@ AMD_SMI_CPU_FUNCTIONS(DEFINE_AMDSMI)
 static int32_t device_count = 0;
 static amdsmi_processor_handle *device_handles = NULL;
 static int32_t gpu_count = 0;
-static int32_t cpu_count = 0;
+static uint32_t cpu_count = 0;
 static amdsmi_processor_handle **cpu_core_handles = NULL;
 static uint32_t *cores_per_socket = NULL;
 static void *amds_dlp = NULL;
@@ -45,7 +45,6 @@ static uint32_t amdsmi_lib_major = 0;
 static uint32_t amdsmi_lib_minor = 0;
 // Forward declarations for internal helpers
 static int load_amdsmi_sym(void);
-static int init_device_table(void);
 static int shutdown_device_table(void);
 static int init_event_table(void);
 static int shutdown_event_table(void);
@@ -681,18 +680,13 @@ static int shutdown_event_table(void) {
   return PAPI_OK;
 }
 
-static int init_device_table(void) {
-  // Nothing to do (device_handles and device_count already set in amds_init)
-  return PAPI_OK;
-}
-
 static int shutdown_device_table(void) {
   if (device_handles) {
     papi_free(device_handles);
     device_handles = NULL;
   }
   if (cpu_core_handles) {
-    int s;
+    uint32_t s;
     for (s = 0; s < cpu_count; ++s) {
       if (cpu_core_handles[s])
         papi_free(cpu_core_handles[s]);
@@ -908,7 +902,7 @@ fn_fail:
   }
   // sockets already freed if allocated
   if (cpu_core_handles) {
-    for (int s = 0; s < cpu_count; ++s) {
+    for (s = 0; s < cpu_count; ++s) {
       if (cpu_core_handles[s])
         papi_free(cpu_core_handles[s]);
     }

--- a/src/components/amd_smi/amds_accessors.c
+++ b/src/components/amd_smi/amds_accessors.c
@@ -893,9 +893,6 @@ int access_amdsmi_fan_speed(int mode, void *arg) {
 
   if (mode == PAPI_MODE_WRITE) {
 
-    if (event->value < 0)
-      return PAPI_EINVAL;
-
     uint64_t new_speed = (uint64_t)event->value;
     uint64_t max_speed = 255;
     if (amdsmi_get_gpu_fan_speed_max_p) {
@@ -1149,7 +1146,7 @@ int access_amdsmi_clock_info(int mode, void *arg) {
     return PAPI_ENOSUPP;
 
   amdsmi_clk_type_t clk_types[] = {AMDSMI_CLK_TYPE_SYS, AMDSMI_CLK_TYPE_MEM};
-  if (event->variant < 0 || event->variant >= 2)
+  if (event->variant >= 2)
     return PAPI_EMISC;
 
   amdsmi_clk_info_t info;
@@ -1444,7 +1441,7 @@ int access_amdsmi_xgmi_bandwidth(int mode, void *arg) {
   if (event->device < 0 || event->device >= gpu_count || !device_handles ||
       !device_handles[event->device])
     return PAPI_EMISC;
-  if (event->subvariant < 0 || event->subvariant >= gpu_count ||
+  if (event->subvariant >= (uint32_t) gpu_count ||
       !device_handles[event->subvariant])
     return PAPI_EMISC;
 

--- a/src/components/amd_smi/amds_accessors.c
+++ b/src/components/amd_smi/amds_accessors.c
@@ -893,6 +893,9 @@ int access_amdsmi_fan_speed(int mode, void *arg) {
 
   if (mode == PAPI_MODE_WRITE) {
 
+    if ((int32_t)event->value < 0)
+      return PAPI_EINVAL;
+
     uint64_t new_speed = (uint64_t)event->value;
     uint64_t max_speed = 255;
     if (amdsmi_get_gpu_fan_speed_max_p) {
@@ -1146,7 +1149,7 @@ int access_amdsmi_clock_info(int mode, void *arg) {
     return PAPI_ENOSUPP;
 
   amdsmi_clk_type_t clk_types[] = {AMDSMI_CLK_TYPE_SYS, AMDSMI_CLK_TYPE_MEM};
-  if (event->variant >= 2)
+  if ((int32_t)event->variant < 0 || event->variant >= 2)
     return PAPI_EMISC;
 
   amdsmi_clk_info_t info;
@@ -1441,7 +1444,7 @@ int access_amdsmi_xgmi_bandwidth(int mode, void *arg) {
   if (event->device < 0 || event->device >= gpu_count || !device_handles ||
       !device_handles[event->device])
     return PAPI_EMISC;
-  if (event->subvariant >= (uint32_t) gpu_count ||
+  if ((int32_t)event->subvariant < 0 || (int32_t)event->subvariant >= gpu_count ||
       !device_handles[event->subvariant])
     return PAPI_EMISC;
 

--- a/src/components/amd_smi/htable.h
+++ b/src/components/amd_smi/htable.h
@@ -186,7 +186,6 @@ static int create_table(uint64_t capacity, struct hash_table **table)
     if (capacity < 1 || table == NULL) {
         return HTABLE_EINVAL;
     }
-    int htable_errno = HTABLE_SUCCESS;
     struct hash_table *t = papi_calloc(1, sizeof(struct hash_table));
     if (t == NULL) {
         return HTABLE_ENOMEM;

--- a/src/components/amd_smi/tests/amdsmi_gemm.c
+++ b/src/components/amd_smi/tests/amdsmi_gemm.c
@@ -454,7 +454,8 @@ static void destroy_rocblas_handles(rocblas_handle *handles, int count) {
 /* ------------------------------- Test body -------------------------------- */
 
 static int real_main(const HarnessOpts *opts) {
-    struct sample_buffer sample_buf = {0};
+    struct sample_buffer sample_buf;
+    memset(&sample_buf, 0, sizeof(sample_buf));
     bool sample_buf_initialized = false;
     /* Gracefully skip if the PAPI AMD SMI component isn't available. */
     const char* root = getenv("PAPI_AMDSMI_ROOT");


### PR DESCRIPTION
## Pull Request Description
This pull request resolves compilation warnings that occur when configuring PAPI with the `amd_smi` component and the option `--enable-warnings`.

Important notes:
1. The functions:
- `silence_stderr_begin`
- `silence_stderr_end`
- `sanitize_name`

Trigger a defined, but never used compilation warning. The functions are used in the following code block that is commented out:
```
    // GPU PM metrics count event (available in lib version 25+)
    if (amdsmi_lib_major >= 25 && amdsmi_get_gpu_pm_metrics_info_p) {
      amdsmi_name_value_t *metrics = NULL;
      uint32_t mcount = 0;

      int saved_stderr = silence_stderr_begin();
      amdsmi_status_t st = amdsmi_get_gpu_pm_metrics_info_p(device_handles[d],
                                                            &metrics, &mcount);
      silence_stderr_end(saved_stderr);

      if (st == AMDSMI_STATUS_SUCCESS && mcount > 0) {
        if (idx >= MAX_EVENTS_PER_DEVICE * device_count && metrics)
          free(metrics);
        CHECK_EVENT_IDX(idx);
        CHECK_SNPRINTF(doNotAllowTruncation, name_buf, sizeof(name_buf), "pm_metrics_count:device=%d", d);
        CHECK_SNPRINTF(allowTruncation, descr_buf, sizeof(descr_buf),
                 "Device %d number of PM metrics available", d);
        if (add_event(&idx, name_buf, descr_buf, d, 0, 0, PAPI_MODE_READ,
                      access_amdsmi_pm_metrics_count) != PAPI_OK) {
          if (metrics) free(metrics);
          return PAPI_ENOMEM;
        }

        uint32_t i;
        for (i = 0; i < mcount; ++i) {
          if (idx >= MAX_EVENTS_PER_DEVICE * device_count) {
            if (metrics) free(metrics);
            CHECK_EVENT_IDX(idx);
          }
          char metric_name[PAPI_2MAX_STR_LEN];
          sanitize_name(metrics[i].name, metric_name, sizeof(metric_name));
          CHECK_SNPRINTF(doNotAllowTruncation, name_buf, sizeof(name_buf), "pm_%s:device=%d", metric_name, d);
          CHECK_SNPRINTF(allowTruncation, descr_buf, sizeof(descr_buf), "Device %d PM metric %s", d,
                   metrics[i].name);
          if (add_event(&idx, name_buf, descr_buf, d, i, 0, PAPI_MODE_READ,
                        access_amdsmi_pm_metric_value) != PAPI_OK) {
            if (metrics) free(metrics);
            return PAPI_ENOMEM;
          }
        }
      }
      if (metrics)
        free(metrics);
    }
```
Therefore, we should address this in a separate PR.

2. `format-truncations` is triggered as well:
```
components/amd_smi/amds_evtapi.c:524:18: warning: ', masks:Mandatory device qua...' directive output may be truncated writing 36 bytes into a region of size between 1 and 1024 [-Wformat-truncation=]
  524 |                  "%s, masks:Mandatory device qualifier [%s]",
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
components/amd_smi/amds_priv.h:95:45: note: in definition of macro 'CHECK_SNPRINTF'
   95 |         int strLen = snprintf(buffer, size, __VA_ARGS__); \
      |                                             ^~~~~~~~~~~
components/amd_smi/amds_evtapi.c:524:21: note: format string is defined here
  524 |                  "%s, masks:Mandatory device qualifier [%s]",
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
components/amd_smi/amds_priv.h:95:22: note: 'snprintf' output 38 or more bytes (assuming 1061) into a destination of size 1024
   95 |         int strLen = snprintf(buffer, size, __VA_ARGS__); \
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
components/amd_smi/amds_evtapi.c:523:9: note: in expansion of macro 'CHECK_SNPRINTF'
  523 |         CHECK_SNPRINTF(allowTruncation, info->long_descr, sizeof(info->long_descr),

```
But it is another case that will require a separate PR.

## Testing
Testing occurred on Odyssey at Oregon (MI300A) with ROCm 7.2.0.

- PAPI utilities*: ✅ 
- `amd_smi` component tests: ✅ 

__*__ - Utilities included `papi_component_avail`, `papi_native_avail`, and `papi_command_line`.


## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
