### PR TITLE
cuda_range: New component using the CUPTI Profiler Host and Range Profiling APIs

### DIFF
--- a/src/components/cuda_range/README.md
+++ b/src/components/cuda_range/README.md
@@ -1,0 +1,96 @@
+# CUDA_RANGE Component
+ The `cuda_range` component takes advantage of the CUPTI Profiler Host API to perform various host-side
+ tasks necessary for collecting profiling data such as enumeration, configuration, and evaluation.
+ Additionally, the Range Profiler API is utilized to gather the profiling data.
+
+* [Enabling the CUDA_RANGE Component](#enabling-the-cuda_range-component)
+* [Hardware and Software Support](#hardware-and-software-support)
+* [Known Limitations](#known-limitations)
+* [FAQ](#faq)
+
+## Enabling the CUDA_RANGE Component
+To enable reading `cuda_range` native events the user needs to link against a PAPI library
+that was configured with the `cuda_range` component i.e.,
+```
+./configure --with-components="cuda_range"
+```
+Furthermore, the `cuda_range` component must be **ACTIVE**. To ensure this, PAPI requires a single environment variable
+to be set: `PAPI_CUDA_RANGE_ROOT`. As an example:
+```
+PAPI_CUDA_RANGE_ROOT=/packages/cuda/#.#.#
+```
+
+Within `PAPI_CUDA_RANGE_ROOT`, we expect the following standard directories for building:
+```
+PAPI_CUDA_RANGE_ROOT/include
+PAPI_CUDA_RANGE_ROOT/extras/CUPTI/include
+```
+
+and for runtime:
+```
+PAPI_CUDA_RANGE_ROOT/lib64
+PAPI_CUDA_RANGE_ROOT/extras/CUPTI/lib64
+```
+
+To verify the `cuda_range` component is active, run the PAPI utility
+`utils/papi_component_avail` and parse the components under the "Active components" banner
+for `cuda_range`:
+```
+Active components:
+Name:   cuda_range              Profiling of NVIDIA GPU's via CUPTI Profiler Host and Cupti Range Profiling API's.
+```
+
+If the `cuda_range` component does not appear under the "Active components" banner then
+it will appear under the "Compiled-in components" banner with a disabled reason:
+```
+Name:   cuda_range              Profiling of NVIDIA GPU's via CUPTI Profiler Host and Cupti Range Profiling API's.
+   \-> Disabled: Unable to load the CUPTI API's. Try setting PAPI_CUDA_RANGE_ROOT or PAPI_CUDA_RANGE_CUPTI.
+```
+Remedy the disabled reason and the `cuda_range` component will then become active.
+
+## Hardware and Software Support
+
+To see the `cuda_range` components current supported hardware and software please visit the GitHub wiki page
+[Hardware and Software Support - NVIDIA](placeholder).
+
+## Known Limitations
+* Cuda Toolkit 13.0.0 removed support for offline compilation of the NVIDIA GPU architectures with compute capabilities <= 7.5 (i.e. P100 and V100).
+
+* The CUPTI Profiler Host API exposes 1,000s of CUPTI metrics. Due to this, the CUPTI Profiler Host workflow to enumerate metrics and obtain metric descriptions will take several minutes to complete and affect the runtime of the PAPI utility `utils/papi_native_avail`. For instance, on a system with a single NVIDIA GH100 the runtime of `utils/papi_native_avail` is roughly 3 minutes to completion.
+
+# FAQ
+
+## Unusual Installations
+If the dynamic shared objects `libcupti` and `libcudart` cannot be found by setting `PAPI_CUDA_RANGE_ROOT` then two other options remain to find them:
+
+1. Setting the dynamic shared objects corresponding environment variable:
+   ```
+   export PAPI_CUDA_RANGE_CUPTI=/your/path/to/libcupti.so
+   export PAPI_CUDA_RANGE_RUNTIME=/your/path/to/libcudart.so
+   ```
+
+   Note, that if using this option:
+     * You must set the enviornment variable directly to the dynamic shared object as shown above.
+     * If the set path fails to open a dynamic shared object, the `cuda_range` component will be disabled.
+
+2. Using `dlopen` and following the search logic used by the dynamic linker. For this option, it is advised to set `LD_LIBRARY_PATH` to the directories containing your `libcupti` and `libcudart` dynamic shared objects, i.e.
+   ```
+   export LD_LIBRARY_PATH=/your/path/to/WhereLib1CanBeFound:/your/path/to/WhereLib2CanBeFound:$LD_LIBRARY_PATH
+   ```
+
+   Note, that if using this option:
+     * Make sure to separate the dynamic shared objects by a colon (`:`).
+     * This option serves as a final fallback if both `PAPI_CUDA_RANGE_ROOT` or the dynamic shared objects corresponding environment variable are unable to load the respective dynamic shared objects (`libcupti`, `libcudart`).
+
+For the dynamic shared object `libcuda`, it is commonly found in `/lib` or `/usr/lib` rather than the Cuda Toolkit installation. Therefore, `dlopen` is used to search `/lib` and `/usr/lib` by default. If not found, the logic for option 1 and option 2 listed above still hold. In the case of option 1, set the corresponding environment variable:
+```
+export PAPI_CUDA_RANGE_DRIVER=/your/path/to/libcuda.so
+```
+
+## CUDA Contexts
+For each `cuda_range` native event added to a PAPI EventSet a CUDA context is required.
+One can be created in the application code using `cuCtxCreate` or `cudaSetDevice`; however, if a context is not present on the calling CPU thread then the `cuda_range` component will create one based on the `#` from the appended device qualifier (`:device=#`). See `cuda_range/tests` for examples.
+
+
+## CUDA Toolkit Versions
+Once your binaries are compiled, it is possible to swap to other Cuda Toolkit versions without needing to recompile the source. Simply update `PAPI_CUDA_RANGE_ROOT` to the location of the newly desired Cuda Toolkit version. As a note, `LD_LIBRARY_PATH` may need to be updated as well.

--- a/src/components/cuda_range/README.md
+++ b/src/components/cuda_range/README.md
@@ -4,7 +4,8 @@
  Additionally, the Range Profiler API is utilized to gather the profiling data.
 
 * [Enabling the CUDA_RANGE Component](#enabling-the-cuda_range-component)
-* [Hardware and Software Support](#hardware-and-software-support)
+* [Supported Architectures](#supported-architectures)
+* [Multiple Pass Events](#multiple-pass-events)
 * [Known Limitations](#known-limitations)
 * [FAQ](#faq)
 
@@ -48,10 +49,41 @@ Name:   cuda_range              Profiling of NVIDIA GPU's via CUPTI Profiler Hos
 ```
 Remedy the disabled reason and the `cuda_range` component will then become active.
 
-## Hardware and Software Support
+## Supported Architectures
 
-To see the `cuda_range` components current supported hardware and software please visit the GitHub wiki page
-[Hardware and Software Support - NVIDIA](placeholder).
+To see the `cuda_range` component's latest supported hardware and software please visit the [Supported Architectures](https://github.com/icl-utk-edu/papi/wiki/Supported-Architectures#nvidia) GitHub Wiki page.
+
+## Multiple Pass Events 
+The `cuda_range` component supports event's that require multiple passes to be submitted to the GPU for collection. Although the `cuda_range` component supports multiple pass events, they are not supported by default and attempting to add one to a PAPI eventset results in the error code `PAPI_EMULPASS` being returned. Therefore, to signal the desire to profile with multiple pass events and to avoid `PAPI_EMULPASS` being returned the environment variable `PAPI_CUDA_RANGE_ENABLE_MULTIPASSES` must be set:
+```
+export PAPI_CUDA_RANGE_ENABLE_MULTIPASSES=1
+setenv("PAPI_CUDA_RANGE_ENABLE_MULTIPASSES", 1, 1)
+```
+
+To see the available `cuda_range` multiple pass events simply run `utils/papi_native_avail` and parse the output descriptions for `PAPI_CUDA_RANGE_ENABLE_MULTIPASSES`:
+```
+--------------------------------------------------------------------------------
+| cuda_range:::l1tex__throughput
+|            L1TEX Throughput. The number of passes required for collection is 3.
+|            To profile, set the environment variable PAPI_CUDA_RANGE_ENABLE_MULTIPASSES
+|            equal to 1.
+```
+
+Furthermore, in application code you can query the required number of passes for collection for a `cuda_range` native event through `PAPI_get_event_info`:
+```c
+int component_index = PAPI_get_component_index("cuda_range");
+int modifier = PAPI_ENUM_FIRST;
+int eventcode = 0 | PAPI_NATIVE_MASK;
+PAPI_enum_cmp_event(&eventcode, modifier, component_index);
+
+PAPI_event_info_t event_info;
+PAPI_get_event_info(eventcode, &event_info);
+printf("Number of passes: %d\n", event_info.num_passes_for_collection);
+```
+
+To see an example of how to profile `cuda_range` multiple pass events, please see `components/cuda_range/tests/test_cuda_range_multiple_pass_events.cu`.
+
+Lastly, if a PAPI eventset is created with both a single pass and a mutiple pass `cuda_range` native event then the eventset will require multiple passes for collection.
 
 ## Known Limitations
 * Cuda Toolkit 13.0.0 removed support for offline compilation of the NVIDIA GPU architectures with compute capabilities <= 7.5 (i.e. P100 and V100).

--- a/src/components/cuda_range/Rules.cuda_range
+++ b/src/components/cuda_range/Rules.cuda_range
@@ -1,0 +1,15 @@
+COMPSRCS += components/cuda_range/cuda_range_linux.c \
+            components/cuda_range/cuda_range_profiling.cpp \
+
+COMPOBJS += cuda_range_linux.o cuda_range_profiling.o
+
+cuda_range_cflags = -I$(PAPI_CUDA_RANGE_ROOT)/extras/CUPTI/include -I$(PAPI_CUDA_RANGE_ROOT)/include
+CFLAGS  += -g $(cuda_range_cflags)
+
+LDFLAGS += $(LDL)
+
+cuda_range_linux.o: components/cuda_range/cuda_range_linux.c $(HEADERS)
+	$(CC) $(LIBCFLAGS) $(OPTFLAGS) -c $< -o $@
+
+cuda_range_profiling.o: components/cuda_range/cuda_range_profiling.cpp $(HEADERS)
+	$(CXX) $(LIBCFLAGS) $(OPTFLAGS) -c $< -o $@

--- a/src/components/cuda_range/cuda_range_linux.c
+++ b/src/components/cuda_range/cuda_range_linux.c
@@ -1,0 +1,457 @@
+// C STL headers.
+#include <stdint.h>
+#include <string.h>
+
+// Internal headers.
+#include "cuda_range_profiling.h"
+#include "papi.h"
+#include "papi_internal.h"
+#include "papi_vector.h"
+#include "papi_memory.h"
+#include "extras.h"
+
+#define CUDA_RANGE_EVENTS_STOPPED (0x1)
+#define CUDA_RANGE_EVENTS_RUNNING (0x2)
+
+unsigned int _cuda_range_lock;
+
+// Initialization and finalize.
+static int cuda_range_init_component(int cid);
+static int cuda_range_init_thread(hwd_context_t *ctx);
+static int cuda_range_init_control_state(hwd_control_state_t *ctl);
+static int cuda_range_init_private(void);
+static int cuda_range_shutdown_component(void);
+static int cuda_range_shutdown_thread(hwd_context_t *ctx);
+static int cuda_range_cleanup_eventset(hwd_control_state_t *ctl);
+
+//  Set and update component state.
+static int cuda_range_update_control_state(hwd_control_state_t *ctl, NativeInfo_t *ntv_info, int ntv_count, hwd_context_t *ctx);
+static int cuda_range_start(hwd_context_t *ctx, hwd_control_state_t *ctl);
+static int cuda_range_read(hwd_context_t *ctx, hwd_control_state_t *ctl, long long **val, int flags);
+static int cuda_range_stop(hwd_context_t *ctx, hwd_control_state_t *ctl);
+static int cuda_range_reset(hwd_context_t *ctx, hwd_control_state_t *ctl);
+
+// Event conversion.
+static int cuda_range_ntv_enum_events(unsigned int *event_code, int modifier);
+static int cuda_range_ntv_code_to_name(unsigned int event_code, char *name, int len);
+static int cuda_range_ntv_name_to_code(const char *name, unsigned int *event_code);
+static int cuda_range_ntv_code_to_info(unsigned int event_code, PAPI_event_info_t *info);
+static int cuda_range_ntv_code_to_descr(unsigned int event_code, char *descr, int len);
+
+static int cuda_range_set_domain(hwd_control_state_t *ctl, int domain);
+static int cuda_range_ctl(hwd_context_t *ctx, int code, _papi_int_option_t *option);
+
+typedef struct {
+    int initialized;
+    int state;
+    int component_id;
+} cuda_range_context_t;
+
+typedef struct {
+    uint32_t *event_codes;
+    int num_events;
+    cuda_range_ctx_t cuda_range_ctx;
+} cuda_range_control_t;
+
+papi_vector_t _cuda_range_vector = {
+    .cmp_info = {
+        .name = "cuda_range",
+        .short_name = "cuda_range",
+        .version = "1.0",
+        .description = "Profiling of NVIDIA GPU's via CUPTI Profiler Host and Cupti Range Profiling API's.",
+        .initialized = 0,
+    },
+
+    .size = {
+        .context = sizeof(cuda_range_context_t),
+        .control_state = sizeof(cuda_range_control_t),
+        .reg_value = 1,
+        .reg_alloc = 1,
+    },
+
+    .init_component = cuda_range_init_component,
+    .init_thread = cuda_range_init_thread,
+    .init_control_state = cuda_range_init_control_state,
+    .shutdown_component = cuda_range_shutdown_component,
+    .shutdown_thread = cuda_range_shutdown_thread,
+    .cleanup_eventset = cuda_range_cleanup_eventset,
+
+    .update_control_state = cuda_range_update_control_state,
+    .start = cuda_range_start,
+    .stop = cuda_range_stop,
+    .read = cuda_range_read,
+    .reset = cuda_range_reset,
+
+    .ntv_enum_events = cuda_range_ntv_enum_events,
+    .ntv_code_to_name = cuda_range_ntv_code_to_name,
+    .ntv_name_to_code = cuda_range_ntv_name_to_code,
+    .ntv_code_to_descr = cuda_range_ntv_code_to_descr,
+    .ntv_code_to_info = cuda_range_ntv_code_to_info,
+
+    .set_domain = cuda_range_set_domain,
+    .ctl = cuda_range_ctl,
+};
+
+static int check_n_initialize(void);
+
+int cuda_range_init_component(int cid)
+{
+    _cuda_range_vector.cmp_info.CmpIdx = cid;
+    _cuda_range_vector.cmp_info.num_native_events = -1;
+    _cuda_range_vector.cmp_info.num_cntrs = -1;
+    _cuda_range_vector.cmp_info.num_mpx_cntrs = -1;
+    _cuda_range_lock = PAPI_NUM_LOCK + NUM_INNER_LOCK + cid;
+
+    _cuda_range_vector.cmp_info.disabled = PAPI_EDELAY_INIT;
+    int strLen = snprintf(_cuda_range_vector.cmp_info.disabled_reason, sizeof(_cuda_range_vector.cmp_info.disabled_reason),
+                          "%s", "Not initialized. Access component events to initialize it.");
+    if (strLen < 0 || (size_t) strLen >= sizeof(_cuda_range_vector.cmp_info.disabled_reason)) {
+        SUBDBG("Failed to fully write disabled reason into buffer. Proceeding.\n");
+    }  
+
+    return PAPI_EDELAY_INIT;
+}
+
+int cuda_range_init_thread(hwd_context_t *ctx)
+{
+    cuda_range_context_t *cuda_range_ctx = (cuda_range_context_t *) ctx;
+    memset(cuda_range_ctx, 0, sizeof(*cuda_range_ctx));
+    cuda_range_ctx->initialized = 1;
+    cuda_range_ctx->component_id = _cuda_range_vector.cmp_info.CmpIdx;
+
+    return PAPI_OK;
+}
+
+int cuda_range_init_control_state(hwd_control_state_t *ctl __attribute__((unused)))
+{
+    return check_n_initialize();
+}
+
+static int evt_get_count(int *count)
+{
+    unsigned int event_code = 0;
+
+    if (cuda_range_event_enum(&event_code, PAPI_ENUM_FIRST) == PAPI_OK) {
+        ++(*count);
+    }
+    while (cuda_range_event_enum(&event_code, PAPI_ENUM_EVENTS) == PAPI_OK) {
+        ++(*count);
+    }
+
+    return PAPI_OK;
+}
+
+int cuda_range_init_private(void)
+{
+    int papi_errno = PAPI_OK;
+
+    _papi_hwi_lock(COMPONENT_LOCK);
+
+    if (_cuda_range_vector.cmp_info.initialized) {
+        papi_errno = _cuda_range_vector.cmp_info.disabled;
+        goto fn_exit;
+    }
+
+    int strLen;
+    papi_errno = initialize_cuda_range_component();
+    if (papi_errno != PAPI_OK) {
+        _cuda_range_vector.cmp_info.disabled = papi_errno;
+        const char *err_string = cuda_range_get_last_err_msg();
+        strLen = snprintf(_cuda_range_vector.cmp_info.disabled_reason, sizeof(_cuda_range_vector.cmp_info.disabled_reason),
+                              "%s", err_string);
+        if (strLen < 0 || (size_t) strLen >= sizeof(_cuda_range_vector.cmp_info.disabled_reason)){
+            SUBDBG("Failed to fully write the cuda_range disabled reason. Proceeding.\n");
+        }
+
+        goto fn_fail;
+    }
+
+    int number_of_native_events = 0;
+    papi_errno = evt_get_count(&number_of_native_events);
+    if (papi_errno != PAPI_OK) {
+        goto fn_fail;
+    }
+    _cuda_range_vector.cmp_info.num_native_events = number_of_native_events;
+
+    int number_of_counters = 0;
+    papi_errno = get_the_maximum_number_of_hardware_metrics_per_device(&number_of_counters);
+    if (papi_errno != PAPI_OK) {
+        goto fn_fail;
+    }
+    _cuda_range_vector.cmp_info.num_cntrs = number_of_counters;
+    _cuda_range_vector.cmp_info.num_mpx_cntrs = number_of_counters;
+
+    _cuda_range_vector.cmp_info.initialized = 1;
+    strLen = snprintf(_cuda_range_vector.cmp_info.disabled_reason, sizeof(_cuda_range_vector.cmp_info.disabled_reason),
+                          "%s", "");
+    if (strLen < 0 || (size_t) strLen >= sizeof(_cuda_range_vector.cmp_info.disabled_reason)) {
+        SUBDBG("Failed to fully write the empty cuda_range disabled reason. Proceeding.\n");
+    }
+    
+  fn_exit:
+    _cuda_range_vector.cmp_info.disabled = papi_errno;
+    _papi_hwi_unlock(COMPONENT_LOCK);
+    return papi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int cuda_range_shutdown_component(void)
+{
+    if (_cuda_range_vector.cmp_info.initialized == 0) {
+        SUBDBG("PAPI_shutdown has been called, but either the cuda_range component was never"
+               " initialized or PAPI_shutdown was already previously called.\n");
+        return PAPI_OK;
+    }
+
+    if (_cuda_range_vector.cmp_info.disabled != PAPI_OK) {
+        SUBDBG("PAPI_shutdown has been called, but the cuda_range component is disabled.\n");
+        return PAPI_OK;
+    }
+
+    _cuda_range_vector.cmp_info.initialized = 0;
+
+    return cuda_range_unload_function_pointers_and_shutdown();
+}
+
+int cuda_range_shutdown_thread(hwd_context_t *ctx)
+{
+    cuda_range_context_t *cuda_range_ctx = (cuda_range_context_t *) ctx;
+    cuda_range_ctx->initialized = 0;
+    cuda_range_ctx->state = 0;
+
+    return PAPI_OK;
+}
+
+int cuda_range_cleanup_eventset(hwd_control_state_t *ctl)
+{
+    cuda_range_control_t *cuda_range_ctl = (cuda_range_control_t *) ctl;
+    papi_free(cuda_range_ctl->event_codes);
+    cuda_range_ctl->event_codes = NULL;
+    cuda_range_ctl->num_events = 0;
+
+    return PAPI_OK;
+}
+
+static int update_native_events(cuda_range_control_t *, NativeInfo_t *, int);
+
+
+int initialize_cuda_range_ctx(cuda_range_ctx_t *cuda_range_ctx, uint32_t *event_codes, int native_event_count)
+{
+    if ((*cuda_range_ctx) == NULL) {
+        (*cuda_range_ctx) = (cuda_range_ctx_t) calloc(1, sizeof(struct cuda_range_ctx));
+        if ((*cuda_range_ctx) == NULL) {
+            SUBDBG("Failed to allocate memory for cuda_range_ctl->cuda_range_ctx.\n");
+            return PAPI_ENOMEM;
+        }   
+    }   
+
+    (*cuda_range_ctx)->event_codes = event_codes;
+    (*cuda_range_ctx)->num_events = native_event_count;
+    (*cuda_range_ctx)->counters = (long long *) realloc((*cuda_range_ctx)->counters, (*cuda_range_ctx)->num_events * sizeof(long long));
+    if ((*cuda_range_ctx)->counters == NULL) {
+        SUBDBG("Failed to allocate memory for cuda_range_ctl->cuda_range_ctx->counters.\n");
+        return PAPI_ENOMEM;
+    } 
+
+    return PAPI_OK;
+}
+
+
+int cuda_range_update_control_state(hwd_control_state_t *ctl, NativeInfo_t *ntv_info, int ntv_count, hwd_context_t *ctx __attribute__((unused)))
+{
+    int papi_errno = check_n_initialize();
+    if (papi_errno != PAPI_OK) {
+        return papi_errno;
+    }
+
+    cuda_range_control_t *cuda_range_ctl = (cuda_range_control_t *) ctl;
+
+    papi_errno = update_native_events(cuda_range_ctl, ntv_info, ntv_count);
+    if (papi_errno != PAPI_OK) {
+        return papi_errno;
+    }
+
+    papi_errno = initialize_cuda_range_ctx(&cuda_range_ctl->cuda_range_ctx, cuda_range_ctl->event_codes, ntv_count);
+    if (papi_errno != PAPI_OK) {
+        return papi_errno;
+    }
+
+    papi_errno = cuda_range_store_added_native_events(cuda_range_ctl->event_codes, ntv_count);
+    if (papi_errno != PAPI_OK) {
+        return papi_errno;
+    }
+
+    return PAPI_OK;
+}
+
+int update_native_events(cuda_range_control_t *ctl, NativeInfo_t *ntv_info, int ntv_count)
+{
+    int papi_errno = PAPI_OK;
+
+    if (ntv_count != ctl->num_events) {
+        ctl->num_events = ntv_count;
+        if (ntv_count == 0) {
+            papi_free(ctl->event_codes);
+            ctl->event_codes = NULL;
+            goto fn_exit;
+        }
+        else {
+            ctl->event_codes = papi_realloc(ctl->event_codes, ntv_count * sizeof(*ctl->event_codes));
+            if (ctl->event_codes == NULL) {
+                papi_errno = PAPI_ENOMEM;
+                goto fn_fail;
+            }
+        }
+    }
+
+    int i;
+    for (i = 0; i < ntv_count; ++i) {
+        ctl->event_codes[i] = ntv_info[i].ni_event;
+        ntv_info[i].ni_position = i;
+    }
+
+  fn_exit:
+    return papi_errno;
+  fn_fail:
+    ctl->num_events = 0;
+    goto fn_exit;
+}
+
+int cuda_range_start(hwd_context_t *ctx, hwd_control_state_t *ctl)
+{
+    cuda_range_context_t *cuda_range_ctx = (cuda_range_context_t *) ctx;
+    cuda_range_control_t *cuda_range_ctl = (cuda_range_control_t *) ctl;
+
+    if (cuda_range_ctl->num_events == 0) {
+        SUBDBG("Error! Cannot call PAPI_start on an empty eventset.\n");
+        return PAPI_ENOSUPP;
+    }
+
+    if (cuda_range_ctx->state == CUDA_RANGE_EVENTS_RUNNING) {
+        SUBDBG("Error! Cannot PAPI_start more than one eventset at a time for every component.\n");
+        return PAPI_EISRUN;
+    }
+
+    int papi_errno = cuda_range_start_profiling();
+    if (papi_errno != PAPI_OK) {
+        return papi_errno;
+    }
+
+    cuda_range_ctx->state = CUDA_RANGE_EVENTS_RUNNING;
+
+    return PAPI_OK;
+}
+
+int cuda_range_read(hwd_context_t *ctx __attribute__((unused)), hwd_control_state_t *ctl, long long **val, int flags __attribute__((unused)))
+{
+    cuda_range_control_t *cuda_range_ctl = (cuda_range_control_t *) ctl;
+
+    int papi_errno = cuda_range_decode_and_evaluate_counter_data(cuda_range_ctl->cuda_range_ctx, val);
+    if (papi_errno != PAPI_OK) {
+        return papi_errno;
+    }
+
+    return PAPI_OK;
+}
+
+int cuda_range_stop(hwd_context_t *ctx, hwd_control_state_t *ctl)
+{
+    cuda_range_context_t *cuda_range_ctx = (cuda_range_context_t *) ctx;
+    cuda_range_control_t *cuda_range_ctl = (cuda_range_control_t *) ctl;
+
+    if (cuda_range_ctx->state == CUDA_RANGE_EVENTS_STOPPED) {
+        SUBDBG("Error! Cannot PAPI_stop an eventset that has yet to have PAPI_start called on it.\n");
+        return PAPI_ENOTRUN;
+    }
+
+    int papi_errno = cuda_range_stop_profiling();
+    if (papi_errno != PAPI_OK) {
+        return papi_errno;
+    } 
+
+    cuda_range_ctx->state = CUDA_RANGE_EVENTS_STOPPED;
+    cuda_range_ctl->cuda_range_ctx = NULL;
+
+    return papi_errno;
+}
+
+int cuda_range_reset(hwd_context_t *ctx __attribute__((unused)), hwd_control_state_t *ctl)
+{
+    cuda_range_control_t *cuda_range_ctl = (cuda_range_control_t *) ctl;
+
+    return cuda_range_reset_counters(cuda_range_ctl->cuda_range_ctx);
+}
+
+int cuda_range_ntv_enum_events(unsigned int *event_code, int modifier)
+{
+    int papi_errno = check_n_initialize();
+    if (papi_errno != PAPI_OK) {
+        return papi_errno;
+    }
+
+    return cuda_range_event_enum(event_code, modifier);
+}
+
+int cuda_range_ntv_code_to_name(unsigned int event_code, char *name, int len)
+{
+    int papi_errno = check_n_initialize();
+    if (papi_errno != PAPI_OK) {
+        return papi_errno;
+    }
+
+    return cuda_range_native_event_code_to_native_event_name(event_code, name, len);
+}
+
+int cuda_range_ntv_name_to_code(const char *name, unsigned int *code)
+{
+    int papi_errno = check_n_initialize();
+    if (papi_errno != PAPI_OK) {
+        return papi_errno;
+    }
+
+    uint32_t event_code;
+    papi_errno = cuda_range_native_event_name_to_native_event_code(name, &event_code);
+    if(papi_errno != PAPI_OK) {
+        return papi_errno;
+    }
+    *code = (unsigned int) event_code;
+
+    return PAPI_OK;
+}
+
+int cuda_range_ntv_code_to_descr(unsigned int event_code __attribute__((unused)), char *descr __attribute__((unused)), int len __attribute__((unused)))
+{
+    SUBDBG("cuda_range_ntv_code_to_info is implemented; therefore, implementation of"
+           " cuda_range_ntv_code_to_descr should not be necessary.\n");
+    return PAPI_ENOIMPL;
+}
+
+int cuda_range_ntv_code_to_info(unsigned int event_code, PAPI_event_info_t *info)
+{
+    int papi_errno = check_n_initialize();
+    if (papi_errno != PAPI_OK) {
+        return papi_errno;
+    }
+
+    return cuda_range_event_code_to_info(event_code, info);
+}
+
+int cuda_range_set_domain(hwd_control_state_t *ctl __attribute__((unused)), int domain __attribute__((unused)))
+{
+    return PAPI_OK;
+}
+
+int cuda_range_ctl(hwd_context_t *ctx __attribute__((unused)), int code __attribute__((unused)), _papi_int_option_t *option __attribute__((unused)))
+{
+    return PAPI_OK;
+}
+
+int check_n_initialize(void)
+{
+    if (!_cuda_range_vector.cmp_info.initialized) {
+        return cuda_range_init_private();
+    }
+
+    return _cuda_range_vector.cmp_info.disabled;
+}

--- a/src/components/cuda_range/cuda_range_linux.c
+++ b/src/components/cuda_range/cuda_range_linux.c
@@ -265,6 +265,11 @@ int cuda_range_update_control_state(hwd_control_state_t *ctl, NativeInfo_t *ntv_
         return papi_errno;
     }
 
+    // This check is required such that PAPI_EMULPASS error codes are caught.
+    if (ntv_count == 0) {
+        return PAPI_OK;
+    }
+
     cuda_range_control_t *cuda_range_ctl = (cuda_range_control_t *) ctl;
 
     papi_errno = update_native_events(cuda_range_ctl, ntv_info, ntv_count);

--- a/src/components/cuda_range/cuda_range_profiling.cpp
+++ b/src/components/cuda_range/cuda_range_profiling.cpp
@@ -1,0 +1,2792 @@
+// C++ standard library headers
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <map>
+#include <string>
+#include <sstream>
+#include <vector>
+#include <set>
+
+// POSIX standard headers.
+#include <dlfcn.h>
+#include <dirent.h>
+
+// CTK headers.
+#include <cuda_runtime_api.h>
+#include <cupti_profiler_host.h>
+#include <cupti_profiler_target.h>
+#include <cupti_target.h>
+#include <cupti_range_profiler.h>
+
+// Internal headers.
+#include "cuda_range_profiling.h"
+#include "cuda_range_profiling.hpp"
+#include "papi.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "papi_debug.h"
+#include "papi_internal.h"
+#include "papi_memory.h"
+#ifdef __cplusplus
+}
+#endif
+
+// 0 bits are left to be used with uint32_t. Therefore, if another qualifier is added bits will need
+// to be pulled from NAMEID_WIDTH or implement uint64_t.
+#define EVENTS_WIDTH    (sizeof(uint32_t) * 8)
+#define STAT_WIDTH      ( 3 ) // 2^3 = 8
+#define DEVICE_WIDTH    ( 6 ) // 2^6 = 64
+#define SUBMETRIC_WIDTH ( 5 ) // 2^5 = 32
+#define QLMASK_WIDTH    ( 3 ) // 2^2 = 4
+#define NAMEID_WIDTH    ( 15 ) // 2^15 = 32768
+#define UNUSED_WIDTH    (EVENTS_WIDTH - DEVICE_WIDTH - QLMASK_WIDTH - NAMEID_WIDTH - STAT_WIDTH - SUBMETRIC_WIDTH)
+#define STAT_SHIFT      (EVENTS_WIDTH - UNUSED_WIDTH - STAT_WIDTH)
+#define SUBMETRIC_SHIFT (EVENTS_WIDTH - UNUSED_WIDTH - STAT_WIDTH - SUBMETRIC_WIDTH)
+#define DEVICE_SHIFT    (EVENTS_WIDTH - UNUSED_WIDTH - STAT_WIDTH - SUBMETRIC_WIDTH - DEVICE_WIDTH)
+#define QLMASK_SHIFT    (DEVICE_SHIFT - QLMASK_WIDTH)
+#define NAMEID_SHIFT    (QLMASK_SHIFT - NAMEID_WIDTH)
+#define STAT_MASK       ((0xFFFFFFFF >> (EVENTS_WIDTH - STAT_WIDTH)) << STAT_SHIFT)
+#define DEVICE_MASK     ((0xFFFFFFFF >> (EVENTS_WIDTH - DEVICE_WIDTH)) << DEVICE_SHIFT)
+#define SUBMETRIC_MASK  ((0xFFFFFFFF >> (EVENTS_WIDTH - SUBMETRIC_WIDTH)) << SUBMETRIC_SHIFT)
+#define QLMASK_MASK     ((0xFFFFFFFF >> (EVENTS_WIDTH - QLMASK_WIDTH)) << QLMASK_SHIFT)
+#define NAMEID_MASK     ((0xFFFFFFFF >> (EVENTS_WIDTH - NAMEID_WIDTH)) << NAMEID_SHIFT)
+#define SUBMETRIC_FLAG  (0x4)
+#define STAT_FLAG       (0x2)
+#define DEVICE_FLAG     (0x1)
+#define NOQUAL_FLAG     (0x0)
+
+// CUPTI Profiler Host API.
+typedef CUptiResult ( *cuptiProfilerHostInitialize_t ) (CUpti_Profiler_Host_Initialize_Params *pParams);
+cuptiProfilerHostInitialize_t cuptiProfilerHostInitializePtr;
+typedef CUptiResult ( *cuptiProfilerHostGetMaxNumHardwareMetricsPerPass_t ) (CUpti_Profiler_Host_GetMaxNumHardwareMetricsPerPass_Params *pParams);
+cuptiProfilerHostGetMaxNumHardwareMetricsPerPass_t cuptiProfilerHostGetMaxNumHardwareMetricsPerPassPtr;
+typedef CUptiResult ( *cuptiProfilerHostGetBaseMetrics_t ) (CUpti_Profiler_Host_GetBaseMetrics_Params *pParams);
+cuptiProfilerHostGetBaseMetrics_t cuptiProfilerHostGetBaseMetricsPtr;
+typedef CUptiResult ( *cuptiProfilerHostGetSubMetrics_t ) (CUpti_Profiler_Host_GetSubMetrics_Params *pParams);
+cuptiProfilerHostGetSubMetrics_t cuptiProfilerHostGetSubMetricsPtr;
+typedef CUptiResult ( *cuptiProfilerHostGetMetricProperties_t ) (CUpti_Profiler_Host_GetMetricProperties_Params *pParams);
+cuptiProfilerHostGetMetricProperties_t cuptiProfilerHostGetMetricPropertiesPtr;
+typedef CUptiResult ( *cuptiProfilerHostGetSupportedChips_t ) (CUpti_Profiler_Host_GetSupportedChips_Params *pParams);
+cuptiProfilerHostGetSupportedChips_t cuptiProfilerHostGetSupportedChipsPtr;
+typedef CUptiResult ( *cuptiProfilerHostConfigAddMetrics_t ) (CUpti_Profiler_Host_ConfigAddMetrics_Params *pParams);
+cuptiProfilerHostConfigAddMetrics_t cuptiProfilerHostConfigAddMetricsPtr; 
+typedef CUptiResult ( *cuptiProfilerHostGetConfigImageSize_t ) (CUpti_Profiler_Host_GetConfigImageSize_Params *pParams);
+cuptiProfilerHostGetConfigImageSize_t cuptiProfilerHostGetConfigImageSizePtr;
+typedef CUptiResult ( *cuptiProfilerHostGetConfigImage_t ) (CUpti_Profiler_Host_GetConfigImage_Params *pParams);
+cuptiProfilerHostGetConfigImage_t cuptiProfilerHostGetConfigImagePtr;
+typedef CUptiResult ( *cuptiProfilerHostGetNumOfPasses_t ) (CUpti_Profiler_Host_GetNumOfPasses_Params *pParams);
+cuptiProfilerHostGetNumOfPasses_t cuptiProfilerHostGetNumOfPassesPtr;
+typedef CUptiResult ( *cuptiProfilerHostEvaluateToGpuValues_t ) (CUpti_Profiler_Host_EvaluateToGpuValues_Params *pParams);
+cuptiProfilerHostEvaluateToGpuValues_t cuptiProfilerHostEvaluateToGpuValuesPtr;
+typedef CUptiResult ( *cuptiProfilerHostDeinitialize_t ) (CUpti_Profiler_Host_Deinitialize_Params *pParams);
+cuptiProfilerHostDeinitialize_t cuptiProfilerHostDeinitializePtr;
+
+// CUPTI Range Profiling API.
+typedef CUptiResult ( *cuptiRangeProfilerEnable_t ) (CUpti_RangeProfiler_Enable_Params *pParams);
+cuptiRangeProfilerEnable_t cuptiRangeProfilerEnablePtr;
+typedef CUptiResult ( *cuptiRangeProfilerGetCounterDataSize_t ) (CUpti_RangeProfiler_GetCounterDataSize_Params *pParams);
+cuptiRangeProfilerGetCounterDataSize_t cuptiRangeProfilerGetCounterDataSizePtr;
+typedef CUptiResult ( *cuptiRangeProfilerCounterDataImageInitialize_t ) (CUpti_RangeProfiler_CounterDataImage_Initialize_Params *pParams);
+cuptiRangeProfilerCounterDataImageInitialize_t cuptiRangeProfilerCounterDataImageInitializePtr;
+typedef CUptiResult ( *cuptiRangeProfilerSetConfig_t ) (CUpti_RangeProfiler_SetConfig_Params *pParams);
+cuptiRangeProfilerSetConfig_t cuptiRangeProfilerSetConfigPtr;
+typedef CUptiResult ( *cuptiRangeProfilerStart_t ) (CUpti_RangeProfiler_Start_Params *pParams);
+cuptiRangeProfilerStart_t cuptiRangeProfilerStartPtr;
+typedef CUptiResult ( *cuptiRangeProfilerPushRange_t ) (CUpti_RangeProfiler_PushRange_Params *pParams);
+cuptiRangeProfilerPushRange_t cuptiRangeProfilerPushRangePtr;
+typedef CUptiResult ( *cuptiRangeProfilerPopRange_t ) (CUpti_RangeProfiler_PopRange_Params *pParams);
+cuptiRangeProfilerPopRange_t cuptiRangeProfilerPopRangePtr;
+typedef CUptiResult ( *cuptiRangeProfilerStop_t ) (CUpti_RangeProfiler_Stop_Params *pParams);
+cuptiRangeProfilerStop_t cuptiRangeProfilerStopPtr;
+typedef CUptiResult ( *cuptiRangeProfilerDecodeData_t ) (CUpti_RangeProfiler_DecodeData_Params *pParams);
+cuptiRangeProfilerDecodeData_t cuptiRangeProfilerDecodeDataPtr;
+typedef CUptiResult ( *cuptiRangeProfilerDisable_t ) (CUpti_RangeProfiler_Disable_Params *pParams);
+cuptiRangeProfilerDisable_t cuptiRangeProfilerDisablePtr;
+typedef CUptiResult ( *cuptiRangeProfilerCounterDataGetRangeInfo_t) (CUpti_RangeProfiler_CounterData_GetRangeInfo_Params *pParams);
+cuptiRangeProfilerCounterDataGetRangeInfo_t cuptiRangeProfilerCounterDataGetRangeInfoPtr;
+
+// CUPTI API Misc.
+typedef CUptiResult ( *cuptiProfilerGetCounterAvailability_t ) ( CUpti_Profiler_GetCounterAvailability_Params *pParams );
+cuptiProfilerGetCounterAvailability_t cuptiProfilerGetCounterAvailabilityPtr;
+typedef CUptiResult ( *cuptiDeviceGetChipName_t ) (CUpti_Device_GetChipName_Params *pParams);
+cuptiDeviceGetChipName_t cuptiDeviceGetChipNamePtr;
+typedef CUptiResult ( *cuptiProfilerInitialize_t ) (CUpti_Profiler_Initialize_Params *pParams);
+cuptiProfilerInitialize_t cuptiProfilerInitializePtr;
+typedef CUptiResult ( *cuptiProfilerDeInitialize_t ) (CUpti_Profiler_DeInitialize_Params *pParams);
+cuptiProfilerDeInitialize_t cuptiProfilerDeInitializePtr;
+
+// CUDA Runtime API.
+typedef cudaError_t ( *cudaGetDeviceCount_t ) (int *count);
+cudaGetDeviceCount_t cudaGetDeviceCountPtr;
+typedef cudaError_t ( *cudaRuntimeGetVersion_t ) (int *runtimeVersion);
+cudaRuntimeGetVersion_t cudaRuntimeGetVersionPtr;
+
+// CUDA Driver API.
+ typedef CUresult (*cuInit_t) (unsigned int flags);
+cuInit_t cuInitPtr;
+typedef CUresult ( *cuCtxCreate_t ) (CUcontext* pctx, CUctxCreateParams* ctxCreateParams, unsigned int  flags, CUdevice dev);
+cuCtxCreate_t cuCtxCreatePtr;
+typedef CUresult ( *cuCtxDestroy_t ) (CUcontext ctx);
+cuCtxDestroy_t cuCtxDestroyPtr;
+typedef CUresult ( *cuCtxGetCurrent_t ) (CUcontext *pctx);
+cuCtxGetCurrent_t cuCtxGetCurrentPtr;
+typedef CUresult ( *cuCtxPopCurrent_t ) (CUcontext *pctx);
+cuCtxPopCurrent_t cuCtxPopCurrentPtr;
+typedef CUresult ( *cuCtxPushCurrent_t ) (CUcontext ctx);
+cuCtxPushCurrent_t cuCtxPushCurrentPtr;
+typedef CUresult ( *cuCtxGetDevice_v2_t ) (CUdevice *device, CUcontext ctx);
+cuCtxGetDevice_v2_t cuCtxGetDevice_v2Ptr;
+
+// CUDA driver, runtime, and CUPTI handles for dlsym.
+void *dl_driver_handle = NULL;
+void *dl_runtime_handle = NULL;
+void *dl_cupti_handle = NULL;
+
+// Reserves an NVIDIA device for profiling.
+int64_t device_bitmask;
+
+// CUPTI metric enumeration.
+std::map<std::string, cupti_metric_info_t> cupti_metrics;
+std::vector<std::string> cupti_metrics_keys;
+
+// CUPTI profiling and metric metadata.
+class CuptiProfile;
+thread_local std::map<int, CuptiProfile> cupti_profile_per_device;
+thread_local std::map<int, CuptiProfile> cupti_profile_metric_descriptions;
+
+/**
+ *  @}
+ ******************************************************************************/
+ 
+/***************************************************************************//**
+ *  @name Workflow to load function pointers
+ *  @{
+ */
+
+/**
+ * @brief Search and load CUDA and CUPTI shared objects
+ *        from the system paths.
+ *
+ * @param *so_names_to_search
+ *   Varying names of the shared object we want to search for.
+ */
+void *search_and_load_from_system_paths(std::vector<std::string> &so_names_to_search)
+{
+    for (std::string so_name : so_names_to_search) {
+        void *so = dlopen(so_name.c_str(), RTLD_NOW | RTLD_GLOBAL);
+        if (so) {
+            return so;
+        }
+    }
+
+    return NULL;
+}
+
+/**
+ * @brief Overloaded function to search and load shared objects by
+ *        the full path.
+ *
+ * @param *full_path_to_shared_object
+ *   Explicit path to the shared object.
+ */
+void *search_and_load_shared_libraries(const char *full_path_to_shared_object)
+{
+    void *so = dlopen(full_path_to_shared_object, RTLD_NOW | RTLD_GLOBAL);
+
+    return so;
+}
+
+/**@class
+ * @brief Search and load CUDA and CUPTI shared objects.
+ *
+ * @param *so_main_name
+ *   The name of the shared object e.g. libcudart. This is used
+ *   to select the standard_sub_paths to use.
+ * @param *parent_path
+ *   The main path we will use to search for the shared objects.
+ * @param &so_names_to_search
+ *   Varying names of the shared object we want to search for. 
+ */
+void *search_and_load_shared_libraries(std::string &so_main_name, const char *parent_path, std::vector<std::string> &so_names_to_search_for)
+{
+    void *so = NULL;
+    std::vector<std::string> standard_sub_paths;
+    // Standard subpaths for the libcudart shared object.
+    if (so_main_name.compare("libcudart")  == 0) {
+        standard_sub_paths.push_back("/lib64/");
+    }
+    // Standard subpaths for the libcupti shared object.
+    else if (so_main_name.compare("libcupti") == 0) {
+        standard_sub_paths.push_back("/extras/CUPTI/lib64/");
+        standard_sub_paths.push_back("/lib64/");
+    }
+    // Provided shared object is not accounted for, should never occur in production code.
+    else {
+        SUBDBG("The provided .so name (%s) is not accounted for. Enter a proper .so name or update the conditional workflow.\n", so_main_name.c_str());
+        return NULL;
+    }
+
+    std::string path_to_shared_object;
+    for (std::string sub_path : standard_sub_paths) {
+        // Construct path to search for dl names.
+        std::string directory_path_to_search = parent_path + sub_path;
+
+        DIR *dir = opendir(directory_path_to_search.c_str());
+        if (dir == NULL) {
+            SUBDBG("Directory path %s could not be opened. Continuing to next subpath if one exists for the shared object.\n",
+                   directory_path_to_search.c_str());
+            continue;
+        }
+
+        int status = 0;
+        for (std::string so_name : so_names_to_search_for) {
+            struct dirent *dirEntry = NULL;
+            while( ( dirEntry = readdir(dir) ) != NULL ) {
+                int result = -1;
+                std::string nameOfDirEntry = dirEntry->d_name;
+                // The so name contains .so or .so.1; therefore, we look for an exact string match (e.g. libcupti.so == libcupti.so).
+                if (so_name.find(".so") != std::string::npos) {
+                    result = so_name.compare(nameOfDirEntry);
+                }
+                // The so name does not contain .so or .so.1; therefore, we look for a substring match (e.g. libcupti in libcupti.so.2025.3.1).
+                else {
+                    result = so_name.compare(0, so_name.length(), nameOfDirEntry);
+                }
+
+                if (result == 0) {
+                    path_to_shared_object = directory_path_to_search + nameOfDirEntry;
+
+                    status = closedir(dir);
+                    if (status != 0) {
+                        SUBDBG("Failed to close directory from path %s. Continuing.\n");
+                    }
+
+                    goto open;
+                }
+            }
+            // Reset the position of the directory stream.
+            rewinddir(dir);
+        }
+        status = closedir(dir);
+        if (status != 0) {
+            SUBDBG("Failed to close directory from path %s. Continuing.\n");
+        }
+    }
+
+    return NULL;
+  exit:
+    return so;
+  open:
+    so = dlopen(path_to_shared_object.c_str(), RTLD_NOW | RTLD_GLOBAL);
+    goto exit;
+}
+
+/**
+  * @brief Load the Driver API functions used internally in the cuda_range
+  *        component.
+  *
+  *        The libcuda shared library is searched for using the shared library names
+  *        libcuda.so, libcuda.so.1, and a catch all libcuda. Once the libcuda shared
+  *        library is found the used Driver API functions are dlsym'd.
+*/
+int load_cuda_driver_function_pointers(void)
+{
+    std::vector<std::string> so_names_to_search = {"libcuda.so", "libcuda.so.1", "libcuda"};
+
+    char *papi_cuda_range_driver = std::getenv("PAPI_CUDA_RANGE_DRIVER");
+    if (papi_cuda_range_driver != NULL) {
+        dl_driver_handle = search_and_load_shared_libraries(papi_cuda_range_driver);
+        if (dl_driver_handle != NULL) {
+            goto load_functions;
+        }
+        else {
+            SUBDBG("PAPI_CUDA_RANGE_DRIVER was set, but did not result in successfully loading the libcuda shared object."
+                   " Set PAPI_CUDA_RANGE_DRIVER to a valid libcuda shared object.\n");
+            return PAPI_ESYS;
+        }
+    }
+    else {
+        SUBDBG("PAPI_CUDA_RANGE_DRIVER was not set. Falling back to dlopen to search for the libcuda shared object.\n");
+    }
+
+    dl_driver_handle = search_and_load_from_system_paths(so_names_to_search);
+    if (dl_driver_handle == NULL) {
+        SUBDBG("Failed to load a libcudart shared object. Try setting PAPI_CUDA_RANGE_RUNTIME.\n");
+    }
+
+    dl_driver_handle = dlopen("libcuda.so", RTLD_NOW | RTLD_GLOBAL);
+
+  load_functions:
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuInitPtr, cuInit_t, dl_driver_handle, "cuInit");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuCtxCreatePtr, cuCtxCreate_t, dl_driver_handle, "cuCtxCreate_v4");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuCtxDestroyPtr, cuCtxDestroy_t, dl_driver_handle, "cuCtxDestroy");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuCtxGetCurrentPtr, cuCtxGetCurrent_t, dl_driver_handle, "cuCtxGetCurrent");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuCtxPopCurrentPtr, cuCtxPopCurrent_t, dl_driver_handle, "cuCtxPopCurrent");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuCtxPushCurrentPtr, cuCtxPushCurrent_t, dl_driver_handle, "cuCtxPushCurrent");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuCtxGetDevice_v2Ptr, cuCtxGetDevice_v2_t, dl_driver_handle, "cuCtxGetDevice_v2");
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Inform the system the dl_driver_handle object is no longer needed by
+  *        the application.
+*/
+void unload_cuda_driver_function_pointers(void)
+{
+    int retval = dlclose(dl_driver_handle);
+    if (retval != 0) {
+        // dlclose can fail, but this function is called at PAPI_shutdown which has a return
+        // type of void. Therefore, an error code here would never make it back to the user.
+        SUBDBG("Failed to close the handle associated with the driver function pointers due to -- %s.\n", dlerror());
+    }
+
+    cuCtxCreatePtr       = nullptr;
+    cuCtxDestroyPtr      = nullptr;
+    cuCtxGetCurrentPtr   = nullptr;
+    cuCtxPopCurrentPtr   = nullptr;
+    cuCtxPushCurrentPtr  = nullptr;
+    cuCtxGetDevice_v2Ptr = nullptr;
+    cuInitPtr            = nullptr;
+
+    return;
+}
+
+/**
+  * @brief Load the Runtime API functions used internally in the cuda_range
+  *        component.
+  *
+  *        The libcudart shared library is searched for using the shared library names
+  *        libcudart.so, libcudart.so.1, and a catch all libcudart. Once the libcudart shared
+  *        library is found the used Runtime API functions are dlsym'd.
+*/
+int load_cuda_runtime_function_pointers(void)
+{
+    // The libcudart shared object names that we will search for.
+    // Note that, the libcudart without .so should always be the last entry
+    // in the vector.
+    std::vector<std::string> so_names_to_search = {"libcudart.so", "libcudart.so.1", "libcudart"};
+
+    char *papi_cuda_range_runtime = std::getenv("PAPI_CUDA_RANGE_RUNTIME"), *papi_cuda_range_root = std::getenv("PAPI_CUDA_RANGE_ROOT");
+    // If a user set PAPI_CUDA_RANGE_RUNTIME with a path to a shared object, attempt to load it (takes precedent over PAPI_CUDA_RANGE_ROOT)
+    if (papi_cuda_range_runtime != NULL) {
+        dl_runtime_handle = search_and_load_shared_libraries(papi_cuda_range_runtime);
+        if (dl_runtime_handle != NULL) {
+            goto load_functions;
+        }    
+        else {
+            SUBDBG("PAPI_CUDA_RANGE_RUNTIME was set, but did not result in successfully loading the libcudart shared object."
+                   " Set PAPI_CUDA_RANGE_RUNTIME to a valid libcudart shared object.\n");
+            return PAPI_ESYS;
+        }    
+    }    
+    else {
+        SUBDBG("PAPI_CUDA_RANGE_RUNTIME was not set. Falling back to PAPI_CUDA_RANGE_ROOT to search for the libcudart shared object.\n");
+    }    
+
+    if (papi_cuda_range_root != NULL) {
+        std::string so_name = "libcudart";
+        dl_runtime_handle = search_and_load_shared_libraries(so_name, papi_cuda_range_root, so_names_to_search);
+        if (dl_runtime_handle != NULL) {
+            goto load_functions;
+        }    
+        else {
+            SUBDBG("PAPI_CUDA_RANGE_ROOT was set, but did not result in successfully loading the libcudart shared object."
+                   " Falling back to dlopen to search for the libcudart shared object.\n");
+        }    
+    }    
+    else {
+        SUBDBG("PAPI_CUDA_RANGE_ROOT was not set. Falling back to dlopen to search for the libcudart shared object.\n");
+    }    
+
+    // If PAPI_CUDA_RANGE_RUNTIME was not set and PAPI_CUDA_RANGE_ROOT was either not set or did not result in the libcudart shared object
+    // being successfully loaded then use dlopen and follow the search logic used by the dynamic linker.
+    dl_runtime_handle = search_and_load_from_system_paths(so_names_to_search);
+    if (dl_runtime_handle == NULL) {
+        SUBDBG("Failed to load a libcudart shared object. Try setting PAPI_CUDA_RANGE_RUNTIME or PAPI_CUDA_RANGE_ROOT.\n");
+        return PAPI_ESYS;
+    }    
+
+  load_functions:
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cudaGetDeviceCountPtr, cudaGetDeviceCount_t, dl_runtime_handle, "cudaGetDeviceCount");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cudaRuntimeGetVersionPtr, cudaRuntimeGetVersion_t, dl_runtime_handle, "cudaRuntimeGetVersion");
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Inform the system the dl_runtime_handle object is no longer needed by
+  *        the application.
+*/
+void unload_cuda_runtime_function_pointers(void)
+{
+    int retval = dlclose(dl_runtime_handle);
+    if (retval != 0) { 
+        // dlclose can fail, but this function is called at PAPI_shutdown which has a return
+        // type of void. Therefore, an error code here would never make it back to the user.
+        SUBDBG("Failed to close the handle associated with the runtime function pointers due to -- %s.\n", dlerror());
+    }    
+
+    cudaGetDeviceCountPtr    = nullptr;
+    cudaRuntimeGetVersionPtr = nullptr;
+
+    return;
+}
+
+/**
+  * @brief Load the CUPTI API functions used internally in the cuda_range
+  *        component.
+  *
+  *        The libcupti shared library is searched for using the shared library names
+  *        libcupti.so, libcupti.so.1, and a catch all libcupti. Once the libcupti shared
+  *        library is found the used Runtime API functions are dlsym'd.
+*/
+int load_cupti_function_pointers(void)
+{
+    // The libcupti shared object names that we will search for.
+    // Note that, the libcupti without .so should always be the last entry
+    // in the vector.
+    std::vector<std::string> so_names_to_search = {"libcupti.so", "libcupti.so.1", "libcupti"};
+
+    char *papi_cuda_range_cupti = std::getenv("PAPI_CUDA_RANGE_CUPTI"), *papi_cuda_range_root = std::getenv("PAPI_CUDA_RANGE_ROOT");
+    // If a user set PAPI_CUDA_RANGE_CUPTI with a path to a shared object, attempt to load it (takes precedent over PAPI_CUDA_RANGE_ROOT)
+    if (papi_cuda_range_cupti != NULL) {
+        dl_cupti_handle = search_and_load_shared_libraries(papi_cuda_range_cupti); 
+        if (dl_cupti_handle != NULL) {
+            goto load_functions;
+        }    
+        else {
+            SUBDBG("PAPI_CUDA_RANGE_CUPTI was set, but did not result in successfully loading the libcupti shared object."
+                   " Set PAPI_CUDA_RANGE_CUPTI to a valid libcupti shared object.\n");
+            return PAPI_ESYS;
+        }    
+    }    
+    else {
+        SUBDBG("PAPI_CUDA_RANGE_CUPTI was not set. Falling back to PAPI_CUDA_RANGE_ROOT to search for the libcupti shared object.\n");
+    }    
+
+    if (papi_cuda_range_root != NULL) {
+        std::string so_name = "libcupti";
+        dl_cupti_handle = search_and_load_shared_libraries(so_name, papi_cuda_range_root, so_names_to_search);
+        if (dl_cupti_handle != NULL) {
+            goto load_functions;
+        }    
+        else {
+            SUBDBG("PAPI_CUDA_RANGE_ROOT was set, but did not result in successfully loading the libcupti shared object."
+                   " Falling back to dlopen to search for the libcupti shared object.\n");
+        }    
+    }    
+    else {
+        SUBDBG("PAPI_CUDA_RANGE_ROOT was not set. Falling back to dlopen to search for the libcudart shared object.\n");
+    }    
+
+    // If PAPI_CUDA_RANGE_CUPTI was not set and PAPI_CUDA_RANGE_ROOT was either not set or did not result in the libcupti shared object
+    // being successfully loaded then use dlopen and follow the search logic used by the dynamic linker.
+    dl_cupti_handle = search_and_load_from_system_paths(so_names_to_search);
+    if (dl_cupti_handle) {
+        SUBDBG("Failed to load a libcupti shared object. Try setting PAPI_CUDA_RANGE_CUPTI or PAPI_CUDA_RANGE_ROOT.\n");
+        return PAPI_ESYS;
+    }    
+
+  load_functions:
+    // CUPTI Profiler Host API.
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiProfilerHostInitializePtr, cuptiProfilerHostInitialize_t, dl_cupti_handle, "cuptiProfilerHostInitialize");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiProfilerHostGetMaxNumHardwareMetricsPerPassPtr, cuptiProfilerHostGetMaxNumHardwareMetricsPerPass_t,
+                                    dl_cupti_handle, "cuptiProfilerHostGetMaxNumHardwareMetricsPerPass");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiProfilerHostGetBaseMetricsPtr, cuptiProfilerHostGetBaseMetrics_t, dl_cupti_handle, "cuptiProfilerHostGetBaseMetrics");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiProfilerHostGetSubMetricsPtr, cuptiProfilerHostGetSubMetrics_t, dl_cupti_handle, "cuptiProfilerHostGetSubMetrics");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiProfilerHostGetMetricPropertiesPtr, cuptiProfilerHostGetMetricProperties_t, dl_cupti_handle, "cuptiProfilerHostGetMetricProperties");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiProfilerHostGetSupportedChipsPtr, cuptiProfilerHostGetSupportedChips_t, dl_cupti_handle, "cuptiProfilerHostGetSupportedChips");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiProfilerHostConfigAddMetricsPtr, cuptiProfilerHostConfigAddMetrics_t, dl_cupti_handle, "cuptiProfilerHostConfigAddMetrics");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiProfilerHostGetConfigImageSizePtr, cuptiProfilerHostGetConfigImageSize_t, dl_cupti_handle, "cuptiProfilerHostGetConfigImageSize");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiProfilerHostGetConfigImagePtr, cuptiProfilerHostGetConfigImage_t, dl_cupti_handle, "cuptiProfilerHostGetConfigImage");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiProfilerHostGetNumOfPassesPtr, cuptiProfilerHostGetNumOfPasses_t, dl_cupti_handle, "cuptiProfilerHostGetNumOfPasses");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiProfilerHostEvaluateToGpuValuesPtr, cuptiProfilerHostEvaluateToGpuValues_t, dl_cupti_handle, "cuptiProfilerHostEvaluateToGpuValues");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiProfilerHostDeinitializePtr, cuptiProfilerHostDeinitialize_t, dl_cupti_handle, "cuptiProfilerHostDeinitialize");
+    
+    // CUPTI Range Profiling API.
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiRangeProfilerEnablePtr, cuptiRangeProfilerEnable_t, dl_cupti_handle, "cuptiRangeProfilerEnable");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiRangeProfilerGetCounterDataSizePtr, cuptiRangeProfilerGetCounterDataSize_t, dl_cupti_handle, "cuptiRangeProfilerGetCounterDataSize");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiRangeProfilerCounterDataImageInitializePtr, cuptiRangeProfilerCounterDataImageInitialize_t, dl_cupti_handle, "cuptiRangeProfilerCounterDataImageInitialize");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiRangeProfilerSetConfigPtr, cuptiRangeProfilerSetConfig_t, dl_cupti_handle, "cuptiRangeProfilerSetConfig");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiRangeProfilerStartPtr, cuptiRangeProfilerStart_t, dl_cupti_handle, "cuptiRangeProfilerStart");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiRangeProfilerPushRangePtr, cuptiRangeProfilerPushRange_t, dl_cupti_handle, "cuptiRangeProfilerPushRange");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiRangeProfilerPopRangePtr, cuptiRangeProfilerPopRange_t, dl_cupti_handle, "cuptiRangeProfilerPopRange");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiRangeProfilerStopPtr, cuptiRangeProfilerStop_t, dl_cupti_handle, "cuptiRangeProfilerStop");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiRangeProfilerDecodeDataPtr, cuptiRangeProfilerDecodeData_t, dl_cupti_handle, "cuptiRangeProfilerDecodeData");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiRangeProfilerDisablePtr, cuptiRangeProfilerDisable_t, dl_cupti_handle, "cuptiRangeProfilerDisable");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiRangeProfilerCounterDataGetRangeInfoPtr, cuptiRangeProfilerCounterDataGetRangeInfo_t, dl_cupti_handle, "cuptiRangeProfilerCounterDataGetRangeInfo");
+
+    // General CUPTI API.
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiProfilerGetCounterAvailabilityPtr, cuptiProfilerGetCounterAvailability_t, dl_cupti_handle, "cuptiProfilerGetCounterAvailability");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiDeviceGetChipNamePtr, cuptiDeviceGetChipName_t, dl_cupti_handle, "cuptiDeviceGetChipName");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiProfilerInitializePtr, cuptiProfilerInitialize_t, dl_cupti_handle, "cuptiProfilerInitialize");
+    ASSIGN_AND_CHECK_DLSYM_API_CALL(cuptiProfilerDeInitializePtr, cuptiProfilerDeInitialize_t, dl_cupti_handle, "cuptiProfilerDeInitialize");
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Inform the system the dl_cupti_handle object is no longer needed by
+  *        the application.
+*/
+void unload_cupti_function_pointers(void)
+{
+    int retval = dlclose(dl_cupti_handle);
+    if (retval != 0) { 
+        // dlclose can fail, but this function is called at PAPI_shutdown which has a return
+        // type of void. Therefore, an error code here would never make it back to the user.
+        SUBDBG("Failed to close the handle associated with the cupti function pointers due to -- %s.\n", dlerror());
+    }    
+
+    // CUPTI Profiler Host API.
+    cuptiProfilerHostInitializePtr                      = nullptr;
+    cuptiProfilerHostGetMaxNumHardwareMetricsPerPassPtr = nullptr;
+    cuptiProfilerHostGetBaseMetricsPtr                  = nullptr;
+    cuptiProfilerHostGetSubMetricsPtr                   = nullptr;
+    cuptiProfilerHostGetMetricPropertiesPtr             = nullptr;
+    cuptiProfilerHostGetSupportedChipsPtr               = nullptr;
+    cuptiProfilerHostConfigAddMetricsPtr                = nullptr;
+    cuptiProfilerHostGetConfigImageSizePtr              = nullptr;
+    cuptiProfilerHostGetConfigImagePtr                  = nullptr;
+    cuptiProfilerHostGetNumOfPassesPtr                  = nullptr;
+    cuptiProfilerHostEvaluateToGpuValuesPtr             = nullptr;
+    cuptiProfilerHostDeinitializePtr                    = nullptr;
+
+    // CUPTI Range Profiling API.
+    cuptiRangeProfilerEnablePtr                         = nullptr;
+    cuptiRangeProfilerGetCounterDataSizePtr             = nullptr;
+    cuptiRangeProfilerCounterDataImageInitializePtr     = nullptr;
+    cuptiRangeProfilerSetConfigPtr                      = nullptr;
+    cuptiRangeProfilerStartPtr                          = nullptr;
+    cuptiRangeProfilerPushRangePtr                      = nullptr;
+    cuptiRangeProfilerPopRangePtr                       = nullptr;
+    cuptiRangeProfilerStopPtr                           = nullptr;
+    cuptiRangeProfilerDecodeDataPtr                     = nullptr;
+    cuptiRangeProfilerDisablePtr                        = nullptr;
+    cuptiRangeProfilerCounterDataGetRangeInfoPtr        = nullptr;
+
+    // CUPTI API Misc.
+    cuptiProfilerGetCounterAvailabilityPtr              = nullptr;
+    cuptiDeviceGetChipNamePtr                           = nullptr;
+    cuptiProfilerInitializePtr                          = nullptr;
+    cuptiProfilerDeInitializePtr                        = nullptr;
+
+    return;
+}
+
+/**
+ *  @}
+ ******************************************************************************/
+
+std::string cuda_range_error_message;
+/**
+ * @brief Set the error message that will appear in the PAPI_component_info_t member
+ *        variable disabled_reason.
+ *
+ * @param &message_to_set
+ *   The error message to set.
+ */
+void cuda_range_set_last_err_msg(std::string &message_to_set)
+{
+    cuda_range_error_message = message_to_set;
+}
+
+/**
+ *  @}
+ ******************************************************************************/
+ 
+/***************************************************************************//**
+ *  @name   C++ class for cuda_range component
+ *  @{
+ */
+
+class CuptiProfile
+{
+private:
+    CUcontext m_context = nullptr;
+    bool m_context_ownership = false;
+    bool m_all_passes_submitted = false;
+    CUpti_Profiler_Host_Object *m_host_object = nullptr;
+    CUpti_RangeProfiler_Object *m_range_profiler_object = nullptr;
+    std::string m_chip_name;
+    size_t m_samples_read = 0;
+    
+    std::vector<uint8_t> m_counter_availability_image;
+    std::vector<uint8_t> m_config_image;
+    std::vector<uint8_t> m_counter_data_image;
+
+    std::vector<size_t> m_event_insertion_order;
+    std::vector<const char *> m_cupti_metric_names;
+    std::vector<double> m_metric_values;
+
+public:
+    // Constructors and Destructor.
+    CuptiProfile(CUcontext context, bool context_ownership);
+    CuptiProfile(CuptiProfile &&obj);
+    ~CuptiProfile(void);
+
+    // Setters.
+    void set_cupti_metric_names(const std::vector<std::string> &cupti_metric_names);
+    void set_event_insertion_order(const std::vector<size_t> &event_insertion_order);
+    
+    // Getters.
+    bool get_all_passes_submitted(void); 
+
+    // Member functions for metric enumeration and metric metadata.
+    int base_metrics(size_t metric_type, const char ***base_metric_names, size_t &number_of_base_metrics);
+    int sub_metrics(size_t metric_type, const char *base_metric_name, const char ***sub_metric_names, size_t &number_of_sub_metrics);
+    int metric_properties(const char *cupti_metric_name, std::string &description);
+    int number_of_passes(size_t &number_of_passes);
+
+    // Member functions for metric profiling.
+    int create_config_image(void);
+    int enable_range_profiler(void);
+    int create_counter_data_image(void);
+    int config(void);
+    int start_profiling(void);
+    int push_range(std::string &range_name);
+    int pop_range(void);
+    int stop_profiling(void);
+    int decode_data(void);
+    int evaluate_counter_data(void);
+    void calculate(cuda_range_ctx_t ctx);
+    int disable_range_profiler(void);
+
+    // Member functions for both metric enumeration/metadata and profiling.
+    int counter_availability(void);
+    int chip_name(int device_index);
+    int host_initialize(void);
+    int host_deinitialize(void);
+    void destroy_context(void);
+};
+
+/**
+ * @brief CuptiProfile constructor. Sets the private member variables
+ *        m_context and m_context_ownership.
+ *
+ * @param context
+ *   A CUDA context to be used for profiling.
+ * @param context_ownership
+ *   True if we internally created the CUDA context and false if a user
+ *   created the CUDA context.
+ */
+inline CuptiProfile::CuptiProfile(CUcontext context, bool context_ownership)
+{
+    m_context = context;
+    m_context_ownership = context_ownership;
+}
+
+/**
+ * @brief CuptiProfile move constructor. Transfers ownerhship of
+ *        m_context and m_context_ownership.
+ * 
+ * @param &&obj
+ *   The CuptiProfile object to take ownership of.
+ */
+inline CuptiProfile::CuptiProfile(CuptiProfile &&obj)
+{
+    // Transfer ownership.
+    m_context = obj.m_context;
+    m_context_ownership = obj.m_context_ownership;
+
+    // Leave obj in a valid state.
+    obj.m_context = nullptr;
+    obj.m_context_ownership = false;
+}
+
+/**
+ * @brief CuptiProfile destructor. The allocated CUPTI metric names
+ *        are freed and the internal created context's are destroy.
+ */
+inline CuptiProfile::~CuptiProfile(void)
+{
+    // Free memory allocated in set_cupt_metric_names.
+    for (size_t i = 0; i < m_cupti_metric_names.size(); i++) {
+        free((char*) m_cupti_metric_names[i]);
+    }
+    m_cupti_metric_names.clear();
+
+    destroy_context();
+}
+
+/**
+ * @brief A setter member function to set the private member variable
+ *        m_cupti_metric_names.
+ *
+ *        This setter is called in cuda_range_store_added_native_events
+ *        to set the user added cuda_range native events that are to
+ *        be used for profiling.
+ * 
+ * @param &cupti_metric_names
+ *   A vector of CUPTI metric names in the format of basename.rollup.submetric
+ *   to be used for profiling.
+ */
+inline void CuptiProfile::set_cupti_metric_names(const std::vector<std::string> &cupti_metric_names)
+{
+    // Free the cached user added events.
+    if (m_cupti_metric_names.size() > 0) {
+        for (size_t i = 0; i < m_cupti_metric_names.size(); i++) {
+            free((char*) m_cupti_metric_names[i]);
+        }
+        m_cupti_metric_names.clear();
+    }
+
+    // Cache the user added events.
+    for (std::string cupti_metric_name : cupti_metric_names) {
+        const char *c_cupti_metric_name = strdup(cupti_metric_name.c_str());
+        m_cupti_metric_names.push_back(c_cupti_metric_name);
+    }
+}
+
+/**
+ * @brief A setter member function to set the private member variable
+ *        m_event_insertion_order.
+ *
+ *        This setter is called in cuda_range_store_added_native_events
+ *        to set the order of the user added cuda_range native events. This is done
+ *        to properly map the evaluated counter data values into the returned
+ *        long long values array for PAPI_read and PAPI_stop.
+ * 
+ * @param &event_insertion_order
+ *   A vector containing the order of added cuda_range native events. 
+ */
+inline void CuptiProfile::set_event_insertion_order(const std::vector<size_t> &event_insertion_order)
+{
+    m_event_insertion_order = event_insertion_order;
+}
+
+/**
+ * @brief A getter member function to return the private member
+ *        variable m_all_passes_submitted.
+ *
+ *        This getter is called in cuda_range_decode_and_evaluate_counter_data
+ *        to determine if a counter data image has successfully completed all passes. 
+ */
+inline bool CuptiProfile::get_all_passes_submitted(void)
+{
+    return m_all_passes_submitted;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI call cuptiProfilerHostGetBaseMetrics.
+ *
+ * @param metric_type
+ *   The metric type (counter, ratio, or throughput) 
+ * @param ***base_metric_names
+ *   Stores the list of supported base metric names for the chip.
+ * @param &number_of_base_metrics
+ *   Stores the number of supported base metrics for the chip.  
+ */
+inline int CuptiProfile::base_metrics(size_t metric_type, const char ***base_metric_names, size_t &number_of_base_metrics)
+{
+    CUpti_Profiler_Host_GetBaseMetrics_Params get_base_metrics_params {};
+    /// [in]
+    get_base_metrics_params.structSize = CUpti_Profiler_Host_GetBaseMetrics_Params_STRUCT_SIZE;
+    /// [in]
+    get_base_metrics_params.pPriv = nullptr;
+    /// [in]
+    get_base_metrics_params.pHostObject = m_host_object;
+    /// [in]
+    get_base_metrics_params.metricType = (CUpti_MetricType) metric_type;
+    CHECK_CUPTI_API_CALL( cuptiProfilerHostGetBaseMetricsPtr(&get_base_metrics_params) );
+    *base_metric_names = get_base_metrics_params.ppMetricNames;
+    number_of_base_metrics = get_base_metrics_params.numMetrics;
+
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI call cuptiProfilerHostGetSubMetrics.
+ *
+ * @param metric_type
+ *   The metric type (counter, ratio, or throughput) 
+ * @param ***sub_metric_names
+ *   Stores the list of supported sub-metric names for the chip.
+ * @param &number_of_base_metrics
+ *   Stores the number of supported sub-metrics for the chip.
+ */
+inline int CuptiProfile::sub_metrics(size_t metric_type, const char *base_metric_name, const char ***sub_metric_names, size_t &number_of_sub_metrics)
+{
+    CUpti_Profiler_Host_GetSubMetrics_Params get_sub_metrics_params {};
+    /// [in]
+    get_sub_metrics_params.structSize = CUpti_Profiler_Host_GetSubMetrics_Params_STRUCT_SIZE;
+    /// [in]
+    get_sub_metrics_params.pPriv = nullptr;
+    /// [in]
+    get_sub_metrics_params.pHostObject = m_host_object;
+    /// [in]
+    get_sub_metrics_params.metricType = (CUpti_MetricType) metric_type;
+    /// [in]
+    get_sub_metrics_params.pMetricName = base_metric_name;
+    CHECK_CUPTI_API_CALL( cuptiProfilerHostGetSubMetricsPtr(&get_sub_metrics_params) );
+    *sub_metric_names = get_sub_metrics_params.ppSubMetrics;
+    number_of_sub_metrics = get_sub_metrics_params.numOfSubmetrics;
+
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI call cuptiProfilerHostGetMetricProperties.
+ *
+ * @param cupti_metric_name
+ *   The CUPTI metric name the properties will be listed.
+ * @param &description
+ *   Stores the short description for the CUPTI metric name..
+ */
+inline int CuptiProfile::metric_properties(const char *cupti_metric_name, std::string &description)
+{
+    CUpti_Profiler_Host_GetMetricProperties_Params get_metric_properties_params {};
+    /// [in]
+    get_metric_properties_params.structSize = CUpti_Profiler_Host_GetMetricProperties_Params_STRUCT_SIZE;
+    /// [in]
+    get_metric_properties_params.pPriv = nullptr;
+    /// [in]
+    get_metric_properties_params.pHostObject = m_host_object;
+    /// [in]
+    get_metric_properties_params.pMetricName = cupti_metric_name;
+    CHECK_CUPTI_API_CALL( cuptiProfilerHostGetMetricPropertiesPtr(&get_metric_properties_params) );
+    description = get_metric_properties_params.pDescription;
+
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI call cuptiProfilerHostGetNumOfPasses.
+ *
+ * @param number_of_passes
+ *   Store the number of passes required for profiling the scheduled
+ *   metrics in the config image.
+ */
+inline int CuptiProfile::number_of_passes(size_t &number_of_passes)
+{
+    CUpti_Profiler_Host_GetNumOfPasses_Params get_num_of_passes_params {};
+    /// [in]
+    get_num_of_passes_params.structSize = CUpti_Profiler_Host_GetNumOfPasses_Params_STRUCT_SIZE;
+    /// [in]
+    get_num_of_passes_params.pPriv = nullptr;
+    /// [in]
+    get_num_of_passes_params.configImageSize = m_config_image.size();
+    /// [in]
+    get_num_of_passes_params.pConfigImage = m_config_image.data();
+    CHECK_CUPTI_API_CALL( cuptiProfilerHostGetNumOfPassesPtr(&get_num_of_passes_params) );
+    number_of_passes = get_num_of_passes_params.numOfPasses;
+
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI calls:
+ *        1. cuptiProfilerHostConfigAddMetrics
+ *        2. cuptiProfilerHostGetConfigImageSize
+ *        3. cuptiProfilerHostGetConfigImage
+ *
+ *        This member function sets the private member variable
+ *        m_config_image. 
+ */
+inline int CuptiProfile::create_config_image(void)
+{
+    CUpti_Profiler_Host_ConfigAddMetrics_Params config_add_metrics_params {};
+    /// [in]
+    config_add_metrics_params.structSize = CUpti_Profiler_Host_ConfigAddMetrics_Params_STRUCT_SIZE;
+    /// [in]
+    config_add_metrics_params.pPriv = nullptr;
+    /// [in]
+    config_add_metrics_params.pHostObject = m_host_object;
+    /// [in]
+    config_add_metrics_params.ppMetricNames = m_cupti_metric_names.data();
+    /// [in]
+    config_add_metrics_params.numMetrics = m_cupti_metric_names.size();
+    CHECK_CUPTI_API_CALL(cuptiProfilerHostConfigAddMetricsPtr(&config_add_metrics_params));
+
+    CUpti_Profiler_Host_GetConfigImageSize_Params get_config_image_size_params {};
+    /// [in]
+    get_config_image_size_params.structSize = CUpti_Profiler_Host_GetConfigImageSize_Params_STRUCT_SIZE;
+    /// [in]
+    get_config_image_size_params.pPriv = nullptr;
+    /// [in]
+    get_config_image_size_params.pHostObject = m_host_object;
+    CHECK_CUPTI_API_CALL( cuptiProfilerHostGetConfigImageSizePtr(&get_config_image_size_params) );
+    m_config_image.resize(get_config_image_size_params.configImageSize, 0);
+
+    CUpti_Profiler_Host_GetConfigImage_Params get_config_image_params {};
+    /// [in]
+    get_config_image_params.structSize = CUpti_Profiler_Host_GetConfigImage_Params_STRUCT_SIZE;
+    /// [in]
+    get_config_image_params.pPriv = nullptr;
+    /// [in]
+    get_config_image_params.pHostObject = m_host_object;
+    /// [in]
+    get_config_image_params.configImageSize = m_config_image.size();
+    get_config_image_params.pConfigImage = m_config_image.data();
+    CHECK_CUPTI_API_CALL( cuptiProfilerHostGetConfigImagePtr( &get_config_image_params) );
+
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI call cuptiRangeProfilerEnable.
+ *
+ *        This member function sets the private member variable
+ *        m_range_profiler_object. 
+ */
+inline int CuptiProfile::enable_range_profiler(void)
+{
+    CUpti_RangeProfiler_Enable_Params enable_params {};
+    /// [in]
+    enable_params.structSize = CUpti_RangeProfiler_Enable_Params_STRUCT_SIZE;
+    /// [in]
+    enable_params.pPriv = nullptr;
+    /// [in]
+    enable_params.ctx = m_context;
+    CHECK_CUPTI_API_CALL( cuptiRangeProfilerEnablePtr(&enable_params) );
+    m_range_profiler_object = enable_params.pRangeProfilerObject;
+
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI calls:
+ *        1. cuptiRangeProfilerGetCounterDataSize
+ *        2. cuptiRangeProfilerCounterDataImageInitialize
+ *
+ *        This member function sets the private member variable
+ *        m_counter_data_image.
+ */
+inline int CuptiProfile::create_counter_data_image(void)
+{
+    CUpti_RangeProfiler_GetCounterDataSize_Params get_counter_data_size_params {};
+    /// [in]
+    get_counter_data_size_params.structSize = CUpti_RangeProfiler_GetCounterDataSize_Params_STRUCT_SIZE;
+    /// [in]
+    get_counter_data_size_params.pPriv = nullptr;
+    /// [in]
+    get_counter_data_size_params.pRangeProfilerObject = m_range_profiler_object;
+    /// [in]
+    get_counter_data_size_params.pMetricNames = m_cupti_metric_names.data();
+    /// [in]
+    get_counter_data_size_params.numMetrics = m_cupti_metric_names.size();
+    /// [in]
+    get_counter_data_size_params.maxNumOfRanges = 1;
+    /// [in]
+    get_counter_data_size_params.maxNumRangeTreeNodes = 1;
+    CHECK_CUPTI_API_CALL(cuptiRangeProfilerGetCounterDataSizePtr(&get_counter_data_size_params));
+    m_counter_data_image.resize(get_counter_data_size_params.counterDataSize, 0);
+
+    CUpti_RangeProfiler_CounterDataImage_Initialize_Params initialize_counter_data_image_params {};
+    /// [in]
+    initialize_counter_data_image_params.structSize = CUpti_RangeProfiler_CounterDataImage_Initialize_Params_STRUCT_SIZE;
+    /// [in]
+    initialize_counter_data_image_params.pPriv = nullptr;
+    /// [in]
+    initialize_counter_data_image_params.pRangeProfilerObject = m_range_profiler_object;
+    /// [in]
+    initialize_counter_data_image_params.pCounterData = m_counter_data_image.data();
+    /// [in]
+    initialize_counter_data_image_params.counterDataSize = m_counter_data_image.size();
+    CHECK_CUPTI_API_CALL( cuptiRangeProfilerCounterDataImageInitializePtr(&initialize_counter_data_image_params) );
+
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI call cuptiRangeProfilerSetConfig.
+ *
+ *        This member function sets the private member variable
+ *        m_range_profiler_object. 
+ */
+inline int CuptiProfile::config(void)
+{
+    CUpti_RangeProfiler_SetConfig_Params set_config_params {};
+    /// [in]
+    set_config_params.structSize = CUpti_RangeProfiler_SetConfig_Params_STRUCT_SIZE;
+    /// [in]
+    set_config_params.pPriv = nullptr;
+    /// [in]
+    set_config_params.pRangeProfilerObject = m_range_profiler_object;
+    /// [in]
+    set_config_params.configSize = m_config_image.size();
+    /// [in]
+    set_config_params.pConfig = m_config_image.data();
+    /// [in]
+    set_config_params.counterDataImageSize = m_counter_data_image.size();
+    /// [in]
+    set_config_params.pCounterDataImage = m_counter_data_image.data();
+    /// [in]
+    set_config_params.range = CUPTI_UserRange;
+    /// [in]
+    set_config_params.replayMode = CUPTI_UserReplay;
+    /// [in]
+    set_config_params.maxRangesPerPass = 1;
+    /// [in]
+    set_config_params.numNestingLevels = 1;
+    /// [in]
+    set_config_params.minNestingLevel = 1;
+    /// [in]
+    set_config_params.passIndex = 0;
+    /// [in]
+    set_config_params.targetNestingLevel = 1;
+    CHECK_CUPTI_API_CALL( cuptiRangeProfilerSetConfigPtr(&set_config_params) );
+
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI call cuptiRangeProfilerStart.
+ */
+inline int CuptiProfile::start_profiling()
+{
+    CUpti_RangeProfiler_Start_Params start_range_profiler {};
+    /// [in]
+    start_range_profiler.structSize = CUpti_RangeProfiler_Start_Params_STRUCT_SIZE;
+    /// [in]
+    start_range_profiler.pPriv = nullptr;
+    /// [in]
+    start_range_profiler.pRangeProfilerObject = m_range_profiler_object;
+    CHECK_CUPTI_API_CALL( cuptiRangeProfilerStartPtr(&start_range_profiler) );
+
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI call cuptiRangeProfilerPushRange.
+ * 
+ * @param &range_name
+ *   Name of the range to be profiled.
+ */
+inline int CuptiProfile::push_range(std::string &range_name)
+{
+    CUpti_RangeProfiler_PushRange_Params push_range_params {};
+    /// [in]
+    push_range_params.structSize = CUpti_RangeProfiler_PushRange_Params_STRUCT_SIZE;
+    /// [in]
+    push_range_params.pPriv = NULL;
+    /// [in]
+    push_range_params.pRangeProfilerObject = m_range_profiler_object;
+    /// [in]
+    push_range_params.pRangeName = range_name.c_str();
+    CHECK_CUPTI_API_CALL( cuptiRangeProfilerPushRangePtr(&push_range_params) );
+
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI call cuptiRangeProfilerPopRange.
+ */
+inline int CuptiProfile::pop_range(void)
+{
+    CUpti_RangeProfiler_PopRange_Params pop_range_params {};
+    /// [in]
+    pop_range_params.structSize = CUpti_RangeProfiler_PopRange_Params_STRUCT_SIZE;
+    /// [in]
+    pop_range_params.pPriv = nullptr;
+    /// [in]
+    pop_range_params.pRangeProfilerObject = m_range_profiler_object;
+    CHECK_CUPTI_API_CALL( cuptiRangeProfilerPopRangePtr(&pop_range_params) );
+
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI call cuptiRangeProfilerStop.
+ */
+inline int CuptiProfile::stop_profiling(void)
+{
+    CUpti_RangeProfiler_Stop_Params stop_params {};
+    /// [in]
+    stop_params.structSize = CUpti_RangeProfiler_Stop_Params_STRUCT_SIZE;
+    /// [in]
+    stop_params.pPriv = nullptr;
+    /// [in]
+    stop_params.pRangeProfilerObject = m_range_profiler_object;
+    CHECK_CUPTI_API_CALL( cuptiRangeProfilerStopPtr(&stop_params) );
+    m_all_passes_submitted = stop_params.isAllPassSubmitted;
+
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI call cuptiRangeProfilerDecodeData.
+ */
+inline int CuptiProfile::decode_data(void)
+{
+    CUpti_RangeProfiler_DecodeData_Params decode_data_params {};
+    /// [in]
+    decode_data_params.structSize = CUpti_RangeProfiler_DecodeData_Params_STRUCT_SIZE;
+    /// [in]
+    decode_data_params.pPriv = nullptr;
+    /// [in]
+    decode_data_params.pRangeProfilerObject = m_range_profiler_object;
+    CHECK_CUPTI_API_CALL( cuptiRangeProfilerDecodeDataPtr(&decode_data_params) );
+
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI call cuptiProfilerHostEvaluateToGpuValues.
+ */
+inline int CuptiProfile::evaluate_counter_data(void)
+{
+    m_metric_values.resize(m_cupti_metric_names.size(), 0.0);
+    CUpti_Profiler_Host_EvaluateToGpuValues_Params evaluate_to_gpu_values_params {};
+    /// [in]
+    evaluate_to_gpu_values_params.structSize = CUpti_Profiler_Host_EvaluateToGpuValues_Params_STRUCT_SIZE;
+    /// [in]
+    evaluate_to_gpu_values_params.pPriv = nullptr;
+    /// [in]
+    evaluate_to_gpu_values_params.pHostObject = m_host_object;
+    /// [in]
+    evaluate_to_gpu_values_params.pCounterDataImage = m_counter_data_image.data();
+    /// [in]
+    evaluate_to_gpu_values_params.counterDataImageSize = m_counter_data_image.size();
+    /// [in]
+    evaluate_to_gpu_values_params.rangeIndex = 0;
+    /// [in]
+    evaluate_to_gpu_values_params.ppMetricNames = m_cupti_metric_names.data();
+    /// [in]
+    evaluate_to_gpu_values_params.numMetrics = m_cupti_metric_names.size();
+    /// [in/out]
+    evaluate_to_gpu_values_params.pMetricValues = m_metric_values.data();
+    CHECK_CUPTI_API_CALL( cuptiProfilerHostEvaluateToGpuValuesPtr(&evaluate_to_gpu_values_params) );
+
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that determines
+ *        the rollup metric appended to the CUPTI metric name and
+ *        calculates the counter value to be stored in the array
+ *        for PAPI_read and PAPI_stop.
+ *
+ *        The first PAPI_read/PAPI_stop will store the initial obtained value
+ *        into the array. Subsequent PAPI_read/PAPI_stop calls will then
+ *        store the counter value based on the stat qualifier (i.e. avg,
+ *        max, min, and sum). In the case of avg, it is a running average.
+ *
+ * @param ctx
+ *   A structure containing the state, event ids, counters, and number
+ *   of events.
+ */
+inline void CuptiProfile::calculate(cuda_range_ctx_t ctx)
+{
+    for (size_t i = 0; i < m_cupti_metric_names.size(); i++) {
+        size_t pos = m_event_insertion_order[i];
+        long long metric_value_ll = static_cast<long long>(m_metric_values[i]);
+        // PAPI_read has previously not been called. Set initial counter values.
+        if (m_samples_read == 0) {
+            ctx->counters[pos] = metric_value_ll;
+        }
+        // PAPI_read has previously been called. Update counter values. 
+        else {
+            // Calculate the running avg.
+            if (strstr(m_cupti_metric_names[i], "avg")) {
+                ctx->counters[pos] = ( (m_samples_read * ctx->counters[pos]) + metric_value_ll ) / (m_samples_read + 1);
+            }
+            // Calculate the max across all reads.
+            else if (strstr(m_cupti_metric_names[i], "max")) {
+                ctx->counters[pos] = std::max(metric_value_ll, ctx->counters[pos]);
+            }
+            // Calculate the min across all reads.
+            else if (strstr(m_cupti_metric_names[i], "min")) {
+                ctx->counters[pos] = std::min(metric_value_ll, ctx->counters[pos]);
+            }
+            // Calculate the sum across all reads.
+            else if (strstr(m_cupti_metric_names[i], "sum")) {
+                ctx->counters[pos] += metric_value_ll;
+            }
+            // A rollup metric does not exist for the name.
+            // Note, this will occur for CUPTI_METRIC_TYPE_RATIO.
+            else {
+                ctx->counters[pos] = metric_value_ll;
+            }
+        }
+    }
+    m_samples_read++;
+
+    return;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI call cuptiRangeProfilerDisable.
+ */
+inline int CuptiProfile::disable_range_profiler(void)
+{
+    CUpti_RangeProfiler_Disable_Params disable_params {};
+    /// [in]
+    disable_params.structSize = CUpti_RangeProfiler_Disable_Params_STRUCT_SIZE;
+    /// [in]
+    disable_params.pPriv = nullptr;
+    /// [in]
+    disable_params.pRangeProfilerObject = m_range_profiler_object;
+    CHECK_CUPTI_API_CALL( cuptiRangeProfilerDisablePtr(&disable_params) );
+    m_range_profiler_object = nullptr;
+
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI call cuptiProfilerGetCounterAvailability.
+ *
+ *        This member function sets the private member variable
+ *        m_counter_availability_image.
+ */
+inline int CuptiProfile::counter_availability(void)
+{
+    CUpti_Profiler_GetCounterAvailability_Params get_counter_availability_params {};
+    /// [in]
+    get_counter_availability_params.structSize = CUpti_Profiler_GetCounterAvailability_Params_STRUCT_SIZE;
+    /// [in]
+    get_counter_availability_params.pPriv = nullptr;
+    /// [in]
+    get_counter_availability_params.ctx = m_context;
+    /// [in]
+    get_counter_availability_params.pCounterAvailabilityImage = nullptr;
+    /// [in]
+    #if CUDART_VERSION >= 13010
+    get_counter_availability_params.bAllowDeviceLevelCounters = 1;
+    #endif
+    CHECK_CUPTI_API_CALL( cuptiProfilerGetCounterAvailabilityPtr(&get_counter_availability_params) );
+    m_counter_availability_image.resize(get_counter_availability_params.counterAvailabilityImageSize);
+    /// [in]
+    get_counter_availability_params.pCounterAvailabilityImage = m_counter_availability_image.data();
+    /// [in/out]
+    get_counter_availability_params.counterAvailabilityImageSize = m_counter_availability_image.size();
+    CHECK_CUPTI_API_CALL( cuptiProfilerGetCounterAvailabilityPtr(&get_counter_availability_params) );
+
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI call cuptiDeviceGetChipName.
+ *
+ *        This member function sets the private member variable
+ *        m_chip_name.
+ *
+ * @param device_index
+ *   An NVIDIA device index.
+ */
+inline int CuptiProfile::chip_name(int device_index)
+{
+    CUpti_Device_GetChipName_Params get_chip_name_params {};
+    /// [in]
+    get_chip_name_params.structSize = CUpti_Device_GetChipName_Params_STRUCT_SIZE;
+    /// [in]
+    get_chip_name_params.pPriv = nullptr;
+    /// [in]
+    get_chip_name_params.deviceIndex = device_index;
+    CHECK_CUPTI_API_CALL( cuptiDeviceGetChipNamePtr(&get_chip_name_params) );
+    m_chip_name = get_chip_name_params.pChipName;
+ 
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI call cuptiProfilerHostInitialize.
+ *
+ *        This member function sets the private member variable
+ *        m_host_object.
+ */
+inline int CuptiProfile::host_initialize(void)
+{
+    CUpti_Profiler_Host_Initialize_Params initializeParams {};
+    /// [in] 
+    initializeParams.structSize = CUpti_Profiler_Host_Initialize_Params_STRUCT_SIZE;
+    /// [in]
+    initializeParams.pPriv = nullptr;
+    /// [in]
+    initializeParams.profilerType = CUPTI_PROFILER_TYPE_RANGE_PROFILER;
+    /// [in]
+    initializeParams.pChipName = m_chip_name.c_str();
+    /// [in]
+    initializeParams.pCounterAvailabilityImage = m_counter_availability_image.data();
+    /// [in]
+    #if CUDART_VERSION >= 13020
+    // Only valid for PM sampling and can be set to nullptr for CUPTI Range Profiler.
+    initializeParams.pSinglePassMetricSetName = nullptr;
+    #endif
+    CHECK_CUPTI_API_CALL( cuptiProfilerHostInitializePtr(&initializeParams) );
+    m_host_object = initializeParams.pHostObject;
+
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that wraps
+ *        the CUPTI call cuptiProfilerHostDeinitialize.
+ *
+ *        This member function sets the private member variable
+ *        m_host_object back to a nullptr.
+ */
+inline int CuptiProfile::host_deinitialize(void)
+{
+    CUpti_Profiler_Host_Deinitialize_Params hostDeinitializeParams {};
+    /// [in]
+    hostDeinitializeParams.structSize = CUpti_Profiler_Host_Deinitialize_Params_STRUCT_SIZE;
+    /// [in]
+    hostDeinitializeParams.pPriv = nullptr;
+    /// [in]
+    hostDeinitializeParams.pHostObject = m_host_object;
+    CHECK_CUPTI_API_CALL( cuptiProfilerHostDeinitializePtr(&hostDeinitializeParams) );
+    m_host_object = nullptr;
+
+    return PAPI_OK;
+}
+
+/**
+ * @brief A member function of the class CuptiProfile that
+ *        destroys OWNED CUDA contexts.
+ *
+ *        Normally we can leave this to the destructor; however, the global class destructor
+ *        is not called until the end of int main. Therefore, if PAPI_shutdown is called
+ *        before the last } cuCtxDestroyPtr is set equal to nullptr and will lead
+ *        to a segmentation fault in the destructor.      
+ */
+inline void CuptiProfile::destroy_context(void)
+{
+    if (m_context_ownership == true && m_context != nullptr) {
+        cuCtxDestroyPtr(m_context);
+        m_context_ownership = false;
+        m_context = nullptr;
+    }
+
+    return;
+}
+
+/**
+ *  @}
+ ******************************************************************************/
+
+/**
+ *  @}
+ ******************************************************************************/
+
+/***************************************************************************//**
+ *  @name   Helper functions for the PAPI instrumentation
+ *  @{
+ */
+
+/**
+  * @brief A wrapper for the CUPTI call cuptiProfilerInitialize.
+*/
+int initialize_cupti_profiler(void)
+{
+    CUpti_Profiler_Initialize_Params profiler_initialize_params {};
+    /// [in]
+    profiler_initialize_params.structSize = CUpti_Profiler_Initialize_Params_STRUCT_SIZE;
+    /// [in]
+    profiler_initialize_params.pPriv = nullptr;
+    CHECK_CUPTI_API_CALL( cuptiProfilerInitializePtr(&profiler_initialize_params) );
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief A wrapper for the CUPTI call cuptiDeviceGetChipName.
+  *
+  * @param device_index
+  *   Index of an NVIDIA device (e.g. 0, 1, 2, 3, ..).
+  * @param &device_chip_name
+  *   Stores the chipname for the specificed device index.
+*/
+int get_device_chip_name(int device_index, std::string &chip_name)
+{
+    CUpti_Device_GetChipName_Params get_chip_name_params {};
+    /// [in]
+    get_chip_name_params.structSize = CUpti_Device_GetChipName_Params_STRUCT_SIZE;
+    /// [in]
+    get_chip_name_params.pPriv = nullptr;
+    /// [in]
+    get_chip_name_params.deviceIndex = device_index;
+    CHECK_CUPTI_API_CALL( cuptiDeviceGetChipNamePtr(&get_chip_name_params) );
+    chip_name = get_chip_name_params.pChipName;
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief For each device on the system, get the CUPTI metrics.
+  *
+  *        The base metrics will be stored as keys in an std::map.
+  *        The value associated with the base metric keys will be a
+  *        structure containing vectors to store the rollup metrics,
+  *        sub metrics, and devices associated with the key.
+  *
+  * @param device_count
+  *   Number of NVIDIA devices detected on the system.
+*/
+int enumerate_and_collect_metrics_per_device(int device_count)
+{
+    // Check for a user context on the calling CPU thread.
+    CUcontext context = nullptr;
+    CHECK_DRIVER_API_CALL( cuCtxGetCurrentPtr(&context) );
+    if (context != nullptr) {
+        // Pop the context from the calling CPU thread.
+        CUcontext popped_context;
+        CHECK_DRIVER_API_CALL( cuCtxPopCurrentPtr(&popped_context) );
+    }
+
+    std::map<std::string, std::vector<std::string>> cached_device_metrics;
+    for (int device_index = 0; device_index < device_count; device_index++) {
+         std::string chip_name {};
+         CHECK_INTERNAL_FUNC_CALL( get_device_chip_name(device_index, chip_name) );
+
+        // CUPTI metrics have not been obtained for the current chip name.
+        if (cached_device_metrics.count(chip_name) == 0) {
+            CUcontext context;
+            unsigned int flags = 0;
+            CHECK_DRIVER_API_CALL( cuCtxCreatePtr(&context, (CUctxCreateParams*)0, flags, device_index) );
+
+            CuptiProfile profile = CuptiProfile(context, true);
+
+            CHECK_INTERNAL_FUNC_CALL( profile.counter_availability() );
+
+            CHECK_INTERNAL_FUNC_CALL( profile.chip_name(device_index) );
+
+            CHECK_INTERNAL_FUNC_CALL( profile.host_initialize() );
+
+            for (size_t metric_type = 0; metric_type < CUPTI_METRIC_TYPE__COUNT; metric_type++) {
+                const char **base_metric_names = nullptr;
+                size_t number_of_base_metrics = 0;
+                CHECK_INTERNAL_FUNC_CALL( profile.base_metrics(metric_type, &base_metric_names, number_of_base_metrics) );
+
+                for (size_t base_metric_index = 0; base_metric_index < number_of_base_metrics; base_metric_index++) {
+                    std::string base_metric_name = base_metric_names[base_metric_index];
+                    cupti_metrics[base_metric_name].name_id = cupti_metrics.size();
+                    cupti_metrics[base_metric_name].cupti_metric_type = (CUpti_MetricType) metric_type;
+                    cupti_metrics[base_metric_name].device_ids.push_back(std::to_string(device_index));
+
+                    const char **sub_metric_names = nullptr;
+                    size_t number_of_sub_metrics = 0;
+                    CHECK_INTERNAL_FUNC_CALL( profile.sub_metrics(metric_type, base_metric_name.c_str(), &sub_metric_names, number_of_sub_metrics) );
+
+                    for (size_t sub_metric_index = 0; sub_metric_index < number_of_sub_metrics; sub_metric_index++) {
+                        std::string sub_metric_name = sub_metric_names[sub_metric_index];
+                        // Erase the leading period.
+                        sub_metric_name.erase(0, 1);
+                        // Handle counter metrics. Note, counter metrics can appear as .rollup or .rollup.submetric.
+                        if (metric_type == CUPTI_METRIC_TYPE_COUNTER) {
+                            int period_count = std::count (sub_metric_name.begin(), sub_metric_name.end(), '.');
+                            // Only .rollup appeared.
+                            if (period_count == 0) {
+                                if (std::find(cupti_metrics[base_metric_name].stats.begin(), cupti_metrics[base_metric_name].stats.end(), sub_metric_name) == cupti_metrics[base_metric_name].stats.end()) {
+                                    cupti_metrics[base_metric_name].stats.push_back(sub_metric_name);
+                                }
+                            }
+                            // .rollup.submetric appeared.
+                            else {
+                                std::istringstream input(sub_metric_name);
+                                std::string rollup;
+                                std::getline(input, rollup, '.');
+                                if (std::find(cupti_metrics[base_metric_name].stats.begin(), cupti_metrics[base_metric_name].stats.end(), rollup) == cupti_metrics[base_metric_name].stats.end()) {
+                                    cupti_metrics[base_metric_name].stats.push_back(rollup);
+                                }
+
+                                std::string submetric;
+                                std::getline(input, submetric, '.');
+                                if (std::find(cupti_metrics[base_metric_name].submetrics.begin(), cupti_metrics[base_metric_name].submetrics.end(), submetric) == cupti_metrics[base_metric_name].submetrics.end()) {
+                                    cupti_metrics[base_metric_name].submetrics.push_back(submetric);
+                                }
+                            }
+                        }
+                        // Handle ratio metrics. Note, ratio metrics appear as .submetric.
+                        else if (metric_type == CUPTI_METRIC_TYPE_RATIO) {
+                            if (std::find(cupti_metrics[base_metric_name].submetrics.begin(), cupti_metrics[base_metric_name].submetrics.end(), sub_metric_name) == cupti_metrics[base_metric_name].submetrics.end()) {
+                                cupti_metrics[base_metric_name].submetrics.push_back(sub_metric_name);
+                            }
+                        }
+                        // Handle throughput metrics. Note, throughput metrics appear as .rollup.submetric.
+                        else if (metric_type == CUPTI_METRIC_TYPE_THROUGHPUT) {
+                            std::istringstream input(sub_metric_name);
+                            std::string rollup;
+                            std::getline(input, rollup, '.');
+                            if (std::find(cupti_metrics[base_metric_name].stats.begin(), cupti_metrics[base_metric_name].stats.end(), rollup) == cupti_metrics[base_metric_name].stats.end()) {
+                                cupti_metrics[base_metric_name].stats.push_back(rollup);
+                            }
+
+                            std::string submetric;
+                            std::getline(input, submetric, '.');
+                            if (std::find(cupti_metrics[base_metric_name].submetrics.begin(), cupti_metrics[base_metric_name].submetrics.end(), submetric) == cupti_metrics[base_metric_name].submetrics.end()) {
+                                cupti_metrics[base_metric_name].submetrics.push_back(submetric);
+                            }
+                        }
+                        // CUpti_MetricType is not implemented.
+                        else {
+                            SUBDBG("NVIDIA has added a new CUpti_MetricType (%u).\n", metric_type);
+                            return PAPI_EBUG;
+                        }
+                    }
+
+                    // Cache the base_metric_name based on the device.
+                    // We do this such that we can save on initialization time
+                    // if repeated devices exist (i.e. 4 * A100's) on a system.
+                    cached_device_metrics[chip_name].push_back(base_metric_name);
+                }
+            }
+            CHECK_INTERNAL_FUNC_CALL( profile.host_deinitialize() );
+        }
+        // CUPTI metrics have been obtained for the current chip name.
+        else {
+            for (std::string base_metric_name : cached_device_metrics[chip_name]) {
+                cupti_metrics[base_metric_name].device_ids.push_back(std::to_string(device_index));
+            }
+        }
+    }
+
+    // Store the maps keys as a vector.
+    for (const std::pair<std::string, cupti_metric_info_t> pair : cupti_metrics) {
+        cupti_metrics_keys.push_back(pair.first);
+    }
+
+    // Push the user's context back onto the calling CPU thread.
+    if (context != nullptr) {
+        CHECK_DRIVER_API_CALL( cuCtxPushCurrentPtr(context) );
+    }
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief A wrapper for the CUPTI call cuptiProfilerHostGetMaxNumHardwareMetricsPerPass.
+  *
+  * @param device_chip_name
+  *   Name of the NVIDIA chip.
+  * @param &max_number_of_hardware_metrics
+  *   Stores the max number of hardware metrics per pass for the NVIDIA chip.
+*/
+int get_max_num_hardware_metrics_per_pass(std::string &device_chip_name, int &max_number_of_hardware_metrics)
+{
+    CUpti_Profiler_Host_GetMaxNumHardwareMetricsPerPass_Params get_max_num_hardware_metrics_per_pass_params {};
+    /// [in]
+    get_max_num_hardware_metrics_per_pass_params.structSize = CUpti_Profiler_Host_GetMaxNumHardwareMetricsPerPass_Params_STRUCT_SIZE;
+    /// [in]
+    get_max_num_hardware_metrics_per_pass_params.pPriv = nullptr;
+    /// [in]
+    get_max_num_hardware_metrics_per_pass_params.profilerType = CUPTI_PROFILER_TYPE_RANGE_PROFILER;
+    /// [in]
+    get_max_num_hardware_metrics_per_pass_params.pChipName = device_chip_name.c_str();
+    /// [in]
+    get_max_num_hardware_metrics_per_pass_params.pCounterAvailabilityImage = nullptr;
+    CHECK_CUPTI_API_CALL( cuptiProfilerHostGetMaxNumHardwareMetricsPerPassPtr(&get_max_num_hardware_metrics_per_pass_params) );
+    max_number_of_hardware_metrics = get_max_num_hardware_metrics_per_pass_params.maxMetricsPerPass;
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief A wrapper for the CUPTI call cuptiProfilerHostGetSupportedChips.
+  *
+  * @param &number_of_supported_chips
+  *   Stores the number of supported chips.
+  * @param *const **supported_chip_names
+  *   Stores the list of supported chips.
+*/
+int get_supported_chips(int &number_of_supported_chips, const char *const **supported_chip_names)
+{
+    CUpti_Profiler_Host_GetSupportedChips_Params get_supported_chip_params {};
+    /// [in]
+    get_supported_chip_params.structSize = CUpti_Profiler_Host_GetSupportedChips_Params_STRUCT_SIZE;
+    /// [in]
+    get_supported_chip_params.pPriv = nullptr;
+    /// [in/out]
+    get_supported_chip_params.numChips = 0;
+    CHECK_CUPTI_API_CALL( cuptiProfilerHostGetSupportedChipsPtr(&get_supported_chip_params) );
+    number_of_supported_chips = get_supported_chip_params.numChips;
+    *supported_chip_names = get_supported_chip_params.ppChipNames;
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Verify is all NVIDIA chips on the system are supported.
+  *
+  * @param device_count
+  *   Number of NVIDIA devices on the system.
+*/
+int check_for_chips_not_supported_on_the_system(int device_count)
+{
+    int number_of_supported_chips = 0;
+    const char *const *supported_chip_names = nullptr;
+    CHECK_INTERNAL_FUNC_CALL( get_supported_chips(number_of_supported_chips, &supported_chip_names) );
+
+    std::map<size_t, std::string> chips_not_supported;
+    for (size_t chip_index = 0; chip_index < static_cast<size_t>(device_count); chip_index++) {
+        std::string chip_name;
+        CHECK_INTERNAL_FUNC_CALL( get_device_chip_name(chip_index, chip_name) );
+
+        int chip_supported = false;
+        for (int supp_chip_index = 0; supp_chip_index < number_of_supported_chips; supp_chip_index++) {
+            if (chip_name.compare(supported_chip_names[supp_chip_index]) == 0) {
+                chip_supported = true;
+            }
+        }
+
+        if (chip_supported == false) {
+            chips_not_supported[chip_index] = chip_name;
+        }
+    }
+
+    if (chips_not_supported.empty() == false) {
+        std::string first_formatter = " - ";
+        std::string second_formatter = ", ";
+        std::stringstream ss;
+        ss << "The cuda_range component does not support devices (index - chipname): ";
+        for (auto entry : chips_not_supported) {
+            ss << entry.first << first_formatter << entry.second << second_formatter;
+        }
+        std::string formatted_error_message = ss.str();
+
+        // Remove the trailing second_formatter (", ").
+        int starting_index = formatted_error_message.length() - second_formatter.length();
+        formatted_error_message.erase(starting_index, second_formatter.length());
+        formatted_error_message += ". A possible reason is because of the Cuda Toolkit in use.";
+
+        cuda_range_set_last_err_msg(formatted_error_message);
+        return PAPI_ECMP;
+    }
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Use the stat, submetric, and device qualifiers
+  *        to bit mask an event id.
+  *
+  * @param *native_event_info
+  *   Structure containing integer values for stat, submetric, device,
+  *   flags, and name_id.
+  * @param *event_id
+  *   Stores the bit masked event id.
+*/
+int encode_evt_id(native_event_info_t *native_event_info, uint32_t *event_id)
+{
+    *event_id  = (uint32_t)(native_event_info->stat     << STAT_SHIFT);
+    *event_id |= (uint32_t)(native_event_info->submetric << SUBMETRIC_SHIFT);
+    *event_id |= (uint32_t)(native_event_info->device   << DEVICE_SHIFT);
+    *event_id |= (uint32_t)(native_event_info->flags    << QLMASK_SHIFT);
+    *event_id |= (uint32_t)(native_event_info->name_id   << NAMEID_SHIFT);
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Decode the bit masked event id to get the stat,
+  *        submetric, and device qualifier indexes.
+  *
+  * @param *event_id
+  *   Stores the bit masked event id.
+  * @param *native_event_info
+  *   Structure containing integer values for stat, submetric, device,
+  *   flags, and name_id.
+*/
+int decode_evt_id(uint32_t event_id, native_event_info_t *native_event_info)
+{
+    native_event_info->stat          = (uint32_t)((event_id & STAT_MASK) >> STAT_SHIFT);
+    native_event_info->submetric     = (uint32_t)((event_id & SUBMETRIC_MASK) >> SUBMETRIC_SHIFT);
+    native_event_info->device        = (uint32_t)((event_id & DEVICE_MASK) >> DEVICE_SHIFT);
+    native_event_info->flags         = (uint32_t)((event_id & QLMASK_MASK) >> QLMASK_SHIFT);
+    native_event_info->name_id        = (uint32_t)((event_id & NAMEID_MASK) >> NAMEID_SHIFT);
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Formats the qualifier vectors (stat, submetric, or device id) for a CUPTI metric name
+  *        into a comma separated list.
+  *
+  * @param qualifiers
+  *   A list of valid qualifiers for a CUPTI metric name.
+  * @param &formatted_qualifiers
+  *   Stores the comma separated list of qualifiers.
+*/
+void format_qualifiers_for_code_to_info(std::vector<std::string> qualifiers, std::string &formatted_qualifiers)
+{
+    for (auto const &entry : qualifiers) {
+        // Add a comma.
+        if (entry != qualifiers.back()) {
+            formatted_qualifiers += entry + ", ";
+        }
+        // Do not add a comma - last element.
+        else {
+            formatted_qualifiers += entry;
+        }
+    }
+
+    return;
+}
+
+/**
+  * @brief Take a user provided cuda_range native event name and
+  *        parse it for the CUPTI base metric name.
+  *
+  * @param *cuda_range_native_event_name
+  *   A user provided cuda_range native event name.
+  * @param *cupti_base_name
+  *   Stores the cupti_base_name.
+  * @param string_length
+  *   Maximum legnth the CUPTI base metric name can be.
+*/
+int parse_native_event_name_for_cupti_base_name(const char *cuda_range_native_event_name, char *cupti_base_name, int string_length)
+{
+    int length_of_base_name = 0;
+    for (int c = 0; cuda_range_native_event_name[c] != ':' && cuda_range_native_event_name[c] != '\0'; c++) {
+        length_of_base_name++;
+    }
+
+    int string_len = snprintf(cupti_base_name, string_length, "%.*s", length_of_base_name, cuda_range_native_event_name);
+    if (string_len < 0 || string_len >= string_length) {
+        SUBDBG("Failed to fully write the base metric name into the buffer.");
+        return PAPI_EBUF;
+    }
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Take a user provided cuda_range native event name and
+  *        parse the qualifiers.
+  *
+  * @param *cuda_range_native_event_name
+  *   A user provided cuda_range native event name.
+  * @param *qualifier_name
+  *   Name of the qualifier to search for.
+  * @param qualifier_value
+  *   Stores the value associated with the qualifier.
+*/
+int parse_native_event_name_for_qualifiers(const char *cuda_range_native_event_name, const char *qualifier_name, std::string &qualifier_value)
+{
+    const char *position_of_qualifier = strstr(cuda_range_native_event_name, qualifier_name);
+    if (position_of_qualifier != nullptr) {
+        const char *beginning_of_qualifier_value = position_of_qualifier + strlen(qualifier_name);
+        for (int c = 0; beginning_of_qualifier_value[c] != ':' && beginning_of_qualifier_value[c] != '\0'; c++) {
+             qualifier_value += beginning_of_qualifier_value[c];
+        }
+    }
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Get the qualifier name for the qualifier index.
+  *
+  * @param decoded_flags
+  *   The resulting flags from the encoded cuda_range native event.
+  * @param qualifier_bitmask
+  *   The specific flag we want to check against to see if it is present.
+  * @param decoded_qualifier_index
+  *   The encoded qualifier index corresponding to a vector entry.
+  * @param &vector_of_qualifiers
+  *   The vector to index into using decoded_qualifier_index.
+  * @param required
+  *   True or false -- if the qualifier is required we add a default.
+  * @param qualifier_name
+  *   Stores the resulting qualifier value.
+*/
+int obtain_qualifier_name(int decoded_flags, int qualifier_bitmask, size_t decoded_qualifier_index, std::vector<std::string> &vector_of_qualifiers, bool required, std::string &qualifier_name)
+{
+    // Qualifier is present in cuda_range native event code. 
+    if (decoded_flags & qualifier_bitmask) {
+        if (decoded_qualifier_index < vector_of_qualifiers.size()) {
+            qualifier_name = vector_of_qualifiers[decoded_qualifier_index];
+        }
+        else {
+            SUBDBG("Invalid cuda_range native event code. The decoded qualifier index (%d) does not index (index is %d)"
+                   " into the vector (size is %u).", decoded_qualifier_index, vector_of_qualifiers.size()); 
+            return PAPI_ENOEVNT;
+        }
+    }
+    // Qualifier is not present in the cuda_range native_event code, but is required.
+    else if (required) {
+        qualifier_name = vector_of_qualifiers[0];
+    }
+    
+    return PAPI_OK;
+}
+
+/**
+  * @brief A helper function to take a user provided native event code and
+  *        convert it to the corresponding cuda_range native event name. 
+  *
+  * @param native_event_code
+  *   A user provided native event code.
+  * @param &base_name
+  *   Stores the corresponding base name.
+  * @param &stat_name
+  *   Stores the corresponding stat name.
+  * @param &sub_metric_name
+  *   Stores the corresponding sub-metric name.
+  * @param &device_id
+  *   Stores the corresponding device id.
+*/
+int native_event_code_to_native_event_name(unsigned int native_event_code, std::string &base_name, std::string &stat_name, std::string &sub_metric_name, std::string &device_id)
+{   
+    native_event_info_t native_event_info;
+    decode_evt_id(native_event_code, &native_event_info);
+
+    // Native event base name is present in the map.
+    if ((size_t) native_event_info.name_id < cupti_metrics_keys.size()) {
+        base_name = cupti_metrics_keys[native_event_info.name_id];
+    }   
+    // Native event base name is not present in the map.
+    else {
+        SUBDBG("The eventcode provided does not index into (index is %u) the vector of keys (size of vector is %u)."
+               " Therefore, the basename is not valid.\n", native_event_info.name_id, cupti_metrics_keys.size());
+        return PAPI_ENOEVNT;
+    }
+
+    cupti_metric_info_t cupti_metric_info = cupti_metrics[base_name];
+    int papi_errno = PAPI_OK;
+    switch(cupti_metric_info.cupti_metric_type) {
+        // Handle CUPTI counter metrics.
+        case CUPTI_METRIC_TYPE_COUNTER:
+            papi_errno = obtain_qualifier_name(native_event_info.flags, STAT_FLAG, native_event_info.stat, cupti_metric_info.stats,
+                                               true, stat_name);
+            if (papi_errno != PAPI_OK) {
+                return papi_errno;
+            }
+
+            papi_errno = obtain_qualifier_name(native_event_info.flags, SUBMETRIC_FLAG, native_event_info.submetric, cupti_metric_info.submetrics,
+                                               false, sub_metric_name);
+            if (papi_errno != PAPI_OK) {
+                return papi_errno;
+            }
+
+            break;
+        // Handle CUPTI ratio metrics.
+        case CUPTI_METRIC_TYPE_RATIO:
+            // Stat qualifier is present and is not supported for CUPTI ratio metrics.
+            if (native_event_info.flags & STAT_FLAG) {
+                SUBDBG("CUPTI ratio metrics do not support a stat qualifier.\n");
+                return PAPI_ENOEVNT;
+            }
+
+            papi_errno = obtain_qualifier_name(native_event_info.flags, SUBMETRIC_FLAG, native_event_info.submetric, cupti_metric_info.submetrics,
+                                               true, sub_metric_name);
+            if (papi_errno != PAPI_OK) {
+                return papi_errno;
+            }
+
+            break;
+        // Handle CUPTI throughput metrics.
+        case CUPTI_METRIC_TYPE_THROUGHPUT:
+            papi_errno = obtain_qualifier_name(native_event_info.flags, STAT_FLAG, native_event_info.stat, cupti_metric_info.stats,
+                                               true, stat_name);
+            if (papi_errno != PAPI_OK) {
+                return papi_errno;
+            }
+            
+            papi_errno = obtain_qualifier_name(native_event_info.flags, SUBMETRIC_FLAG, native_event_info.submetric, cupti_metric_info.submetrics,
+                                               true, sub_metric_name);
+            if (papi_errno != PAPI_OK) {
+                return papi_errno;
+            }
+
+            break;
+        // The CUpti_MetricType is not accounted for.
+        default:
+            SUBDBG("The CUpti_MetricType (%d) is not valid for the current workflow. Possible reason is the"
+                   "  addition of a new CUpti_MetricType.\n", cupti_metric_info.cupti_metric_type);
+            return PAPI_EBUG;
+    }
+
+    // Device qualifier is present.
+    if (native_event_info.flags & DEVICE_FLAG) {
+        // Device is present in the vector.
+        if ((size_t) native_event_info.device < cupti_metric_info.device_ids.size()) {
+            device_id = cupti_metric_info.device_ids[native_event_info.device];
+        }
+        // Device is not present in the vector.
+        else {
+            SUBDBG("The eventcode provided does not index into (index is %d) the vector of devices (size of vector is %d)."
+                   " Therefore, the device is not valid.\n", native_event_info.device, cupti_metric_info.device_ids.size());
+            return PAPI_ENOEVNT;
+        }
+    }
+    // Device qualifier is not present -- use default.
+    else {
+        device_id = cupti_metric_info.device_ids[0];
+    }
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Reserve an NVIDIA device.
+  *
+  *        The cuda_range component only allows an NVIDIA device
+  *        to be used on a single thread. Therefore, internally
+  *        the NVIDIA device will be "reserved" for use. 
+  *
+  * @param device_index
+  *   The index of the device to be reserved.
+*/
+int cuda_range_reserve_device(int device_index)
+{
+    uint64_t local_bitmask = 0; 
+    local_bitmask |= (1 << device_index);
+
+    if (local_bitmask & device_bitmask) {
+        SUBDBG("The cuda_range component only supports one thread per device and device %d is already in use.\n", device_index);
+        return PAPI_ECNFLCT;
+    }    
+
+    _papi_hwi_lock(_cuda_range_lock);
+    device_bitmask |= local_bitmask;
+    _papi_hwi_unlock(_cuda_range_lock);
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Un-reserve the NVIDIA device reserved by the call
+  *        cuda_range_reserve_device.
+  *
+  * @param device_index
+  *   The index of the device to be un-reserved.
+*/
+int cuda_range_unreserve_device(int device_index)
+{
+    uint64_t local_bitmask = 0; 
+    local_bitmask |= (1 << device_index);
+
+    if ((local_bitmask & device_bitmask) != local_bitmask) {
+        SUBDBG("Device %d is not reserved and should be.\n", device_index);
+        return PAPI_EBUG;
+    }    
+
+    _papi_hwi_lock(_cuda_range_lock);
+    device_bitmask ^= local_bitmask;
+    _papi_hwi_unlock(_cuda_range_lock);
+
+    return PAPI_OK;
+}
+
+typedef struct added_native_events_data_t
+{
+    std::vector<std::string> cupti_metric_names;
+    std::vector<size_t> event_insertion_order;
+} added_native_events_data_t;
+
+/**
+ *  @}
+ ******************************************************************************/
+ 
+/***************************************************************************//**
+ *  @name PAPI instrumentation
+ *  @{
+ */
+
+/** 
+  * @brief Initial initialization of the cuda_range component.
+  *
+  *        The following is done within this function call:
+  *        1. Load the function pointers for the Cuda Driver,
+  *        Cuda Runtime, and CUPTI APIs.
+  *        2. Verify NVIDIA devices exist on the machine.
+  *        3. Initialize the CUPTI Profiler interface.
+*/
+extern "C" int initialize_cuda_range_component(void)
+{
+    int papi_errno = load_cuda_driver_function_pointers();
+    if (papi_errno != PAPI_OK) {
+        std::string error_message = "Unable to load the Cuda Driver API's. Try setting PAPI_CUDA_RANGE_ROOT or PAPI_CUDA_RANGE_DRIVER.";
+        cuda_range_set_last_err_msg(error_message);
+        return PAPI_ECMP;
+    }
+
+    papi_errno = load_cuda_runtime_function_pointers();
+    if (papi_errno != PAPI_OK) {
+        std::string error_message = "Unable to load the Cuda Runtime API's. Try setting PAPI_CUDA_RANGE_ROOT or PAPI_CUDA_RANGE_RUNTIME.";
+        cuda_range_set_last_err_msg(error_message);
+        return PAPI_ECMP;
+    }
+
+    papi_errno = load_cupti_function_pointers();
+    if (papi_errno != PAPI_OK) {
+        std::string error_message = "Unable to load the CUPTI API's. Try setting PAPI_CUDA_RANGE_ROOT or PAPI_CUDA_RANGE_CUPTI.";
+        cuda_range_set_last_err_msg(error_message);
+        return PAPI_ECMP;
+    }
+
+    int device_count = 0;
+    CHECK_RUNTIME_API_CALL( cudaGetDeviceCountPtr(&device_count) );
+    // From documentation, cudaGetDeviceCount always succeeds; therefore,
+    // we need to verify device_count is not 0.
+    if (device_count == 0) {
+        std::string error_message = "No NVIDIA devices detected on the machine.";
+        cuda_range_set_last_err_msg(error_message);
+        return PAPI_ECMP;
+    }
+
+    // During initial development of the cuda_range component, using Cuda Toolkit 12.9 resulted in
+    // cuptiProfilerHostGetMetricProperties returning the error CUPTI_ERROR_INVALID_METRIC_NAME.
+    // However, Cuda Toolkit 13.0 does not have this error occur. Therefore, we restrict users to
+    // Cuda Toolkit 13.0.
+    int cuda_runtime_version = 0, minimum_cuda_runtime_version = 13000;
+    CHECK_RUNTIME_API_CALL( cudaRuntimeGetVersionPtr(&cuda_runtime_version) );
+    if (cuda_runtime_version < minimum_cuda_runtime_version) {
+        std::stringstream ss;
+        ss << "The cuda_range component requires a Cuda Toolkit >= 13.0. Detected Cuda Toolkit in use is "
+           << cuda_runtime_version / 1000 << "."
+           << (cuda_runtime_version % 1000) / 10
+           << ".";
+        std::string error_message = ss.str();
+
+        cuda_range_set_last_err_msg(error_message);
+        return PAPI_ECMP;
+    }
+
+    papi_errno = initialize_cupti_profiler();
+    if (papi_errno != PAPI_OK) {
+        std::string error_message = "Unable to initialize the CUPTI profiler interface. A possible reason is"
+                                   " a mismatched Cuda Toolkit and NVIDIA architecture. Try setting PAPI_CUDA_RANGE_ROOT"
+                                   " to a newer Cuda Toolkit version.";
+        cuda_range_set_last_err_msg(error_message);
+        return PAPI_ECMP;
+    }
+
+    papi_errno = check_for_chips_not_supported_on_the_system(device_count);
+    if (papi_errno != PAPI_OK) {
+        return PAPI_ECMP;
+    }
+
+    CHECK_DRIVER_API_CALL( cuInitPtr(0) );
+
+    papi_errno = enumerate_and_collect_metrics_per_device(device_count);
+    if (papi_errno != PAPI_OK) {
+        std::string error_message = "Failed to create map containing cuda_range native events.";
+        cuda_range_set_last_err_msg(error_message);
+        return PAPI_ECMP;
+    }
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief For each device the maximum number of hardware metrics
+  *        that can be scheduled in a single pass for a chip are retrieved.
+  *
+  *        Note 1: In the case a system has heterogeneous NVIDIA
+  *        architectures (i.e. H100 and V100) the maximum will be
+  *        taken between them. 
+  *
+  *        Note 2: Per NVIDIA, while this represents a theoretical upper limit,
+  *        practical constraints may prevent reaching this threshold for a specfic
+  *        set of metrics. Furthermore, the maximum achievable value is contingent
+  *        upon the characteristics and architecture of the chip in question.
+  *
+  * @param *maximum_number_of_counters
+  *   Stores the maximum number of counters across all NVIDIA devivces on the system.. 
+*/
+extern "C" int get_the_maximum_number_of_hardware_metrics_per_device(int *maximum_number_of_counters)
+{
+    int device_count = 0; 
+    CHECK_RUNTIME_API_CALL( cudaGetDeviceCountPtr(&device_count) );
+
+    std::vector<int> number_of_counters_per_device;
+    for (size_t device_index = 0; device_index < static_cast<size_t>(device_count); device_index++) {
+        std::string deviceChipName;
+        int retval = get_device_chip_name(device_index, deviceChipName);
+        if (retval != PAPI_OK) {
+            return retval;
+        }    
+
+        int maxNumberOfHardwareMetrics = 0; 
+        retval = get_max_num_hardware_metrics_per_pass(deviceChipName, maxNumberOfHardwareMetrics);
+        if (retval != PAPI_OK) {
+            return retval;
+        }    
+
+        number_of_counters_per_device.push_back(maxNumberOfHardwareMetrics);
+    }    
+ 
+    *maximum_number_of_counters = *std::max_element(number_of_counters_per_device.begin(), number_of_counters_per_device.end());
+ 
+    return PAPI_OK;
+}
+
+/**
+  * @brief Take a user provided native event code and enumerate to the
+  *        next native event code.
+  *
+  *        Implementation only accounts for PAPI_ENUM_FIRST, PAPI_ENUM_EVENTS,
+  *        and PAPI_ENUM_NTV_UMASKS modifiers.
+  *
+  * @param *native_event_code
+  *   A user provided native event code.
+  * @param modifier
+  *   Value to indicate the enumeration of events, i.e. PAPI_ENUM_FIRST.
+*/
+extern "C" int cuda_range_event_enum(uint32_t *native_event_code, int modifier)
+{
+    int papi_errno;
+
+    std::string base_name;
+    native_event_info_t native_event_info;
+    switch(modifier) {
+        case PAPI_ENUM_FIRST:
+            native_event_info.stat = 0;
+            native_event_info.submetric = 0;
+            native_event_info.device = 0;
+            native_event_info.flags = NOQUAL_FLAG;
+            native_event_info.name_id = 0;
+            encode_evt_id(&native_event_info, native_event_code);
+            papi_errno = PAPI_OK;
+            break;
+        case PAPI_ENUM_EVENTS:
+            decode_evt_id(*native_event_code, &native_event_info);
+            // Enumeration does not exceed map.
+            if (native_event_info.name_id + 1 < cupti_metrics.size()) {
+                native_event_info.stat = 0;
+                native_event_info.submetric = 0;
+                native_event_info.device = 0;
+                native_event_info.flags = NOQUAL_FLAG;
+                native_event_info.name_id++;
+                encode_evt_id(&native_event_info, native_event_code);
+                papi_errno = PAPI_OK;
+                break;
+            }
+            // Enumeration exceeds map.
+            else {
+                SUBDBG("Attempted to exceed the size of the map. Therefore, no metrics are left to enumerate.\n");
+                papi_errno = PAPI_ENOEVNT;
+                break;
+            }
+
+            papi_errno = PAPI_ENOEVNT;
+            break;
+        case PAPI_NTV_ENUM_UMASKS:
+            decode_evt_id(*native_event_code, &native_event_info);
+
+            base_name = cupti_metrics_keys[native_event_info.name_id];
+            if (native_event_info.flags == NOQUAL_FLAG && cupti_metrics[base_name].stats.size() > 0) {
+                native_event_info.stat = 0;
+                native_event_info.submetric = 0;
+                native_event_info.device = 0;
+                native_event_info.flags = STAT_FLAG;
+                encode_evt_id(&native_event_info, native_event_code);
+                papi_errno = PAPI_OK;
+                break;
+            }
+
+            if ((native_event_info.flags == NOQUAL_FLAG || native_event_info.flags == STAT_FLAG) && cupti_metrics[base_name].submetrics.size() > 0) {
+                native_event_info.stat = 0;
+                native_event_info.submetric = 0;
+                native_event_info.device = 0;
+                native_event_info.flags = SUBMETRIC_FLAG;
+                encode_evt_id(&native_event_info, native_event_code);
+                papi_errno = PAPI_OK;
+                break;
+            }
+
+            if (native_event_info.flags == SUBMETRIC_FLAG && cupti_metrics[base_name].device_ids.size() > 0) {
+                native_event_info.stat = 0;
+                native_event_info.submetric = 0;
+                native_event_info.device = 0;
+                native_event_info.flags = DEVICE_FLAG;
+                encode_evt_id(&native_event_info, native_event_code);
+                papi_errno = PAPI_OK;
+                break;
+            }
+
+            papi_errno = PAPI_ENOEVNT;
+            break;
+        default:
+            SUBDBG("The provided modifier is not supported in the cuda_range component.\n");
+            papi_errno = PAPI_EINVAL;
+    }   
+
+    return papi_errno;
+}
+
+/**
+  * @brief Take a user provided cuda_range native event name and
+  *        convert it to the corresponding cuda_range native event
+  *        code.
+  *
+  * @param *native_event_name
+  *   A user provided cuda_range native event name.
+  * @param *native_event_code
+  *   Stores the corresponding cuda_range native event code.
+*/
+extern "C" int cuda_range_native_event_name_to_native_event_code(const char *native_event_name, uint32_t *native_event_code)
+{
+    native_event_info_t native_event_info = {};
+
+    // Parse the base name.
+    char base_metric_name[PAPI_2MAX_STR_LEN];
+    CHECK_INTERNAL_FUNC_CALL( parse_native_event_name_for_cupti_base_name(native_event_name, base_metric_name, PAPI_MAX_STR_LEN) );
+
+    std::map<std::string, cupti_metric_info_t>::iterator eventEntry = cupti_metrics.find(base_metric_name);
+    // Base name exists.
+    if (eventEntry != cupti_metrics.end()) {
+        native_event_info.name_id = std::distance(cupti_metrics.begin(), eventEntry);    
+    }
+    // Base name does not exist.
+    else {
+        SUBDBG("The provided base name (%s) is not valid.\n", base_metric_name);
+        return PAPI_ENOEVNT;
+    }
+
+    std::string value_of_qualifier;
+    cupti_metric_info_t cupti_metric_info = eventEntry->second;
+
+    // Parse for the stat qualifier.
+    const char *name_of_stat_qualifier = ":stat=";
+    CHECK_INTERNAL_FUNC_CALL( parse_native_event_name_for_qualifiers(native_event_name, name_of_stat_qualifier, value_of_qualifier) );
+    // Stat qualifier found.
+    if (value_of_qualifier.empty() == false) {
+        std::vector<std::string>::iterator stats_iter = std::find(cupti_metric_info.stats.begin(), cupti_metric_info.stats.end(), value_of_qualifier);
+        // User provided a valid stat, update from index 0 (default).
+        if (stats_iter != cupti_metric_info.stats.end()) {
+            native_event_info.stat = std::distance(cupti_metric_info.stats.begin(), stats_iter);
+            native_event_info.flags = STAT_FLAG;
+        }
+        // User did not provide a valid stat.
+        else {
+            SUBDBG("The provided stat (%s) is not a valid option.\n", value_of_qualifier.c_str());
+            return PAPI_ENOEVNT;
+        }
+    }
+    value_of_qualifier.clear();
+
+    // Parse for the submetric qualifier.
+    const char *name_of_sub_qualifier = ":submetric=";
+    CHECK_INTERNAL_FUNC_CALL( parse_native_event_name_for_qualifiers(native_event_name, name_of_sub_qualifier, value_of_qualifier) );
+    // Submetric qualifier found.
+    if (value_of_qualifier.empty() == false) {
+        std::vector<std::string>::iterator sub_metrics_iter  = std::find(cupti_metric_info.submetrics.begin(), cupti_metric_info.submetrics.end(), value_of_qualifier);
+        // User provided a valid submetric, update from index 0 (default).
+        if (sub_metrics_iter != cupti_metric_info.submetrics.end()) {
+            native_event_info.submetric = std::distance(cupti_metric_info.submetrics.begin(), sub_metrics_iter);
+            native_event_info.flags |= SUBMETRIC_FLAG;
+        }
+        // User did not provide a valid submetric.
+        else {
+            SUBDBG("The provided submetric (%s) is not a valid option.\n", value_of_qualifier.c_str());
+            return PAPI_ENOEVNT;
+        }
+    }
+    value_of_qualifier.clear();
+
+    // Parse for the device qualifier.
+    const char *name_of_dev_qualifier = ":device=";
+    CHECK_INTERNAL_FUNC_CALL( parse_native_event_name_for_qualifiers(native_event_name, name_of_dev_qualifier, value_of_qualifier) );
+    // User provided a device qualifier.
+    if (value_of_qualifier.empty() == false) {
+        std::vector<std::string>::iterator device_ids_iter = std::find(cupti_metric_info.device_ids.begin(), cupti_metric_info.device_ids.end(), value_of_qualifier);
+        // User provided a valid device, update from index 0 (default).
+        if (device_ids_iter != cupti_metric_info.device_ids.end()) {
+            native_event_info.device = std::distance(cupti_metric_info.device_ids.begin(), device_ids_iter);
+            native_event_info.flags |= DEVICE_FLAG;
+        }
+        // User did not provide a valid device. 
+        else {
+            SUBDBG("The provided device (%s) is not a valid option.\n", value_of_qualifier.c_str());
+            return PAPI_ENOEVNT; 
+        }
+    }
+
+    encode_evt_id(&native_event_info, native_event_code);
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Take a user provided cuda_range native event code and
+  *        convert it to the corresponding cuda_range native event
+  *        name.
+  *
+  * @param *native_event_code
+  *   A user provided cuda_range native event code.
+  * @param *native_event_name
+  *   Stores the corresponding cuda_range native event name.
+*/
+extern "C" int cuda_range_native_event_code_to_native_event_name(unsigned int native_event_code, char *native_event_name, int len)
+{
+    std::string base_name, stat_name, sub_metric_name, device_id;
+    CHECK_INTERNAL_FUNC_CALL( native_event_code_to_native_event_name(native_event_code, base_name, stat_name, sub_metric_name, device_id) );
+
+    std::string cuda_range_native_event_name = base_name;
+    // Concatenate stat qualifier.
+    if (stat_name.empty() == false) {
+        cuda_range_native_event_name += ":stat=" + stat_name;
+    }
+
+    // Concatenate submetric qualifier.
+    if (sub_metric_name.empty() == false) {
+        cuda_range_native_event_name += ":submetric=" + sub_metric_name;
+    }
+
+    // Concatenate device qualifier.
+    if (device_id.empty() == false) {
+        cuda_range_native_event_name += ":device=" + device_id;
+    }
+
+    CHECK_SNPRINTF_CALL( snprintf(native_event_name, len, "%s", cuda_range_native_event_name.c_str()),
+                         int, len );
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Take a user provided cuda_range native event code and
+  *        fill the member variables of the PAPI_event_info_t structure.
+  *
+  * @param *native_event_code
+  *   A user provided cuda_range native event code.
+  * @param *info
+  *   A filled PAPI_event_info_t structure for the user provided cuda_range native
+  *   event code.
+*/
+extern "C" int cuda_range_event_code_to_info(uint32_t native_event_code, PAPI_event_info_t *info)
+{
+    // Check for a user context on the calling CPU thread.
+    CUcontext context = nullptr;
+    CHECK_DRIVER_API_CALL( cuCtxGetCurrentPtr(&context) );
+    if (context != nullptr) {
+        // Pop the context from the calling CPU thread.
+        CUcontext popped_context;
+        CHECK_DRIVER_API_CALL( cuCtxPopCurrentPtr(&popped_context) );
+    }
+
+    native_event_info_t native_event_info;
+    decode_evt_id(native_event_code, &native_event_info);
+
+    std::string base_metric_name = cupti_metrics_keys[native_event_info.name_id];
+    cupti_metric_info_t &cupti_metric_info = cupti_metrics[base_metric_name];
+    int device_id_int = std::stoi(cupti_metric_info.device_ids[0]);
+
+    // Description has not been stored for the CUPTI metric.
+    if (cupti_metric_info.description.empty() == true) {
+        // Class entry for device has yet to be instantiated.
+        if (cupti_profile_metric_descriptions.count(device_id_int) == 0) {
+            CUcontext context;
+            unsigned int flags = 0;
+            CHECK_DRIVER_API_CALL( cuCtxCreatePtr(&context, (CUctxCreateParams*)0, flags, device_id_int) );
+
+            bool own_context = true;
+            cupti_profile_metric_descriptions.emplace(device_id_int, CuptiProfile(context, own_context));
+            CHECK_INTERNAL_FUNC_CALL( cupti_profile_metric_descriptions.at(device_id_int).counter_availability() );
+            CHECK_INTERNAL_FUNC_CALL( cupti_profile_metric_descriptions.at(device_id_int).chip_name(device_id_int) );
+        }
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_metric_descriptions.at(device_id_int).host_initialize() );
+
+        std::string cupti_metric_name {};
+        // CUPTI metric is of type Counter or Throughput.
+        if (cupti_metric_info.cupti_metric_type == CUPTI_METRIC_TYPE_COUNTER ||
+            cupti_metric_info.cupti_metric_type == CUPTI_METRIC_TYPE_THROUGHPUT) {
+            cupti_metric_name = base_metric_name + "." + cupti_metric_info.stats[0] + "." + cupti_metric_info.submetrics[0];
+        }
+        // CUPTI metric is of type Ratio.
+        else {
+            cupti_metric_name = base_metric_name + "." + cupti_metric_info.submetrics[0];
+        }
+        cupti_profile_metric_descriptions.at(device_id_int).set_cupti_metric_names({cupti_metric_name}); 
+
+        std::string description {};
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_metric_descriptions.at(device_id_int).metric_properties(base_metric_name.c_str(), description) );
+        description += ".";
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_metric_descriptions.at(device_id_int).create_config_image() );
+
+        size_t number_of_passes = 0;
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_metric_descriptions.at(device_id_int).number_of_passes(number_of_passes) );
+        description += " The number of passes required for collection is " + std::to_string(number_of_passes) + ".";
+        cupti_metric_info.description = description;
+
+        // Avoid continously adding metrics to the current CUpti_Profiler_Host_Object by destroying it.
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_metric_descriptions.at(device_id_int).host_deinitialize() ); 
+    }
+
+    int string_length;
+    switch (native_event_info.flags) {
+        case (NOQUAL_FLAG):
+        {
+            string_length = snprintf( info->symbol, PAPI_HUGE_STR_LEN, "%s", base_metric_name.c_str());
+            if (string_length < 0 || string_length >= PAPI_HUGE_STR_LEN) {
+                SUBDBG("Failed to fully write metric name in case 0.\n");
+                return PAPI_EBUF;
+            }
+            string_length = snprintf( info->long_descr, PAPI_HUGE_STR_LEN, "%s", cupti_metric_info.description.c_str());
+            if (string_length < 0 || string_length >= PAPI_HUGE_STR_LEN) {
+                SUBDBG("Failed to fully write long description in case 0.\n");
+                return PAPI_EBUF;
+            }
+            break;
+        }
+        case DEVICE_FLAG:
+        {
+            string_length = snprintf( info->symbol, PAPI_HUGE_STR_LEN, "%s:device=%s", base_metric_name.c_str(), cupti_metric_info.device_ids[0].c_str() );
+            if (string_length < 0 || string_length >= PAPI_HUGE_STR_LEN) {
+                SUBDBG("Failed to fully write metric name in case DEVICE_FLAG.\n");
+                return PAPI_EBUF;
+            }
+
+            std::string devices_formatted;
+            format_qualifiers_for_code_to_info(cupti_metric_info.device_ids, devices_formatted);
+
+            string_length = snprintf(info->long_descr, PAPI_HUGE_STR_LEN, "masks:Mandatory device qualifier [%s]",
+                              devices_formatted.c_str());
+            if (string_length < 0 || string_length >= PAPI_HUGE_STR_LEN) {
+                SUBDBG("Failed to fully write long description in case DEVICE_FLAG.\n");
+                return PAPI_EBUF;
+            }
+            break;
+        }
+        case STAT_FLAG:
+        {
+            string_length = snprintf( info->symbol, PAPI_HUGE_STR_LEN, "%s:stat=%s", base_metric_name.c_str(), cupti_metric_info.stats[0].c_str());
+            if (string_length < 0 || string_length >= PAPI_HUGE_STR_LEN) {
+                SUBDBG("Failed to fully write metric name in case STAT_FLAG.\n");
+                return PAPI_EBUF;
+            }
+
+            std::string stats_formatted;
+            format_qualifiers_for_code_to_info(cupti_metric_info.stats, stats_formatted);
+
+            string_length = snprintf(info->long_descr, PAPI_HUGE_STR_LEN, "masks:Mandatory stat qualifier [%s]",
+                              stats_formatted.c_str());
+            if (string_length < 0 || string_length >= PAPI_HUGE_STR_LEN) {
+                SUBDBG("Failed to fully write long description in case STAT_FLAG.\n");
+                return PAPI_EBUF;
+            }
+            break;
+        }
+        case SUBMETRIC_FLAG:
+        {
+            string_length = snprintf( info->symbol, PAPI_HUGE_STR_LEN, "%s:submetric=%s", base_metric_name.c_str(), cupti_metric_info.submetrics[0].c_str());
+            if (string_length < 0 || string_length >= PAPI_HUGE_STR_LEN) {
+                SUBDBG("Failed to fully write metric name in case SUBMETRIC_FLAG.\n");
+                return PAPI_EBUF;
+            }
+
+            std::string sub_metrics_formatted;
+            format_qualifiers_for_code_to_info(cupti_metric_info.submetrics, sub_metrics_formatted);
+
+            string_length = snprintf(info->long_descr, PAPI_HUGE_STR_LEN, "masks:Mandatory submetric qualifier [%s]",
+                              sub_metrics_formatted.c_str());
+            if (string_length < 0 || string_length >= PAPI_HUGE_STR_LEN) {
+                SUBDBG("Failed to fully write long description in case SUBMETRIC_FLAG.\n");
+                return PAPI_EBUF;
+            }
+            break;
+        }
+        default:
+            break;
+    }
+
+    // Push the user's context back onto the calling CPU thread.
+    if (context != nullptr) {
+        CHECK_DRIVER_API_CALL( cuCtxPushCurrentPtr(context) );
+    }
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Collect the user added cuda_range native events and the user created CUDA contexts.
+  *
+  *        Note: If a user did not have a CUDA context on the calling CPU thread then
+  *        one will be created based on # from :device=#.
+  *
+  * @param *event_codes
+  *   User added cuda_range native event codes.
+  * @param number_of_events
+  *   Number of user added native events.
+*/
+extern "C" int cuda_range_store_added_native_events(uint32_t *event_codes, int number_of_events)
+{
+    // Collect the cuda_range native event data i.e. names and event order.
+    std::map<int, added_native_events_data_t> cuda_range_native_event_data;
+    for (size_t event_index = 0; event_index < static_cast<size_t>(number_of_events); event_index++) {
+        std::string base_name, stat_name, sub_metric_name, device_id;
+        CHECK_INTERNAL_FUNC_CALL( native_event_code_to_native_event_name(event_codes[event_index], base_name, stat_name, sub_metric_name, device_id) );
+
+        std::string cupti_metric_name = base_name;
+        // Concatenate stat (i.e. rollup in CUPTI terminology).
+        if (stat_name.empty() == false) {
+            cupti_metric_name += "." + stat_name;
+        }    
+        // Concatenate submetric.
+        if (sub_metric_name.empty() == false) {
+            cupti_metric_name += "." + sub_metric_name;
+        }
+
+        int device_id_int = std::stoi(device_id);
+        cuda_range_native_event_data[device_id_int].cupti_metric_names.push_back(cupti_metric_name);
+        cuda_range_native_event_data[device_id_int].event_insertion_order.push_back(event_index);
+    }
+
+    // Store the collected cuda_range native events for profiling.
+    for (auto pair : cuda_range_native_event_data) {
+        // No corresponding key entry for the current device.
+        if (cupti_profile_per_device.count(pair.first) == 0) {
+            bool own_context = false;
+            CUdevice device;
+            CUcontext context;
+            CHECK_DRIVER_API_CALL( cuCtxGetCurrentPtr(&context) );
+            // The user created a CUDA context on the calling CPU thread.
+            if (context != nullptr) {
+                SUBDBG("A user context (%p) was found on the calling CPU thread.\n", context);
+                CHECK_DRIVER_API_CALL( cuCtxGetDevice_v2Ptr(&device, context) );
+                if (device != pair.first) {
+                    SUBDBG("The device index for the Cuda context on the calling CPU thread does not match"
+                           " the device index assigned to the device qualifier.\n");
+                    return PAPI_ECMP;
+                }    
+            }    
+            // The user did not create a CUDA context on the calling CPU thread.
+            else {
+                SUBDBG("A user context was not found on the calling CPU thread. One will be created for device id %d\n", pair.first);
+                CHECK_DRIVER_API_CALL( cuCtxCreatePtr(&context, (CUctxCreateParams*)0, 0, pair.first) );
+                char *pop_context = getenv("PAPI_CUDA_RANGE_INTERNAL_VERIFY_CONTEXTS");
+                if (pop_context == nullptr) {
+                    CHECK_DRIVER_API_CALL( cuCtxPopCurrentPtr(&context) );
+                }
+                own_context = true;
+            }
+
+            cupti_profile_per_device.emplace(pair.first, CuptiProfile(context, own_context));
+        }
+        // Corresponding key entry for the current device found.
+        else {
+            SUBDBG("The device (%d) already has a cuda context stored.\n", pair.first);
+        }
+
+        cupti_profile_per_device.at(pair.first).set_cupti_metric_names(pair.second.cupti_metric_names);
+        cupti_profile_per_device.at(pair.first).set_event_insertion_order(pair.second.event_insertion_order);
+    }
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Start profiling.
+  *
+  *        Create and initialize the profiler host object (CUpti_Profiler_Host_Object),
+  *        create a config image for the metrics added to the profiler host object,
+  *        enable Range Profiling, set the config, and start profiling.
+*/
+extern "C" int cuda_range_start_profiling(void)
+{
+    int number_of_devices_on_system = 0;
+    CHECK_RUNTIME_API_CALL( cudaGetDeviceCountPtr(&number_of_devices_on_system) );
+    if (number_of_devices_on_system < 0) {
+        SUBDBG("No NVIDIA devices detected on the machine.");
+        return PAPI_ECMP;
+    }
+
+    for (int device_index = 0; device_index < number_of_devices_on_system; device_index++) {
+        if (cupti_profile_per_device.count(device_index) == 0) {
+            SUBDBG("No entry detected for device %d. Continuing.\n", device_index);
+            continue;
+        }
+        SUBDBG("Entry detected for device %d. Proceeding to start profiling.\n", device_index);
+
+        CHECK_INTERNAL_FUNC_CALL( cuda_range_reserve_device(device_index) );
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).counter_availability() );
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).chip_name(device_index) );
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).host_initialize() );
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).create_config_image() );
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).enable_range_profiler() );
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).create_counter_data_image() );
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).config() );
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).start_profiling() );
+
+        std::string range_name = "PAPI_CUDA_RANGE_DEVICE_" + std::to_string(device_index);
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).push_range(range_name) );
+    }
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Read the counter values.
+  *
+  *        The profiling data stored in the hardware to the counter data image
+  *        will be decoded and then evaluated based on the range index stored
+  *        in the counter data.
+  *        
+  * @param ctx
+  *   A structure containing the state, event ids, counters, and number
+  *   of events.
+  * @param **counter_values
+  *   Stores the decoded and evaluated counter data.
+*/
+extern "C" int cuda_range_decode_and_evaluate_counter_data(cuda_range_ctx_t ctx, long long **counter_values)
+{ 
+    int number_of_devices_on_system = 0; 
+    CHECK_RUNTIME_API_CALL( cudaGetDeviceCountPtr(&number_of_devices_on_system) );
+    if (number_of_devices_on_system < 0) { 
+        SUBDBG("No NVIDIA devices detected on the machine.");
+        return PAPI_ECMP;
+    }    
+
+    bool all_passes_submitted_for_devices = true;
+    for (int device_index = 0; device_index < number_of_devices_on_system; device_index++) {
+        // No user added events for the device.
+        if (cupti_profile_per_device.count(device_index) == 0) { 
+            SUBDBG("No entry detected for device %d. Continuing.\n", device_index);
+            continue;
+        }
+        // Avoid continous overwrites of initial all passes submitted collection.
+        // Example: A user is on a multiple device system and creates a PAPI event set. The PAPI event set
+        // contains a cuda_range native event on device 0 which requires a single pass AND a cuda_range native event on
+        // device 1 which requires 4 passes. In this case a user will need to call PAPI_read 4 times to get the proper value
+        // for the device 1 cuda_range native event. In doing so, the device 0 cuda_range native event will be contiously
+        // overwrote; therefore, a user can avoid overwrites by setting the environemnt variable 
+        // PAPI_CUDA_RANGE_CONTINUE_ON_ALL_PASSES.
+        if (getenv("PAPI_CUDA_RANGE_CONTINUE_ON_ALL_PASSES") &&
+            cupti_profile_per_device.at(device_index).get_all_passes_submitted()) {
+            SUBDBG("PAPI_CUDA_RANGE_CONTINUE_ON_ALL_PASSES set; therefore, continuing for device %d as all passes are submitted.\n");
+            continue;
+        }
+        SUBDBG("Entry detected for device %d. Proceeding to decode and evaluate to gpu values.\n", device_index);
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).pop_range() );
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).stop_profiling() );
+
+        // All passes have been submitted to the device for collection.
+        if (cupti_profile_per_device.at(device_index).get_all_passes_submitted()) {
+            CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).decode_data() );
+
+            CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).evaluate_counter_data() );
+
+            cupti_profile_per_device.at(device_index).calculate(ctx);
+
+            CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).create_counter_data_image() );
+        }
+        // All passes have not been submitted to the device for collection.
+        else {
+            all_passes_submitted_for_devices = false;
+        }
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).start_profiling() );
+
+        std::string range_name = "PAPI_CUDA_RANGE_DEVICE_" + std::to_string(device_index);
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).push_range(range_name) );
+    }
+    *counter_values = ctx->counters;
+
+    return all_passes_submitted_for_devices == true ?  PAPI_OK : PAPI_EALLPASSES_NOT_SUBMITTED;
+}
+
+/**
+  * @brief Stop profiling.
+  *
+  *        CUPTI Range Profiling will be stopped and disabled.
+  *        Along with the CUpti_Profiler_Host_Object being 
+  *        deinitialized and destroyed.
+*/
+extern "C" int cuda_range_stop_profiling(void)
+{
+    int number_of_devices_on_system = 0; 
+    CHECK_RUNTIME_API_CALL( cudaGetDeviceCountPtr(&number_of_devices_on_system) );
+    if (number_of_devices_on_system < 0) { 
+        SUBDBG("No NVIDIA devices detected on the machine.");
+        return PAPI_ECMP;
+    } 
+
+    for (int device_index = 0; device_index < number_of_devices_on_system; device_index++) {
+        if (cupti_profile_per_device.count(device_index) == 0) {
+            SUBDBG("No entry detected for device %d. Continuing.\n", device_index);
+            continue;
+        }
+        SUBDBG("Entry detected for device %d. Proceeding to stop profiling.\n", device_index);
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).stop_profiling() );
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).disable_range_profiler() );
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).host_deinitialize() );
+
+        CHECK_INTERNAL_FUNC_CALL( cuda_range_unreserve_device(device_index) );
+    }
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Reset the counter values to zero.
+  *
+  * @param ctx
+  *   A structure containing the state, event ids, counters, and number
+  *   of events. 
+*/
+extern "C" int cuda_range_reset_counters(cuda_range_ctx_t ctx)
+{
+    memset(ctx->counters, 0, sizeof(ctx->counters) * ctx->num_events);
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Shutdown the cuda_range component.
+  *
+  *        Unload, CUPTI CUDA driver, and CUDA runtime
+  *        function pointers.
+*/
+extern "C" int cuda_range_unload_function_pointers_and_shutdown(void)
+{
+    // Destroy OWNED CUDA contexts for cupti_profile_per_device.
+    // See member function documentation for more details.
+    for (auto& pair : cupti_profile_per_device)
+        pair.second.destroy_context();
+
+    // Destroy OWNED CUDA contexts for cupti_profile_metric_descriptions.
+    // See member function documentation for more details.
+    for (auto& pair : cupti_profile_metric_descriptions)
+        pair.second.destroy_context();
+
+    unload_cupti_function_pointers();
+
+    unload_cuda_runtime_function_pointers();
+
+    unload_cuda_driver_function_pointers();
+
+    return PAPI_OK;
+}
+
+/**
+  * @brief Return the cuda_range error message set by
+  *        cuda_range_set_last_err_msg.
+*/
+extern "C" const char *cuda_range_get_last_err_msg(void)
+{
+    return cuda_range_error_message.c_str();
+}
+
+/**
+ *  @}
+ ******************************************************************************/

--- a/src/components/cuda_range/cuda_range_profiling.cpp
+++ b/src/components/cuda_range/cuda_range_profiling.cpp
@@ -1264,13 +1264,23 @@ inline int CuptiProfile::counter_availability(void)
     #if CUDART_VERSION >= 13010
     get_counter_availability_params.bAllowDeviceLevelCounters = 1;
     #endif
+    CUptiResult cupti_result = cuptiProfilerGetCounterAvailabilityPtr(&get_counter_availability_params);
+    if (cupti_result != CUPTI_SUCCESS) {
+        SUBDBG("The call to cuptiProfilerGetCounterAvailability failed with error code %d\n.", cupti_result);
+        return cupti_result;
+    }
+
     CHECK_CUPTI_API_CALL( cuptiProfilerGetCounterAvailabilityPtr(&get_counter_availability_params) );
     m_counter_availability_image.resize(get_counter_availability_params.counterAvailabilityImageSize);
     /// [in]
     get_counter_availability_params.pCounterAvailabilityImage = m_counter_availability_image.data();
     /// [in/out]
     get_counter_availability_params.counterAvailabilityImageSize = m_counter_availability_image.size();
-    CHECK_CUPTI_API_CALL( cuptiProfilerGetCounterAvailabilityPtr(&get_counter_availability_params) );
+    cupti_result = cuptiProfilerGetCounterAvailabilityPtr(&get_counter_availability_params);
+    if (cupti_result != CUPTI_SUCCESS) {
+        SUBDBG("The call to cuptiProfilerGetCounterAvailability failed with error code %d\n.", cupti_result);
+        return cupti_result;
+    }
 
     return PAPI_OK;
 }
@@ -1930,57 +1940,6 @@ int native_event_code_to_native_event_name(unsigned int native_event_code, std::
     return PAPI_OK;
 }
 
-/**
-  * @brief Reserve an NVIDIA device.
-  *
-  *        The cuda_range component only allows an NVIDIA device
-  *        to be used on a single thread. Therefore, internally
-  *        the NVIDIA device will be "reserved" for use. 
-  *
-  * @param device_index
-  *   The index of the device to be reserved.
-*/
-int cuda_range_reserve_device(int device_index)
-{
-    uint64_t local_bitmask = 0; 
-    local_bitmask |= (1 << device_index);
-
-    if (local_bitmask & device_bitmask) {
-        SUBDBG("The cuda_range component only supports one thread per device and device %d is already in use.\n", device_index);
-        return PAPI_ECNFLCT;
-    }    
-
-    _papi_hwi_lock(_cuda_range_lock);
-    device_bitmask |= local_bitmask;
-    _papi_hwi_unlock(_cuda_range_lock);
-
-    return PAPI_OK;
-}
-
-/**
-  * @brief Un-reserve the NVIDIA device reserved by the call
-  *        cuda_range_reserve_device.
-  *
-  * @param device_index
-  *   The index of the device to be un-reserved.
-*/
-int cuda_range_unreserve_device(int device_index)
-{
-    uint64_t local_bitmask = 0; 
-    local_bitmask |= (1 << device_index);
-
-    if ((local_bitmask & device_bitmask) != local_bitmask) {
-        SUBDBG("Device %d is not reserved and should be.\n", device_index);
-        return PAPI_EBUG;
-    }    
-
-    _papi_hwi_lock(_cuda_range_lock);
-    device_bitmask ^= local_bitmask;
-    _papi_hwi_unlock(_cuda_range_lock);
-
-    return PAPI_OK;
-}
-
 typedef struct added_native_events_data_t
 {
     std::vector<std::string> cupti_metric_names;
@@ -2411,13 +2370,15 @@ extern "C" int cuda_range_event_code_to_info(uint32_t native_event_code, PAPI_ev
 
         CHECK_INTERNAL_FUNC_CALL( cupti_profile_metric_descriptions.at(device_id_int).create_config_image() );
 
-        size_t number_of_passes = 0;
-        CHECK_INTERNAL_FUNC_CALL( cupti_profile_metric_descriptions.at(device_id_int).number_of_passes(number_of_passes) );
-        description += " The number of passes required for collection is " + std::to_string(number_of_passes) + ".";
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_metric_descriptions.at(device_id_int).number_of_passes(cupti_metric_info.num_passes_for_collection) );
+        description += " The number of passes required for collection is " + std::to_string(cupti_metric_info.num_passes_for_collection) + ".";
+        if (cupti_metric_info.num_passes_for_collection > 1) {
+            description += " To profile, set the environment variable PAPI_CUDA_RANGE_ENABLE_MULTIPASSES equal to 1.";
+        }
         cupti_metric_info.description = description;
 
         // Avoid continously adding metrics to the current CUpti_Profiler_Host_Object by destroying it.
-        CHECK_INTERNAL_FUNC_CALL( cupti_profile_metric_descriptions.at(device_id_int).host_deinitialize() ); 
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_metric_descriptions.at(device_id_int).host_deinitialize() );
     }
 
     int string_length;
@@ -2496,6 +2457,7 @@ extern "C" int cuda_range_event_code_to_info(uint32_t native_event_code, PAPI_ev
         default:
             break;
     }
+    info->num_passes_for_collection = cupti_metric_info.num_passes_for_collection;
 
     // Push the user's context back onto the calling CPU thread.
     if (context != nullptr) {
@@ -2576,6 +2538,36 @@ extern "C" int cuda_range_store_added_native_events(uint32_t *event_codes, int n
         }
 
         cupti_profile_per_device.at(pair.first).set_cupti_metric_names(pair.second.cupti_metric_names);
+
+        int cupti_error = cupti_profile_per_device.at(pair.first).counter_availability();
+        if (cupti_error != CUPTI_SUCCESS) {
+            // Handle attempt to profile 2 threads with a single device.
+            if (cupti_error == CUPTI_ERROR_HARDWARE_BUSY) {
+                return PAPI_ECNFLCT;
+            }
+            // Handle all other cases.
+            else {
+                return PAPI_ESYS;
+            }
+        }
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(pair.first).chip_name(pair.first) );
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(pair.first).host_initialize() );
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(pair.first).create_config_image() );
+
+        size_t number_of_passes_for_collection = 0;
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(pair.first).number_of_passes(number_of_passes_for_collection) );
+        if (getenv("PAPI_CUDA_RANGE_ENABLE_MULTIPASSES") == nullptr &&
+            number_of_passes_for_collection > 1) {
+            SUBDBG("The added cuda_range native events require multiple passes for collection."
+                   " To profile, set the environment variable PAPI_CUDA_RANGE_ENABLE_MULTIPASSES equal to 1.\n");
+            return PAPI_EMULPASS;
+        }
+
+        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(pair.first).host_deinitialize() );
+
         cupti_profile_per_device.at(pair.first).set_event_insertion_order(pair.second.event_insertion_order);
     }
 
@@ -2605,15 +2597,7 @@ extern "C" int cuda_range_start_profiling(void)
         }
         SUBDBG("Entry detected for device %d. Proceeding to start profiling.\n", device_index);
 
-        CHECK_INTERNAL_FUNC_CALL( cuda_range_reserve_device(device_index) );
-
-        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).counter_availability() );
-
-        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).chip_name(device_index) );
-
         CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).host_initialize() );
-
-        CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).create_config_image() );
 
         CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).enable_range_profiler() );
 
@@ -2730,8 +2714,6 @@ extern "C" int cuda_range_stop_profiling(void)
         CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).disable_range_profiler() );
 
         CHECK_INTERNAL_FUNC_CALL( cupti_profile_per_device.at(device_index).host_deinitialize() );
-
-        CHECK_INTERNAL_FUNC_CALL( cuda_range_unreserve_device(device_index) );
     }
 
     return PAPI_OK;

--- a/src/components/cuda_range/cuda_range_profiling.h
+++ b/src/components/cuda_range/cuda_range_profiling.h
@@ -1,0 +1,46 @@
+#ifndef CUDA_RANGE_PROFILING_H
+#define CUDA_RANGE_PROFILING_H
+
+// Internal headers.
+#include <papi.h>
+
+// The lock for the cuda_range component.
+extern unsigned int _cuda_range_lock;
+
+/**
+ * \brief Params for cuda_range_ctx_t.
+ */
+typedef struct cuda_range_ctx
+{
+    /// [in] The current state assigned to the event set (i.e. CUDA_RANGE_EVENTS_STOPPED and CUDA_RANGE_EVENTS_RUNNING).
+    int state;
+    /// [in] The user added cuda_range native event codes.
+    unsigned int *event_codes;
+    /// [in] The counter values for the user added cuda_range native events.
+    long long *counters;
+    /// [in] The number of user added cuda_range native events.
+    int num_events;
+} *cuda_range_ctx_t;
+
+// The cuda_range PAPI instrumentation.
+#ifdef __cplusplus
+extern "C" {
+#endif
+int initialize_cuda_range_component(void);
+int get_the_maximum_number_of_hardware_metrics_per_device(int *maximum_number_of_counters);
+int cuda_range_event_enum(unsigned int *event_code, int modifier);
+int cuda_range_native_event_name_to_native_event_code(const char *name, uint32_t *code);
+int cuda_range_native_event_code_to_native_event_name(unsigned int code, char *name, int len);
+int cuda_range_event_code_to_info(unsigned int event_code, PAPI_event_info_t *info);
+int cuda_range_store_added_native_events(uint32_t *event_codes, int number_of_events);
+int cuda_range_start_profiling(void);
+int cuda_range_decode_and_evaluate_counter_data(cuda_range_ctx_t ctx, long long **counterValues);
+int cuda_range_stop_profiling(void);
+int cuda_range_reset_counters(cuda_range_ctx_t ctx);
+int cuda_range_unload_function_pointers_and_shutdown(void);
+const char *cuda_range_get_last_err_msg(void);
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CUDA_RANGE_PROFILING_H

--- a/src/components/cuda_range/cuda_range_profiling.hpp
+++ b/src/components/cuda_range/cuda_range_profiling.hpp
@@ -89,6 +89,8 @@ typedef struct cupti_metric_info_t
     std::vector<std::string> device_ids;
     /// [in] The description of the metric.
     std::string description;
+    /// [in] The number of passes required for collection.
+    size_t num_passes_for_collection;
 } cupti_metric_info_t;
 
 /**

--- a/src/components/cuda_range/cuda_range_profiling.hpp
+++ b/src/components/cuda_range/cuda_range_profiling.hpp
@@ -1,0 +1,111 @@
+#ifndef CUDA_RANGE_PROFILER_HPP
+#define CUDA_RANGE_PROFILER_HPP
+
+// POSIX standard headers.
+#include <dlfcn.h>
+
+// Internal headers.
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "papi_debug.h"
+#ifdef __cplusplus
+}
+#endif
+
+#define CHECK_SNPRINTF_CALL(snprintf_call, type, maxLength)                                                                  \
+do {                                                                                                                         \
+    int strLen = snprintf_call;                                                                                              \
+    if (strLen < 0 || (type) strLen >= maxLength) {                                                                          \
+        SUBDBG("The snprintf call (%s) failed to fully write additional arguments into the buffer.\n", #snprintf_call);      \
+        return PAPI_EBUF;                                                                                                    \
+    }                                                                                                                        \
+} while (0)
+
+#define CHECK_INTERNAL_FUNC_CALL(internal_call)                                                                              \
+do {                                                                                                                         \
+    int papi_errno = internal_call;                                                                                          \
+    if (papi_errno != PAPI_OK) {                                                                                             \
+        SUBDBG("The call %s failed with error code %d.\n", #internal_call, papi_errno);                                      \
+        return papi_errno;                                                                                                   \
+    }                                                                                                                        \
+} while (0)
+
+#define CHECK_DRIVER_API_CALL(driver_api_call)                                                                               \
+do                                                                                                                           \
+{                                                                                                                            \
+    CUresult status = driver_api_call;                                                                                       \
+    if (status != CUDA_SUCCESS) {                                                                                            \
+        SUBDBG("The call %s failed with error code %d.\n", #driver_api_call, status);                                        \
+        return PAPI_ESYS;                                                                                                    \
+    }                                                                                                                        \
+} while (0)
+
+#define CHECK_RUNTIME_API_CALL(runtime_api_call)                                                                             \
+do                                                                                                                           \
+{                                                                                                                            \
+    cudaError_t status = runtime_api_call;                                                                                   \
+    if (status != cudaSuccess) {                                                                                             \
+        SUBDBG("The call %s failed with error code %d.\n", #runtime_api_call, status);                                       \
+        return PAPI_ESYS;                                                                                                    \
+    }                                                                                                                        \
+} while (0)
+
+#define CHECK_CUPTI_API_CALL(cupti_api_call)                                                                                 \
+do                                                                                                                           \
+{                                                                                                                            \
+    CUptiResult status = cupti_api_call;                                                                                     \
+    if (status != CUPTI_SUCCESS) {                                                                                           \
+        SUBDBG("The call %s failed with error code %d.\n", #cupti_api_call, status);                                         \
+        return PAPI_ESYS;                                                                                                    \
+    }                                                                                                                        \
+} while (0)
+
+#define ASSIGN_AND_CHECK_DLSYM_API_CALL(function_ptr, typecast, handle, symbol)                                              \
+do {                                                                                                                         \
+    function_ptr = (typecast) dlsym(handle, symbol);                                                                         \
+    if (function_ptr == NULL) {                                                                                              \
+        SUBDBG("The call to dlsym failed due to -- %s.\n", dlerror());                                                       \
+        return PAPI_ESYS;                                                                                                    \
+    }                                                                                                                        \
+} while(0)
+
+
+/**
+ * \brief Params for cupti_metric_info_t
+ */
+typedef struct cupti_metric_info_t
+{
+    /// [in] The type of CUPTI metric (i.e. counter, ratio, throughput).
+    CUpti_MetricType cupti_metric_type;
+    /// [in] The integer position in the std::map.
+    size_t name_id;
+    /// [in] The statistics for a metric (i.e. avg, max, min, sum).
+    std::vector<std::string> stats;
+    /// [in] The submetrics for a metric (i.e. peak_sustatined, peak_sustained_active, peak_sustained_elapsed,
+    /// per_cycle_active, per_cycle_elapsed, per_second, pct_of_peak_sustained_active, pct_of_peak_sustained_elapsed).
+    std::vector<std::string> submetrics;
+    /// [in] The device indices the metric appears on. 
+    std::vector<std::string> device_ids;
+    /// [in] The description of the metric.
+    std::string description;
+} cupti_metric_info_t;
+
+/**
+ * \brief Params for native_event_info_t
+ */
+typedef struct native_event_info_t
+{
+    /// [in] Index corresponding to stat value.
+    size_t stat;
+    /// [in] Index corresponding to submetric value.
+    size_t submetric;
+    /// [in] Index corresponding to NVIDIA device.
+    size_t device;
+    /// [in] Flagged bits indicating if stat, submetric, or device qualifier exists for the event.  
+    size_t flags;
+    /// [in] Index corresponding to CUPTI metricname.
+    size_t name_id;
+} native_event_info_t;
+
+#endif // CUDA_RANGE_PROFILER_HPP

--- a/src/components/cuda_range/tests/Makefile
+++ b/src/components/cuda_range/tests/Makefile
@@ -17,12 +17,13 @@ INCLUDE += -I$(PAPI_CUDA_RANGE_ROOT)/include -I$(PAPI_CUDA_RANGE_ROOT)/extras/CU
 # Set libs for the CUDA runtime and CUPTI dynamic shared objects.
 CUDALIBS = -L$(PAPI_CUDA_RANGE_ROOT)/lib64 -lcudart -L$(PAPI_CUDA_RANGE_ROOT)/extras/CUPTI/lib64 -lcupti -lcuda
 
-list_of_cuda_range_tests = test_cuda_range_floating_point_operations \
-                           test_cuda_range_hello_world               \
-                           test_cuda_range_2thr_1gpu_not_allowed     \
-                           test_cuda_range_no_user_context           \
-                           test_cuda_range_pthreads                  \
-                           test_cuda_range_multiple_pass_events
+list_of_cuda_range_tests = test_cuda_range_floating_point_operations    \
+                           test_cuda_range_hello_world                  \
+                           test_cuda_range_2thr_1gpu_not_allowed        \
+                           test_cuda_range_no_user_context              \
+                           test_cuda_range_pthreads                     \
+                           test_cuda_range_multiple_pass_events_succeed \
+                           test_cuda_range_multiple_pass_events_fail
 cuda_range_tests: $(list_of_cuda_range_tests)
 
 cuda_range_tests_helper.o: cuda_range_tests_helper.cpp
@@ -43,8 +44,11 @@ test_cuda_range_no_user_context: test_cuda_range_no_user_context.cu cuda_range_t
 test_cuda_range_pthreads: test_cuda_range_pthreads.cu cuda_range_tests_helper.o
 	$(nvcc) $(NVCCFLAGS) -Xcompiler $(INCLUDE) cuda_range_tests_helper.o $< -o $@ $(UTILOBJS) $(PAPILIB) $(CUDALIBS)
 
-test_cuda_range_multiple_pass_events: test_cuda_range_multiple_pass_events.cu cuda_range_tests_helper.o
+test_cuda_range_multiple_pass_events_succeed: test_cuda_range_multiple_pass_events_succeed.cu cuda_range_tests_helper.o
 	$(nvcc) $(NVCCFLAGS) -Xcompiler $(INCLUDE) cuda_range_tests_helper.o $< -o $@ $(UTILOBJS) $(PAPILIB) $(CUDALIBS)
+
+test_cuda_range_multiple_pass_events_fail: test_cuda_range_multiple_pass_events_fail.cu
+	$(nvcc) $(NVCCFLAGS) -Xcompiler $(INCLUDE) $< -o $@ $(UTILOBJS) $(PAPILIB) $(CUDALIBS)
 
 clean:
 	rm -f $(list_of_cuda_range_tests) *.o

--- a/src/components/cuda_range/tests/Makefile
+++ b/src/components/cuda_range/tests/Makefile
@@ -47,4 +47,4 @@ test_cuda_range_multiple_pass_events: test_cuda_range_multiple_pass_events.cu cu
 	$(nvcc) $(NVCCFLAGS) -Xcompiler $(INCLUDE) cuda_range_tests_helper.o $< -o $@ $(UTILOBJS) $(PAPILIB) $(CUDALIBS)
 
 clean:
-	rm -f $(list_of_cuda_range_tests)
+	rm -f $(list_of_cuda_range_tests) *.o

--- a/src/components/cuda_range/tests/Makefile
+++ b/src/components/cuda_range/tests/Makefile
@@ -1,0 +1,50 @@
+NAME=cuda_range
+include ../../Makefile_comp_tests.target
+
+PAPI_CUDA_RANGE_ROOT ?= $(shell dirname $(shell dirname $(shell which nvcc)))
+nvcc = $(PAPI_CUDA_RANGE_ROOT)/bin/nvcc
+
+# Set flags for the NVCC compiler.
+NVCCFLAGS += -g -ccbin=$(CC)
+# Following logic from PAPI PR #251.
+ifeq ($(BUILD_SHARED_LIB), yes)
+    NVCCFLAGS += -Xcompiler -fpic
+endif
+
+# Set includes for the CUDA driver, CUDA runtime, and CUPTI APIs.
+INCLUDE += -I$(PAPI_CUDA_RANGE_ROOT)/include -I$(PAPI_CUDA_RANGE_ROOT)/extras/CUPTI/include
+
+# Set libs for the CUDA runtime and CUPTI dynamic shared objects.
+CUDALIBS = -L$(PAPI_CUDA_RANGE_ROOT)/lib64 -lcudart -L$(PAPI_CUDA_RANGE_ROOT)/extras/CUPTI/lib64 -lcupti -lcuda
+
+list_of_cuda_range_tests = test_cuda_range_floating_point_operations \
+                           test_cuda_range_hello_world               \
+                           test_cuda_range_2thr_1gpu_not_allowed     \
+                           test_cuda_range_no_user_context           \
+                           test_cuda_range_pthreads                  \
+                           test_cuda_range_multiple_pass_events
+cuda_range_tests: $(list_of_cuda_range_tests)
+
+cuda_range_tests_helper.o: cuda_range_tests_helper.cpp
+	$(CXX) $(CFLAGS) $(INCLUDE) -o $@ -c $^
+
+test_cuda_range_floating_point_operations: test_cuda_range_floating_point_operations.cu
+	$(nvcc) $(NVCCFLAGS) -Xcompiler $(INCLUDE) $< -o $@ $(UTILOBJS) $(PAPILIB) $(CUDALIBS)
+
+test_cuda_range_hello_world: test_cuda_range_hello_world.cu cuda_range_tests_helper.o
+	$(nvcc) $(NVCCFLAGS) -Xcompiler $(INCLUDE) cuda_range_tests_helper.o  $< -o $@ $(UTILOBJS) $(PAPILIB) $(CUDALIBS)
+
+test_cuda_range_2thr_1gpu_not_allowed: test_cuda_range_2thr_1gpu_not_allowed.cu
+	$(nvcc) $(NVCCFLAGS) -Xcompiler $(INCLUDE) $< -o $@ $(UTILOBJS) $(PAPILIB) $(CUDALIBS)
+
+test_cuda_range_no_user_context: test_cuda_range_no_user_context.cu cuda_range_tests_helper.o
+	$(nvcc) $(NVCCFLAGS) -Xcompiler $(INCLUDE) cuda_range_tests_helper.o $< -o $@ $(UTILOBJS) $(PAPILIB) $(CUDALIBS)
+
+test_cuda_range_pthreads: test_cuda_range_pthreads.cu cuda_range_tests_helper.o
+	$(nvcc) $(NVCCFLAGS) -Xcompiler $(INCLUDE) cuda_range_tests_helper.o $< -o $@ $(UTILOBJS) $(PAPILIB) $(CUDALIBS)
+
+test_cuda_range_multiple_pass_events: test_cuda_range_multiple_pass_events.cu cuda_range_tests_helper.o
+	$(nvcc) $(NVCCFLAGS) -Xcompiler $(INCLUDE) cuda_range_tests_helper.o $< -o $@ $(UTILOBJS) $(PAPILIB) $(CUDALIBS)
+
+clean:
+	rm -f $(list_of_cuda_range_tests)

--- a/src/components/cuda_range/tests/cuda_range_tests_helper.cpp
+++ b/src/components/cuda_range/tests/cuda_range_tests_helper.cpp
@@ -1,0 +1,83 @@
+// C++ STL headers.
+#include <cstring>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// Internal headers.
+#include "cuda_range_tests_helper.hpp"
+#include "papi.h"
+#include "papi_test.h"
+
+/** 
+  * @brief Get a cuda_range native event via PAPI_enum_cmp_event.
+  *
+  *        If the users did not add a cuda_range native event name on the command line then
+  *        one will be enumerated for via PAPI_enum_cmp_event. Furthermore, the device qualifier
+  *        (i.e device=#) will be used to create the CUDA context on the calling CPU thread.
+  *
+  * @param cuda_range_cmp_index
+  *   The current component index for the cuda_range component.
+  * @param &device_index
+  *   Stores the device index the cuda_range native event belongs to.
+  * @param &cuda_range_native_event_names
+  *   A vector to store the enumerated cuda_range native event name. 
+*/
+void get_cuda_range_native_event_name(int cuda_range_cmp_index, int &device_index, std::vector<std::string> &cuda_range_native_event_names)
+{
+    // Get the event code for the first cuda_range native event.
+    int modifier = PAPI_ENUM_FIRST;
+    int cuda_range_eventcode = 0 | PAPI_NATIVE_MASK;
+    CHECK_PAPI_API_CALL( PAPI_enum_cmp_event(&cuda_range_eventcode, modifier, cuda_range_cmp_index) );
+
+    // Convert the cuda_range native event code to a cuda_range native event name.
+    std::string cuda_range_native_event_name(PAPI_2MAX_STR_LEN, '\0');
+    CHECK_PAPI_API_CALL( PAPI_event_code_to_name(cuda_range_eventcode, cuda_range_native_event_name.data()) );
+    size_t c_string_length = std::strlen(cuda_range_native_event_name.c_str());
+    cuda_range_native_event_name.resize(c_string_length);
+
+    // Post process to get the device index from :device=#.
+    std::string qualifier = ":device=";
+    size_t device_qualifier_position = cuda_range_native_event_name.find(qualifier);
+    if (device_qualifier_position != std::string::npos) {
+        std::string device_index_str = cuda_range_native_event_name.substr(device_qualifier_position + qualifier.size(), 1);
+        device_index = std::stoi(device_index_str);
+    }
+    else {
+        std::cout << "The cuda_range native event name lacks a device qualifier." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    cuda_range_native_event_names.push_back(cuda_range_native_event_name);
+
+    return;
+}
+
+/** 
+  * @brief Get a cuda_range native event via PAPI_enum_cmp_event.
+  *
+  *        If the users did not add a cuda_range native event name on the command line then
+  *        one will be enumerated for via PAPI_enum_cmp_event. PAPI_get_event_info will then
+  *        be called to get a cuda_range native event name without a device qualifier. This is done
+  *        such that in a component test we can append the device qualifier based on the device count
+  *        on the system.
+  *
+  * @param cuda_range_cmp_index
+  *   The current component index for the cuda_range component.
+  * @param &cuda_range_native_event_name
+  *   Stores the enumerated cuda_range native event name.
+*/
+void get_cuda_range_native_event_name(int cuda_range_cmp_index, std::string &cuda_range_native_event_name)
+{
+    // Get the event code for the first cuda_range native event.
+    int modifier = PAPI_ENUM_FIRST;
+    int cuda_range_eventcode = 0 | PAPI_NATIVE_MASK;
+    CHECK_PAPI_API_CALL( PAPI_enum_cmp_event(&cuda_range_eventcode, modifier, cuda_range_cmp_index) );
+
+    PAPI_event_info_t native_event_info;
+    CHECK_PAPI_API_CALL( PAPI_get_event_info(cuda_range_eventcode, &native_event_info) );
+    cuda_range_native_event_name = native_event_info.symbol;
+    
+    return;
+}

--- a/src/components/cuda_range/tests/cuda_range_tests_helper.hpp
+++ b/src/components/cuda_range/tests/cuda_range_tests_helper.hpp
@@ -1,0 +1,66 @@
+#ifndef CUDA_RANGE_TESTS_HELPER_HPP
+#define CUDA_RANGE_TESTS_HELPER_HPP
+
+// C++ STL headers.
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+// Define to handle memory allocation checks.
+#define CHECK_MEMORY_ALLOCATION_CALL(var)                                             \
+do {                                                                                  \
+    if (var == NULL) {                                                                \
+        fprintf(stderr, "%s:%d: Error: Memory Allocation Failed \n",                  \
+                __FILE__, __LINE__);                                                  \
+        exit(EXIT_FAILURE);                                                           \
+    }                                                                                 \
+} while (0)
+
+// Define to handle PAPI API calls.
+#define CHECK_PAPI_API_CALL(api_function_call)                                       \
+do {                                                                                 \
+    int papi_errno = api_function_call;                                              \
+    if (papi_errno != PAPI_OK) {                                                     \
+        test_fail(__FILE__, __LINE__, #api_function_call, papi_errno);               \
+    }                                                                                \
+} while (0)
+
+// Define to handle CUDA runtime API calls.
+#define CHECK_CUDA_RUNTIME_API_CALL(api_function_call)                               \
+do {                                                                                 \
+    cudaError_t _status = api_function_call;                                         \
+    if (_status != cudaSuccess) {                                                    \
+        fprintf(stderr, "Call to %s on line %d failed with error code %d.\n",        \
+                #api_function_call, __LINE__, _status);                              \
+        exit(EXIT_FAILURE);                                                          \
+    }                                                                                \
+} while (0)
+
+
+// Define to handle CUDA driver API calls.
+#define CHECK_CUDA_DRIVER_API_CALL(api_function_call)                                \
+do {                                                                                 \
+    CUresult _status = api_function_call;                                            \
+    if (_status != CUDA_SUCCESS) {                                                   \
+        fprintf(stderr, "Call to %s on line %d failed with error code %d.\n",        \
+                #api_function_call, __LINE__, _status);                              \
+        exit(EXIT_FAILURE);                                                          \
+    }                                                                                \
+} while (0)
+
+// Define to handle CUPTI API calls.
+#define CHECK_CUPTI_API_CALL(api_function_call)                                      \
+do {                                                                                 \
+    CUptiResult _status = api_function_call;                                         \
+    if (_status != CUPTI_SUCCESS) {                                                  \
+        fprintf(stderr, "Call to %s on line %d failed with error code %d.\n",        \
+                #api_function_call, __LINE__, _status);                              \
+        exit(EXIT_FAILURE);                                                          \
+    }                                                                                \
+} while (0)
+
+void get_cuda_range_native_event_name(int cuda_range_cmp_index, int &device_index, std::vector<std::string> &cuda_range_native_event_names);
+void get_cuda_range_native_event_name(int cuda_range_cmp_index, std::string &cuda_range_native_event_name);
+
+#endif // CUDA_RANGE_TESTS_HELPER_HPP

--- a/src/components/cuda_range/tests/cuda_range_tests_helper.hpp
+++ b/src/components/cuda_range/tests/cuda_range_tests_helper.hpp
@@ -7,6 +7,9 @@
 #include <string>
 #include <vector>
 
+// CTK headers.
+#include <cuda.h>
+
 // Define to handle memory allocation checks.
 #define CHECK_MEMORY_ALLOCATION_CALL(var)                                             \
 do {                                                                                  \

--- a/src/components/cuda_range/tests/gpu_work.h
+++ b/src/components/cuda_range/tests/gpu_work.h
@@ -1,0 +1,126 @@
+#ifndef GPU_WORK_H
+#define GPU_WORK_H
+
+// C STL headers.
+#include <stdio.h>
+
+// CTK headers.
+#include <cuda.h>
+
+#define _GW_CALL(call)  \
+do {  \
+    cudaError_t _status = (call);  \
+    if (_status != cudaSuccess) {  \
+        fprintf(stderr, "%s: %d: " #call "\n", __FILE__, __LINE__);  \
+    }  \
+} while (0);
+
+// Device code
+__global__ void VecAdd(const int* A, const int* B, int* C, int N)
+{
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i < N)
+        C[i] = A[i] + B[i];
+}
+
+// Device code
+__global__ void VecSub(const int* A, const int* B, int* C, int N)
+{
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i < N)
+        C[i] = A[i] - B[i];
+}
+
+static void initVec(int *vec, int n)
+{
+    for (int i=0; i< n; i++)
+        vec[i] = i;
+}
+
+static void cleanUp(int *h_A, int *h_B, int *h_C, int *h_D, int *d_A, int *d_B, int *d_C, int *d_D)
+{
+    if (d_A)
+        _GW_CALL(cudaFree(d_A));
+    if (d_B)
+        _GW_CALL(cudaFree(d_B));
+    if (d_C)
+        _GW_CALL(cudaFree(d_C));
+    if (d_D)
+        _GW_CALL(cudaFree(d_D));
+
+    // Free host memory
+    if (h_A)
+        free(h_A);
+    if (h_B)
+        free(h_B);
+    if (h_C)
+        free(h_C);
+    if (h_D)
+        free(h_D);
+}
+
+static void VectorAddSubtract(int N, int quiet)
+{
+    if (N==0) N = 50000;
+    size_t size = N * sizeof(int);
+    int threadsPerBlock = 0;
+    int blocksPerGrid = 0;
+    int *h_A, *h_B, *h_C, *h_D;
+    int *d_A, *d_B, *d_C, *d_D;
+    int i, sum, diff;
+    int device;
+    cudaGetDevice(&device);
+    // Allocate input vectors h_A and h_B in host memory
+    h_A = (int*)malloc(size);
+    h_B = (int*)malloc(size);
+    h_C = (int*)malloc(size);
+    h_D = (int*)malloc(size);
+    if (h_A == NULL || h_B == NULL || h_C == NULL || h_D == NULL) {
+        fprintf(stderr, "Allocating input vectors failed.\n");
+    }
+
+    // Initialize input vectors
+    initVec(h_A, N);
+    initVec(h_B, N);
+    memset(h_C, 0, size);
+    memset(h_D, 0, size);
+
+    // Allocate vectors in device memory
+    _GW_CALL(cudaMalloc((void**)&d_A, size));
+    _GW_CALL(cudaMalloc((void**)&d_B, size));
+    _GW_CALL(cudaMalloc((void**)&d_C, size));
+    _GW_CALL(cudaMalloc((void**)&d_D, size));
+
+    // Copy vectors from host memory to device memory
+    _GW_CALL(cudaMemcpy(d_A, h_A, size, cudaMemcpyHostToDevice));
+    _GW_CALL(cudaMemcpy(d_B, h_B, size, cudaMemcpyHostToDevice));
+
+    // Invoke kernel
+    threadsPerBlock = 256;
+    blocksPerGrid = (N + threadsPerBlock - 1) / threadsPerBlock;
+    if (!quiet) fprintf(stderr, "Launching kernel on device %d: blocks %d, thread/block %d\n",
+    device, blocksPerGrid, threadsPerBlock);
+
+    VecAdd<<<blocksPerGrid, threadsPerBlock>>>(d_A, d_B, d_C, N);
+
+    VecSub<<<blocksPerGrid, threadsPerBlock>>>(d_A, d_B, d_D, N);
+
+    // Copy result from device memory to host memory
+    // h_C contains the result in host memory
+    _GW_CALL(cudaMemcpy(h_C, d_C, size, cudaMemcpyDeviceToHost));
+    _GW_CALL(cudaMemcpy(h_D, d_D, size, cudaMemcpyDeviceToHost));
+    if (!quiet) fprintf(stderr, "Kernel launch complete and mem copied back from device %d\n", device);
+    // Verify result
+    for (i = 0; i < N; ++i) {
+        sum = h_A[i] + h_B[i];
+        diff = h_A[i] - h_B[i];
+        if (h_C[i] != sum || h_D[i] != diff) {
+            fprintf(stderr, "error: result verification failed\n");
+            exit(-1);
+        }
+    }
+
+    cleanUp(h_A, h_B, h_C, h_D, d_A, d_B, d_C, d_D);
+}
+
+#endif // GPU_WORK_H

--- a/src/components/cuda_range/tests/run_cuda_range_tests.sh
+++ b/src/components/cuda_range/tests/run_cuda_range_tests.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+absolute_path_to_script_dir=$(cd "$(dirname "$0")" && pwd)
+cd "$absolute_path_to_script_dir"
+
+if [ -n "$PAPI_CUDA_RANGE_ROOT" ]; then
+    export LD_LIBRARY_PATH="${PAPI_CUDA_RANGE_ROOT}/extras/CUPTI/lib64:${LD_LIBRARY_PATH}"
+fi
+
+make_cuda_range_test_targets=(
+    "test_cuda_range_floating_point_operations"
+    "test_cuda_range_hello_world"
+    "test_cuda_range_2thr_1gpu_not_allowed"
+    "test_cuda_range_no_user_context"
+    "test_cuda_range_pthreads"
+    "test_cuda_range_multiple_pass_events"
+)
+
+for cuda_range_test in ${make_cuda_range_test_targets[@]}; do
+    echo "make $cuda_range_test:"
+    make $cuda_range_test
+
+    printf "\n"
+
+    echo "Running $cuda_range_test:"
+    ./$cuda_range_test
+
+    echo "-------------------------------------"
+done

--- a/src/components/cuda_range/tests/run_cuda_range_tests.sh
+++ b/src/components/cuda_range/tests/run_cuda_range_tests.sh
@@ -12,7 +12,8 @@ make_cuda_range_test_targets=(
     "test_cuda_range_2thr_1gpu_not_allowed"
     "test_cuda_range_no_user_context"
     "test_cuda_range_pthreads"
-    "test_cuda_range_multiple_pass_events"
+    "test_cuda_range_multiple_pass_events_succeed"
+    "test_cuda_range_multiple_pass_events_fail"
 )
 
 for cuda_range_test in ${make_cuda_range_test_targets[@]}; do

--- a/src/components/cuda_range/tests/test_cuda_range_2thr_1gpu_not_allowed.cu
+++ b/src/components/cuda_range/tests/test_cuda_range_2thr_1gpu_not_allowed.cu
@@ -1,0 +1,238 @@
+/**
+* @file  test_cuda_range_2thr_1gpu_not_allowed.cu
+* @brief Verify that we do not allow multiple threads on a single device. PAPI_ECNFLCT
+*        should be returned if this occurs.
+*/
+
+// C++ STL headers.
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+// POSIX standard headers.
+#include <pthread.h>
+
+// CTK headers.
+#include <cuda.h>
+
+// Internal headers.
+#include "cuda_range_tests_helper.hpp"
+#include "gpu_work.h"
+#include "papi.h"
+#include "papi_test.h"
+
+#define KERNEL_QUIET 1
+#define MAXIMUM_NUMBER_OF_THREADS 2
+
+/** 
+  * @brief An enum containing the available precisions.
+*/
+typedef struct pthread_params_t
+{
+    CUcontext context;
+    int thread_num;
+    char *cuda_range_native_event_name;
+    pthread_t thread_id;
+    int papi_errno;
+} pthread_params_t;
+
+/** 
+  * @brief The pthread_create start routine.
+  *   
+  * @param *arg
+  *   An instance of the structure pthread_params_t.
+*/
+void *thread_start(void *arg)
+{
+    pthread_params_t *tinfo = (pthread_params_t *) arg;
+
+    CHECK_CUDA_DRIVER_API_CALL( cuCtxSetCurrent(tinfo->context) );
+
+    // Create a PAPI event set.
+    int event_set = PAPI_NULL;
+    CHECK_PAPI_API_CALL( PAPI_create_eventset(&event_set) );
+
+    // Add cuda_range native event names to the event set.
+    CHECK_PAPI_API_CALL( PAPI_add_named_event(event_set, tinfo->cuda_range_native_event_name) );
+
+    // Start profiling.
+    tinfo->papi_errno = PAPI_start(event_set);
+    if (tinfo->papi_errno == PAPI_ECNFLCT) {
+        std::cout << "Thread " << tinfo->thread_num << ": Not allowed to profile." << std::endl;
+        return NULL;
+    }
+
+    // Launch kernel.
+    int number_of_iterations = 50000;
+    VectorAddSubtract(number_of_iterations * (tinfo->thread_num + 1), KERNEL_QUIET);
+    CHECK_CUDA_RUNTIME_API_CALL( cudaGetLastError() ); 
+
+    // Stop profiling.
+    long long cuda_range_counter_value = 0;
+    CHECK_PAPI_API_CALL( PAPI_stop(event_set, &cuda_range_counter_value) );
+
+    // Print profiling data.
+    std::cout << "Thread " << tinfo->thread_num << ": " << tinfo->cuda_range_native_event_name
+              << " produced the counter value -- " << cuda_range_counter_value << "." << std::endl;
+
+    // Cleanup the PAPI event set.
+    CHECK_PAPI_API_CALL( PAPI_cleanup_eventset(event_set) );
+
+    // Destroy the PAPI event set.
+    CHECK_PAPI_API_CALL( PAPI_destroy_eventset(&event_set) );
+
+    return NULL;
+}
+
+/** 
+  * @brief A function wrapper to print out the help message for test_cuda_range_2thr_1gpu_not_allowed.cu.
+*/
+static void print_help_message(void)
+{
+    std::cout << "./test_cuda_range_2thr_1gpu_not_allowed" << std::endl
+              << "Notes:" << std::endl
+              << "1. No command line arguments are available for this test as stands." << std::endl;
+
+    return;
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << "Running the cuda_range component test -- test_cuda_range_2thr_1gpu_not_allowed.cu." << std::endl;
+    CHECK_CUDA_DRIVER_API_CALL( cuInit(0) );
+
+    // If a user provided command line arguments then print the help message.
+    if (argc > 1) {
+        print_help_message();
+        exit(EXIT_FAILURE);
+    }
+
+    // Determine the number of compute-capable devices.
+    int number_of_devices_on_system = 0;
+    CHECK_CUDA_RUNTIME_API_CALL( cudaGetDeviceCount(&number_of_devices_on_system) );
+    // No compute-capable devices on the machine. Exiting.
+    if (number_of_devices_on_system < 1) {
+        std::cout << "No compute-capable devices found on the machine. This is required for the test to run." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // Initialize the PAPI library.
+    int papi_errno = PAPI_library_init( PAPI_VER_CURRENT );
+    if( papi_errno != PAPI_VER_CURRENT ) {
+        test_fail(__FILE__,__LINE__, "PAPI_library_init", papi_errno);
+    }
+    std::cout << "The PAPI version being used for this test is: "
+              << PAPI_VERSION_MAJOR(PAPI_VERSION) << "."
+              << PAPI_VERSION_MINOR(PAPI_VERSION) << "."
+              << PAPI_VERSION_REVISION(PAPI_VERSION) << "."
+              << std::endl;
+
+    // Initialize thread support in the PAPI library.
+    CHECK_PAPI_API_CALL( PAPI_thread_init((unsigned long (*)(void)) pthread_self) );
+
+    // Confirm the cuda_range component exists e.g. compiled in.
+    int cuda_range_cmp_index = PAPI_get_component_index("cuda_range");
+    if (cuda_range_cmp_index < 0) {
+        std::cout << "The cuda_range component does not exist. This is often due to cuda_range not being passed to --with-components at configure." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    std::vector<char *> cuda_range_native_event_names {};
+    cuda_range_native_event_names.reserve(MAXIMUM_NUMBER_OF_THREADS);
+    // Get the event code for the first cuda_range native event.
+    int modifier = PAPI_ENUM_FIRST;
+    int cuda_range_eventcode = 0 | PAPI_NATIVE_MASK;
+    CHECK_PAPI_API_CALL( PAPI_enum_cmp_event(&cuda_range_eventcode, modifier, cuda_range_cmp_index) );
+
+    // Convert the event code to a cuda_range native event name.
+    char first_cuda_range_native_event_name[PAPI_2MAX_STR_LEN] = "";
+    CHECK_PAPI_API_CALL( PAPI_event_code_to_name(cuda_range_eventcode, first_cuda_range_native_event_name) );
+    cuda_range_native_event_names.push_back(first_cuda_range_native_event_name);
+    
+    // Get the position of the device qualifier in the first enumerated cuda_range native event name and
+    // subsequently get the device id.
+    const char *qualifier = ":device=";
+    const char *first_position = std::strstr(first_cuda_range_native_event_name, qualifier);
+    if (first_position == nullptr) {
+        std::cout << "The first enumerated cuda_range native event name lacks a device qualifier. Exiting" << std::endl;
+        exit(EXIT_FAILURE); 
+    }
+    int device_index = std::stoi( first_position + std::strlen(qualifier) );  
+    
+    // Get the next cuda_range native event codes.
+    char second_cuda_range_native_event_name[PAPI_2MAX_STR_LEN] = ""; 
+    modifier = PAPI_ENUM_EVENTS;
+    while (PAPI_enum_cmp_event(&cuda_range_eventcode, modifier, cuda_range_cmp_index) == PAPI_OK) {
+        CHECK_PAPI_API_CALL( PAPI_event_code_to_name(cuda_range_eventcode, second_cuda_range_native_event_name) );
+        const char *second_position = std::strstr(second_cuda_range_native_event_name, qualifier);
+        if (second_position == nullptr) {
+            std::cout << "The second enumerated cuda_range native event name lacks a device qualifier. Exiting" << std::endl;
+            exit(EXIT_FAILURE);
+        }
+
+        if (std::stoi( second_position + std::strlen(qualifier) ) == device_index) {
+            cuda_range_native_event_names.push_back(second_cuda_range_native_event_name);
+            break;
+        }
+    }
+
+    // Verify we indeed have only 2 cuda_range native event names.
+    if (cuda_range_native_event_names.size() != 2) {
+        std::cout << "Two native event names are needed and we have " << cuda_range_native_event_names.size() << ". Exiting." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    std::cout << "Total number of threads to be launched: " << MAXIMUM_NUMBER_OF_THREADS << "." << std::endl;
+    pthread_params_t tinfo[MAXIMUM_NUMBER_OF_THREADS];
+    // Create threads.
+    for(size_t tnum = 0; tnum < MAXIMUM_NUMBER_OF_THREADS; tnum++) {
+        CUcontext context;
+        unsigned int flags = 0;
+        CUdevice device = device_index;
+        CHECK_CUDA_DRIVER_API_CALL( cuCtxCreate(&context, (CUctxCreateParams*)0, flags, device) );
+        CHECK_CUDA_DRIVER_API_CALL( cuCtxPopCurrent(&context) );
+
+        tinfo[tnum].context = context;
+        tinfo[tnum].thread_num = tnum;
+        tinfo[tnum].cuda_range_native_event_name = cuda_range_native_event_names[tnum];
+
+        int status = pthread_create(&tinfo[tnum].thread_id, NULL, thread_start, &tinfo[tnum]);
+        if(status != 0) {
+            std::cout << "Call to pthread_create failed for thread " << tnum << " with error code " << status << "." << std::endl;
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    int papi_ecnflct_returned = 0;
+    // Join with each thread.
+    for (size_t tnum = 0; tnum < MAXIMUM_NUMBER_OF_THREADS; tnum++) {
+        int status = pthread_join(tinfo[tnum].thread_id, NULL);
+        if (status != 0) {
+            std::cout << "Call to pthread_join failed for thread " << tnum << " with error code " << status << "." << std::endl;
+            exit(EXIT_FAILURE);
+        }
+
+        // Destroy the CUDA context.
+        CHECK_CUDA_DRIVER_API_CALL( cuCtxDestroy(tinfo[tnum].context) );
+
+        // See if thread returned PAPI_ECNFLCT.
+        if (tinfo[tnum].papi_errno == PAPI_ECNFLCT) {
+            papi_ecnflct_returned = 1; 
+        }
+    }
+
+    // Shutdown the PAPI library.
+    PAPI_shutdown();
+
+    // Test succeeded -- PAPI_ECNFLCT was correctly returned.
+    if (papi_ecnflct_returned) {
+        test_pass(__FILE__);
+    }
+    // Test failed -- PAPI_ECNFLCT was not returned.
+    else {
+        test_fail(__FILE__, __LINE__, "PAPI_ECNFLCT was not returned and should have been.", 0);
+    }
+
+    return 0;
+}

--- a/src/components/cuda_range/tests/test_cuda_range_2thr_1gpu_not_allowed.cu
+++ b/src/components/cuda_range/tests/test_cuda_range_2thr_1gpu_not_allowed.cu
@@ -54,14 +54,22 @@ void *thread_start(void *arg)
     CHECK_PAPI_API_CALL( PAPI_create_eventset(&event_set) );
 
     // Add cuda_range native event names to the event set.
-    CHECK_PAPI_API_CALL( PAPI_add_named_event(event_set, tinfo->cuda_range_native_event_name) );
+    tinfo->papi_errno = PAPI_add_named_event(event_set, tinfo->cuda_range_native_event_name);
+    if (tinfo->papi_errno != PAPI_OK) {
+        // PAPI_ECNFLCT correctly returned.
+        if (tinfo->papi_errno == PAPI_ECNFLCT) {
+            std::cout << "Thread " << tinfo->thread_num << ": Not allowed to profile." << std::endl;
+            return NULL;
+        }
+        // PAPI_ENCFLCT not correctly returned.
+        else {
+            std::cout << "Thread " << tinfo->thread_num << ": Not allowed to profile. However, PAPI_ECNFLCT not returned." << std::endl;
+            return NULL;
+        }
+    }
 
     // Start profiling.
-    tinfo->papi_errno = PAPI_start(event_set);
-    if (tinfo->papi_errno == PAPI_ECNFLCT) {
-        std::cout << "Thread " << tinfo->thread_num << ": Not allowed to profile." << std::endl;
-        return NULL;
-    }
+    CHECK_PAPI_API_CALL( PAPI_start(event_set) );
 
     // Launch kernel.
     int number_of_iterations = 50000;

--- a/src/components/cuda_range/tests/test_cuda_range_floating_point_operations.cu
+++ b/src/components/cuda_range/tests/test_cuda_range_floating_point_operations.cu
@@ -161,7 +161,7 @@ static void print_help_message(void)
 {
     std::cout << "./cuda_floating_point_operations --device [NVIDIA device index] --number-of-iterations [list of iterations to perform (must be exactly 3) separated by a comma]"
               << " --precision [options include single (default) or double]"
-              << " --operation [options include add (default), multiply, fused_add_multiply]." << std::endl
+              << " --operation [options include add (default), multiply, fused_multiply_add]." << std::endl
               << "Notes:" << std::endl
               << "1. The default precision is single and the default operation is add." << std::endl
               << "2. If the number of iterations listed is greater than 3 then the iteration value will not be stored, BUT the test will proceed." << std::endl;
@@ -280,6 +280,15 @@ int main(int argc, char **argv)
 {
     std::cout << "Running the cuda_range component test -- test_cuda_range_floating_point_operations.cu." << std::endl;
     CHECK_CUDA_DRIVER_API_CALL( cuInit(0) );
+
+    // Cuda Toolkits 13.2.0 - 13.4.0 cannot be used with this test.
+    int cuda_runtime_version = 0;
+    CHECK_CUDA_RUNTIME_API_CALL( cudaRuntimeGetVersion(&cuda_runtime_version) );
+    if (cuda_runtime_version >= 13020 && cuda_runtime_version <= 13040) {
+        std::cout << "Cuda Toolkits 13.2.0 - 13.4.0 produce zero values for cuda_range:::smsp__sass_thread_inst_executed_op_*_pred_on native events."
+                  << " NVIDIA is aware of this issue and Cuda Toolkit 13.4 update 1 will contain the fix." << std::endl;
+        test_skip(__FILE__, __LINE__, "", 0);
+    }
 
     int device_index = 0;
     precision_e precision = SINGLE;

--- a/src/components/cuda_range/tests/test_cuda_range_floating_point_operations.cu
+++ b/src/components/cuda_range/tests/test_cuda_range_floating_point_operations.cu
@@ -1,0 +1,461 @@
+/**
+* @file  cuda_range_floating_point_operations.
+* @brief This test verifies the counters collected for cuda_range native events that deal with
+*        floating point operations.
+*/
+
+// C++ STL headers.
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// CTK headers.
+#include <cuda.h>
+
+// Internal headers.
+#include "cuda_range_tests_helper.hpp"
+#include "papi.h"
+#include "papi_test.h"
+
+#define MAX_ITERATION_ENTRIES 3
+
+/** 
+  * @brief An enum containing the available operations.
+*/
+typedef enum {
+    ADD = 0,
+    MULTIPLY,
+    FUSED_MULTIPLY_ADD,
+} operation_e;
+
+/** 
+  * @brief An enum containing the available precisions.
+*/
+typedef enum {
+    SINGLE = 0,
+    DOUBLE,
+} precision_e;
+
+/** 
+  * @brief An addition kernel.
+  *
+  * @param number_of_iterations
+  *   The number of iterations to perform.
+  * @param *x
+  *   An array for floating point operations.
+  * @param *y
+  *   An array for floating point operations.
+  * @param precision
+  *   The precision to be performed.
+*/
+__global__ void add(int number_of_iterations, void *x, void *y, precision_e precision) {
+    int i;
+    for (i = 0; i < number_of_iterations; i++) {
+        if (precision == SINGLE) {
+            ((float *) y)[i] = ((float *) x)[i] + ((float *) y)[i];
+        }
+        else {
+            ((double *) y)[i] = ((double *) x)[i] + ((double *) y)[i];
+        }
+    }
+
+    return;
+}
+
+/** 
+  * @brief A multiply kernel.
+  *
+  * @param number_of_iterations
+  *   The number of iterations to perform.
+  * @param *x
+  *   An array for floating point operations.
+  * @param *y
+  *   An array for floating point operations.
+  * @param precision
+  *   The precision to be performed.
+*/
+__global__ void multiply(int number_of_iterations, void *x, void *y, precision_e precision)
+{
+    int i;
+    for (i = 0; i < number_of_iterations; i++) {
+        if (precision == SINGLE) {
+            ((float *) y)[i] = ((float *) x)[i] * ((float *) y)[i];
+        }
+        else {
+            ((double *) y)[i] = ((double *) x)[i] * ((double *) y)[i];
+        }
+    }
+
+    return;
+}
+
+/** 
+  * @brief A fused multiply add kernel.
+  *
+  * @param number_of_iterations
+  *   The number of iterations to perform.
+  * @param *x
+  *   An array for floating point operations.
+  * @param *y
+  *   An array for floating point operations.
+  * @param precision
+  *   The precision to be performed.
+*/
+__global__ void fused_multiply_add(int number_of_iterations, void *x, void *y, precision_e precision)
+{
+    int i;
+    for (i = 0; i < number_of_iterations; i++) {
+        if (precision == SINGLE) {
+            ((float *) y)[i] = ((float *) x)[i] * ((float *) y)[i] + 1.0f;
+        }
+        else {
+            ((double *) y)[i] = ((double *) x)[i] * ((double *) y)[i] + 1.0;
+        }
+    }
+
+    return;
+}
+
+/** 
+  * @brief A wrapper function to aid in launching the correct operation.
+  *
+  * @param number_of_iterations
+  *   The number of iterations to perform.
+  * @param *x
+  *   An array for floating point operations.
+  * @param *y
+  *   An array for floating point operations.
+  * @param precision
+  *   The precision to be performed.
+  * @param operation
+  *   The operation to be performed.
+*/
+void launch_kernel(int number_of_iterations, void *x, void *y, precision_e precision, operation_e operation)
+{
+    switch(operation) {
+        case ADD:
+            add<<<1, 1>>>(number_of_iterations, x, y, precision);
+            break;
+        case MULTIPLY:
+            multiply<<<1,1>>>(number_of_iterations, x, y, precision);
+            break;
+        case FUSED_MULTIPLY_ADD:
+            fused_multiply_add<<<1, 1>>>(number_of_iterations, x, y, precision);
+            break;
+        default:
+            break;
+    }
+    CHECK_CUDA_RUNTIME_API_CALL( cudaGetLastError() );
+    CHECK_CUDA_RUNTIME_API_CALL( cudaDeviceSynchronize() );
+
+    return;
+}
+
+/** 
+  * @brief A function wrapper to print out the help message for test_cuda_range_floating_point_operations.cu.
+*/
+static void print_help_message(void)
+{
+    std::cout << "./cuda_floating_point_operations --device [NVIDIA device index] --number-of-iterations [list of iterations to perform (must be exactly 3) separated by a comma]"
+              << " --precision [options include single (default) or double]"
+              << " --operation [options include add (default), multiply, fused_add_multiply]." << std::endl
+              << "Notes:" << std::endl
+              << "1. The default precision is single and the default operation is add." << std::endl
+              << "2. If the number of iterations listed is greater than 3 then the iteration value will not be stored, BUT the test will proceed." << std::endl;
+
+    return;
+}
+
+/** 
+  * @brief Parse the command line arguments provided by the user.
+  *
+  * @param argc
+  *   Number of user passed arguments on the command line.
+  * @param *argv
+  *   Argument vector.
+  * @param &device_index
+  *   Stores the device index passed by the user to --device.
+  * @param &precision
+  *   Stores the precision passed by the user to --precision.
+  * @param &operation
+  *   Stores the operation passed by the user to --operation.
+  * @param &number_of_iterations
+  *   Stores the number of iterations passed by the user to --number-of-iterations.
+*/
+static void parse_and_assign_args(int argc, char *argv[], int &device_index, precision_e &precision,
+                                  operation_e &operation, std::vector<int> &number_of_iterations)
+{
+    for (int i = 1; i < argc; i++) {
+        char *arg = argv[i];
+        if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {
+            print_help_message();
+            exit(EXIT_SUCCESS);
+        }
+        else if (strcmp(arg, "--device") == 0) {
+            if (!argv[i + 1]) {
+                std::cout << "ERROR!! Add a NVIDIA device index." << std::endl;
+                exit(EXIT_FAILURE);
+            }
+            device_index = atoi(argv[i + 1]);
+            i++;
+        }
+        else if (strcmp(arg, "--number-of-iterations") == 0) {
+            if (!argv[i + 1]) {
+                std::cout << "ERROR!! --number-of-iterations given, but no numbers listed. Exiting." << std::endl;
+                exit(EXIT_FAILURE);
+            }
+
+            // Clear the current default iteration values.
+            number_of_iterations.clear();
+
+            std::stringstream ss(argv[i + 1]);
+            std::string iteration_number;
+            while (std::getline(ss, iteration_number, ',')) {
+                // Under the allowed number of iterations.
+                if (number_of_iterations.size() + 1 <= MAX_ITERATION_ENTRIES) {
+                    number_of_iterations.push_back(std::stoi(iteration_number));
+                }
+                // Exceeded the allowed number of iterations.
+                else {
+                    print_help_message();
+                    exit(EXIT_FAILURE);
+                }
+            }   
+            i++;
+        }
+        else if (strcmp(arg, "--precision") == 0) {
+            if (!argv[i + 1]) {
+                std::cout << "ERROR!! --precision given, but no precision listed. Exiting." << std::endl;
+                exit(EXIT_FAILURE);
+            }
+
+            if (strcmp(argv[i + 1], "single") == 0) {
+                precision = SINGLE;
+            }
+            else if (strcmp(argv[i + 1], "double") == 0) {
+                precision = DOUBLE;
+            }
+            else {
+                std::cout << "ERROR!! Provided precision is not valid. Exiting." << std::endl;
+                print_help_message();
+                exit(EXIT_FAILURE);
+            }
+            i++;
+        }
+        else if (strcmp(arg, "--operation") == 0) {
+            if (!argv[i + 1]) {
+                std::cout << "ERROR!! --operation given, but no operation listed. Exiting." << std::endl;
+                exit(EXIT_FAILURE);
+            }
+
+            if (strcmp(argv[i + 1], "add") == 0) {
+                operation = ADD;
+            }
+            else if (strcmp(argv[i + 1], "multiply") == 0) {
+                operation = MULTIPLY;
+            }
+            else if (strcmp(argv[i + 1], "fused_multiply_add") == 0) {
+                operation = FUSED_MULTIPLY_ADD;
+            }
+            else {
+                std::cout << "ERROR!! Provided operation is not valid. Exiting." << std::endl;
+                print_help_message();
+                exit(EXIT_FAILURE);
+            }
+            i++;
+        }
+        else {
+            print_help_message();
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    return;
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << "Running the cuda_range component test -- test_cuda_range_floating_point_operations.cu." << std::endl;
+    CHECK_CUDA_DRIVER_API_CALL( cuInit(0) );
+
+    int device_index = 0;
+    precision_e precision = SINGLE;
+    operation_e operation = ADD;
+    std::vector<int> number_of_iterations {2, 4, 16};
+    // If a user provided command line arguments then parse them.
+    if (argc > 1) {
+        parse_and_assign_args(argc, argv, device_index, precision, operation, number_of_iterations);
+    }
+
+    // Determine the number of compute-capable devices.
+    int number_of_devices_on_system = 0;
+    CHECK_CUDA_RUNTIME_API_CALL( cudaGetDeviceCount(&number_of_devices_on_system) );
+    // No compute-capable devices on the machine. Exiting.
+    if (number_of_devices_on_system < 1) {
+        std::cout << "No compute-capable devices found on the machine. This is required for the test to run." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    int papi_errno = PAPI_library_init(PAPI_VER_CURRENT);
+    if (papi_errno != PAPI_VER_CURRENT) {
+        test_fail(__FILE__, __LINE__, "PAPI_library_init", papi_errno);
+    }   
+    std::cout << "The PAPI version being used for this test is: "
+              << PAPI_VERSION_MAJOR(PAPI_VERSION) << "." 
+              << PAPI_VERSION_MINOR(PAPI_VERSION) << "." 
+              << PAPI_VERSION_REVISION(PAPI_VERSION) << "." 
+              << std::endl;
+
+    // Confirm the cuda_range component exists e.g. compiled in.
+    int cuda_range_cmp_index = PAPI_get_component_index("cuda_range");
+    if (cuda_range_cmp_index < 0) {
+        std::cout << "The cuda_range component does not exist. This is often due to cuda_range not being passed to --with-components at configure." << std::endl;
+        exit(EXIT_FAILURE);
+    } 
+
+    std::string cuda_range_native_event_name {};
+    cuda_range_native_event_name.reserve(PAPI_2MAX_STR_LEN);
+    // Native event name which corresponds to single precision and an operation of addition.
+    if (precision == SINGLE && operation == ADD) {
+        cuda_range_native_event_name = "cuda_range:::smsp__sass_thread_inst_executed_op_fadd_pred_on:stat=sum";
+    }
+    // Native event name which corresponds to single precision and an operation of multiply.
+    else if (precision == SINGLE && operation == MULTIPLY) {
+        cuda_range_native_event_name = "cuda_range:::smsp__sass_thread_inst_executed_op_fmul_pred_on:stat=sum";
+    }
+    // Native event name which corresponds to single precision and an operation of multiply + add.
+    else if (precision == SINGLE && operation == FUSED_MULTIPLY_ADD) {
+        cuda_range_native_event_name = "cuda_range:::smsp__sass_thread_inst_executed_op_ffma_pred_on:stat=sum";
+    }
+    // Native event name which corresponds to double precision and an operation of add.
+    else if (precision == DOUBLE && operation == ADD) {
+        cuda_range_native_event_name = "cuda_range:::smsp__sass_thread_inst_executed_op_dadd_pred_on:stat=sum";
+    }
+    // Native event name which corresponds to double precision and an operation of multiply.
+    else if (precision == DOUBLE && operation == MULTIPLY) {
+        cuda_range_native_event_name = "cuda_range:::smsp__sass_thread_inst_executed_op_dmul_pred_on:stat=sum";
+    }
+    // Native event name which corresponds to double precision and an operation of multiply + add.
+    else if (precision == DOUBLE && operation == FUSED_MULTIPLY_ADD) {
+        cuda_range_native_event_name = "cuda_range:::smsp__sass_thread_inst_executed_op_dfma_pred_on:stat=sum";
+    }
+    // Combination of precision and operation does not exist.
+    else {
+        std::cout << "The combination of precision and operation does not correspond to a cuda_range native event. Exiting." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // Confirm the cuda_range native event corresponding to a precision and operation exists on the system.
+    papi_errno = PAPI_query_named_event(cuda_range_native_event_name.c_str());
+    if (papi_errno != PAPI_OK) {
+        std::cout << "The cuda_range native event (" << cuda_range_native_event_name << ") does not exist on the machine. Skipping." << std::endl;
+        test_skip(__FILE__, __LINE__, "", 0); 
+    } 
+
+    // Set the device to be used for GPU execution.
+    CHECK_CUDA_RUNTIME_API_CALL( cudaSetDevice(device_index) );
+
+    // To properly allocate the below arrays with enough space determine the max iteration number.
+    long long maximum_iteration = 0;
+    for (size_t i = 0; i < number_of_iterations.size(); i++) {
+        if (maximum_iteration < number_of_iterations[i]) {
+            maximum_iteration = number_of_iterations[i];
+        }
+    }
+
+    // Allocate memory for arrays.
+    float *x, *y;
+    unsigned int flags = cudaMemAttachGlobal; // Allows memory to be accessible from any stream on any device
+    CHECK_CUDA_RUNTIME_API_CALL( cudaMallocManaged(&x, maximum_iteration * sizeof(float), flags ) );
+    CHECK_CUDA_RUNTIME_API_CALL( cudaMallocManaged(&y, maximum_iteration * sizeof(float), flags ) );
+
+    // Initialize values for arrays on the host.
+    for (size_t i = 0; i < maximum_iteration; i++) {
+        x[i] = 1.0f;
+        y[i] = 2.0f;
+    }
+
+    // Create a PAPI event set.
+    int event_set = PAPI_NULL;
+    CHECK_PAPI_API_CALL( PAPI_create_eventset(&event_set) );
+
+    // Add the cuda_range native event to the event set.
+    CHECK_PAPI_API_CALL( PAPI_add_named_event(event_set, cuda_range_native_event_name.c_str()) );
+
+    // Start profiling.
+    CHECK_PAPI_API_CALL( PAPI_start(event_set) );
+
+    // 1st PAPI_read.
+    long long expected_cuda_range_cuda_range_counter_value = number_of_iterations[0];
+    launch_kernel(number_of_iterations[0], x, y, precision, operation);
+    long long cuda_range_counter_value = 0;
+    CHECK_PAPI_API_CALL( PAPI_read(event_set, &cuda_range_counter_value) );
+    if (cuda_range_counter_value == expected_cuda_range_cuda_range_counter_value) {
+        std::cout << "1st PAPI_read: Correct count -- expected was " << expected_cuda_range_cuda_range_counter_value << " and actual is " << cuda_range_counter_value << std::endl;
+    }
+    else {
+        std::cout << "1st PAPI_read: Incorrect count -- expected was " << expected_cuda_range_cuda_range_counter_value << " and actual is " << cuda_range_counter_value << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2nd PAPI_read.
+    expected_cuda_range_cuda_range_counter_value += number_of_iterations[1];
+    launch_kernel(number_of_iterations[1], x, y, precision, operation);
+    CHECK_PAPI_API_CALL( PAPI_read(event_set, &cuda_range_counter_value) );
+    if (cuda_range_counter_value == static_cast<long long>(expected_cuda_range_cuda_range_counter_value)) {
+        std::cout << "2nd PAPI_read: Correct count -- expected was " << expected_cuda_range_cuda_range_counter_value << " and actual is " << cuda_range_counter_value << std::endl;
+    }
+    else {
+        std::cout << "2nd PAPI_read: Incorrect count -- expected was " << expected_cuda_range_cuda_range_counter_value << " and actual is " << cuda_range_counter_value << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 3rd PAPI_read.
+    expected_cuda_range_cuda_range_counter_value += number_of_iterations[2];
+    launch_kernel(number_of_iterations[2], x, y, precision, operation);
+    CHECK_PAPI_API_CALL( PAPI_read(event_set, &cuda_range_counter_value) );
+    if (cuda_range_counter_value == static_cast<long long>(expected_cuda_range_cuda_range_counter_value)) {
+        std::cout << "3rd PAPI_read: Correct count -- expected was " << expected_cuda_range_cuda_range_counter_value << " and actual is " << cuda_range_counter_value << std::endl;
+    }
+    else {
+        std::cout << "3rd PAPI_read: Incorrect count -- expected was " << expected_cuda_range_cuda_range_counter_value << " and actual is " << cuda_range_counter_value << std::endl;
+        fprintf(stderr, "\033[0;31m3rd PAPI_read: Correct count -- expected was  %lld and actual is %lld.\n\033[0m", expected_cuda_range_cuda_range_counter_value, cuda_range_counter_value);
+        exit(EXIT_FAILURE);
+    }
+
+    // Final PAPI_read.
+    // No work is occurring; therefore, PAPI_read here SHOULD give back the counter value obtained in the 3rd PAPI_read
+    CHECK_PAPI_API_CALL( PAPI_read(event_set, &cuda_range_counter_value) );
+    if (cuda_range_counter_value == static_cast<long long>(expected_cuda_range_cuda_range_counter_value)) {
+        std::cout << "Final PAPI_read: Correct count -- expected was " << expected_cuda_range_cuda_range_counter_value << " and actual is " << cuda_range_counter_value << std::endl;
+    }   
+    else {
+        std::cout << "Final PAPI_read: Incorrect count -- expected was " << expected_cuda_range_cuda_range_counter_value << " and actual is " << cuda_range_counter_value << std::endl;
+        exit(EXIT_FAILURE);
+    }  
+
+    // 1st PAPI_stop.
+    // No work is occurring; therefore, PAPI_stop here SHOULD give back the counter value obtained in the 3rd PAPI_read
+    CHECK_PAPI_API_CALL( PAPI_stop(event_set, &cuda_range_counter_value) );
+    if (cuda_range_counter_value == static_cast<long long>(expected_cuda_range_cuda_range_counter_value)) {
+        std::cout << "PAPI_stop: Correct count -- expected was " << expected_cuda_range_cuda_range_counter_value << " and actual is " << cuda_range_counter_value << std::endl;
+    }
+    else {
+        std::cout << "PAPI_stop: Incorrect count -- expected was " << expected_cuda_range_cuda_range_counter_value << " and actual is " << cuda_range_counter_value << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // Free the allocated memory on the device. 
+    CHECK_CUDA_RUNTIME_API_CALL( cudaFree(x) );
+    CHECK_CUDA_RUNTIME_API_CALL( cudaFree(y) );
+
+    // Shutdown the PAPI library.
+    PAPI_shutdown();
+
+    test_pass(__FILE__);
+
+    return 0;
+}

--- a/src/components/cuda_range/tests/test_cuda_range_hello_world.cu
+++ b/src/components/cuda_range/tests/test_cuda_range_hello_world.cu
@@ -1,0 +1,253 @@
+/**
+* @file  test_cuda_range_hello_world.cu
+* @brief This test serves as a very simple hello world example where the string
+*        "Hello World!" is mangled and then restored. cuCtxCreate is used for context
+*        creation.
+*/
+
+// C++ STL headers.
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// CTK headers.
+#include <cuda.h>
+
+// Internal headers.
+#include "cuda_range_tests_helper.hpp"
+#include "papi.h"
+#include "papi_test.h"
+
+/** 
+  * @brief Kernel to manipulate the passed in char *.
+  *
+  * @param str
+  *   String to manipulate.
+*/
+__global__ void hello_world(char *str)
+{
+        int idx = blockIdx.x * blockDim.x + threadIdx.x;
+        str[idx] += idx;
+}
+
+/** 
+  * @brief A function wrapper to print out the help message for test_cuda_range_hello_world.cu.
+*/
+static void print_help_message(void)
+{
+    std::cout << "./test_cuda_range_hello_world --device [NVIDIA device index] --cuda-range-native-event-names [list of cuda_range native event names separated by a comma]" << std::endl
+              << "Notes:" << std::endl
+              << "1. Both args (--device and --cuda-range-native-event-names) must be provided." << std::endl
+              << "2. If the device qualifier is provided then it must match the device index provided to --device." << std::endl;
+
+    return;
+}
+
+/** 
+  * @brief Parse the command line arguments provided by the user.
+  *
+  * @param argc
+  *   Number of user passed arguments on the command line.
+  * @param *argv
+  *   Argument vector.
+  * @param &device_index
+  *   Stores the device index passed by the user to --device.
+  * @param &cuda_range_native_event_names
+  *   Stores the cuda_range native event names passed by the user to --cuda-range-native-event-names.
+*/
+static void parse_and_assign_args(int argc, char *argv[], int &device_index, std::vector<std::string> &cuda_range_native_event_names)
+{
+    std::vector<int> device_qualifier_indices {};
+    int device_arg_found = 0, cuda_range_native_event_name_arg_found = 0;
+    for (int i = 1; i < argc; i++) {
+        char *arg = argv[i];
+        if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {
+            print_help_message();
+            exit(EXIT_SUCCESS);
+        }
+        else if(strcmp(arg, "--device") == 0) {
+            if (!argv[i + 1]) {
+                std::cout << "ERROR!! Add a NVIDIA device index." << std::endl;
+                exit(EXIT_FAILURE);
+            }
+            device_index = std::stoi(argv[i + 1]);
+            device_arg_found++;
+            i++;
+        }
+        else if (strcmp(arg, "--cuda-range-native-event-names") == 0) {
+            if (!argv[i + 1]) {
+                std::cout << "ERROR!! --cuda-range-native-event-names given, but no events listed." << std::endl;
+                exit(EXIT_FAILURE);
+            }
+
+            std::stringstream ss(argv[i + 1]);
+            std::string name;
+            while (std::getline(ss, name, ',')) {
+                std::string qualifier = ":device=";
+                size_t device_qualifier_position = name.find(qualifier);
+                if (device_qualifier_position != std::string::npos) {
+                    std::string device_index_str = name.substr(device_qualifier_position + qualifier.size(), 1);
+                    device_qualifier_indices.push_back(std::stoi(device_index_str)); 
+                }
+
+                cuda_range_native_event_names.push_back(name);
+            }
+            cuda_range_native_event_name_arg_found++;
+            i++;
+        }
+        else {
+            print_help_message();
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    if (device_arg_found == 0 || cuda_range_native_event_name_arg_found == 0) {
+        std::cout << "You must use both the --device arg and --cuda-range-native-event-names arg in conjunction." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    for (int device_qualifier_index : device_qualifier_indices) {
+        if (device_qualifier_index != device_index) {
+            std::cout << "The device qualifier index " << device_qualifier_index << " does not match the index " << device_index << " provided to --device." << std::endl;
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    return;
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << "Running the cuda_range component test -- test_cuda_range_hello_world.cu." << std::endl;
+    CHECK_CUDA_DRIVER_API_CALL( cuInit(0) );
+
+    int device_index = -1; 
+    std::vector<std::string> cuda_range_native_event_names {}; 
+    // If a user provided command line arguments then parse them.
+    if (argc > 1) {
+        parse_and_assign_args(argc, argv, device_index, cuda_range_native_event_names);
+    }
+
+    // Determine the number of compute-capable devices.
+    int number_of_devices_on_system = 0;
+    CHECK_CUDA_RUNTIME_API_CALL( cudaGetDeviceCount(&number_of_devices_on_system) );
+    // No compute-capable devices on the machine. Exiting.
+    if (number_of_devices_on_system < 1) {
+        std::cout << "No compute-capable devices found on the machine. This is required for the test to run." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // Initialize the PAPI library.
+    int papi_errno = PAPI_library_init( PAPI_VER_CURRENT );
+    if( papi_errno != PAPI_VER_CURRENT ) { 
+        test_fail(__FILE__,__LINE__, "PAPI_library_init", papi_errno);
+    }   
+    std::cout << "The PAPI version being used for this test is: "
+              << PAPI_VERSION_MAJOR(PAPI_VERSION) << "." 
+              << PAPI_VERSION_MINOR(PAPI_VERSION) << "." 
+              << PAPI_VERSION_REVISION(PAPI_VERSION) << "." 
+              << std::endl;
+
+    // Confirm the cuda_range component exists e.g. compiled in.
+    int cuda_range_cmp_index = PAPI_get_component_index("cuda_range");
+    if (cuda_range_cmp_index < 0) {
+        std::cout << "The cuda_range component does not exist. This is often due to cuda_range not being passed to --with-components at configure." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // The user did not provide the command line argument --cuda-range-native-event-names.
+    if (cuda_range_native_event_names.size() == 0) {
+        get_cuda_range_native_event_name(cuda_range_cmp_index, device_index, cuda_range_native_event_names);
+    }
+
+    // Verify the device_index has been updated before proceeding.
+    if (device_index == -1) {
+        std::cout << "The device index is still -1; therefore, there is a bug in the internal code or test code." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // Create a CUDA context to be used for the entire application code.
+    // Note: If multiple devices/contexts were being used, you'd need to create CUDA contexts for each device.
+    CUcontext context = nullptr;
+    unsigned int flags = 0;
+    CUdevice device = device_index;
+    CHECK_CUDA_DRIVER_API_CALL( cuCtxCreate(&context, (CUctxCreateParams*)0, flags, device) );
+
+    // Create a PAPI event set.
+    int event_set = PAPI_NULL;
+    CHECK_PAPI_API_CALL( PAPI_create_eventset(&event_set) );
+
+    // Add cuda_range native event names to the event set.
+    for (std::string name : cuda_range_native_event_names) {
+        CHECK_PAPI_API_CALL( PAPI_add_named_event(event_set, name.c_str()) );
+    }
+
+    // Start profiling.
+    CHECK_PAPI_API_CALL( PAPI_start(event_set) );
+
+    // Mangle the "Hello World!" string (the null character is left intact for simplicity).
+    char str[] = "Hello World!";
+    std::cout << "Proceeding to mangle the string: " << "'" << str << "'" << "." << std::endl;
+    for (size_t i = 0; i < strlen(str); i++) {
+        str[i] -= i;
+    }
+    std::cout << "Completed mangling the string: " << str << "." << std::endl;
+
+    // Allocate memory on the device.
+    char *d_str;
+    size_t size = sizeof(str);
+    CHECK_CUDA_RUNTIME_API_CALL( cudaMalloc((void**)&d_str, size) );
+    CHECK_MEMORY_ALLOCATION_CALL( d_str );
+
+    // Copy the string to the device.
+    CHECK_CUDA_RUNTIME_API_CALL( cudaMemcpy(d_str, str, size, cudaMemcpyHostToDevice) );
+
+    // Set the grid and block sizes.
+    dim3 dimGrid(2); // One block per word.
+    dim3 dimBlock(6); // One thread per character.
+
+    // Launch kernel.
+    hello_world<<< dimGrid, dimBlock >>>(d_str);
+    CHECK_CUDA_RUNTIME_API_CALL( cudaGetLastError() );
+
+    // Retrieve the results from the device.
+    CHECK_CUDA_RUNTIME_API_CALL( cudaMemcpy(str, d_str, size, cudaMemcpyDeviceToHost) );
+    std::cout << "The string has been unmangled: " << "'" << str << "'" << "." << std::endl;
+
+    // Read profiling data.
+    std::vector<long long> cuda_range_counter_values(cuda_range_native_event_names.size());
+    CHECK_PAPI_API_CALL( PAPI_read(event_set, cuda_range_counter_values.data()) );
+    // Print profiling data.
+    for (size_t i = 0; i < cuda_range_native_event_names.size(); i++) {
+        std::cout << "After PAPI_read, the event " << cuda_range_native_event_names[i] << " produced the value: " << cuda_range_counter_values[i] << std::endl;
+    }
+
+    // Stop profiling.
+    CHECK_PAPI_API_CALL( PAPI_stop(event_set, cuda_range_counter_values.data()) );
+    // Print profiling data.
+    for (size_t i = 0; i < cuda_range_native_event_names.size(); i++) {
+        std::cout << "After PAPI_stop, the event " << cuda_range_native_event_names[i] << " produced the value: " << cuda_range_counter_values[i] << std::endl;
+    }
+
+    // Cleanup the PAPI event set. 
+    CHECK_PAPI_API_CALL( PAPI_cleanup_eventset(event_set) );
+
+    // Destroy the PAPI event set.
+    CHECK_PAPI_API_CALL( PAPI_destroy_eventset(&event_set) );
+
+    // Free the allocated memory on the device.
+    CHECK_CUDA_RUNTIME_API_CALL( cudaFree(d_str) );
+
+    // Destroy the CUDA context.
+    CHECK_CUDA_DRIVER_API_CALL( cuCtxDestroy(context) );
+
+    // Shutdown the PAPI library.
+    PAPI_shutdown();
+
+    test_pass(__FILE__);
+
+    return 0;
+}

--- a/src/components/cuda_range/tests/test_cuda_range_multiple_pass_events.cu
+++ b/src/components/cuda_range/tests/test_cuda_range_multiple_pass_events.cu
@@ -1,0 +1,190 @@
+/**
+* @file  test_cuda_range_multiple_pass_events.cu.
+* @brief This test verifies that multiple pass event support is functional.
+*/
+
+// C++ STL headers.
+#include <cstring>
+#include <iostream>
+#include <map>
+#include <string>
+
+// CTK headers.
+#include <cuda.h>
+#include <cupti_profiler_target.h>
+#include <cupti_target.h>
+
+// Internal headers.
+#include "cuda_range_tests_helper.hpp"
+#include "gpu_work.h"
+#include "papi.h"
+#include "papi_test.h"
+
+#define KERNEL_QUIET 1
+
+typedef struct native_event_data_t
+{
+    const char *cuda_range_native_event_name;
+    size_t expected_number_of_passes_for_collection;
+} native_event_data_t;
+
+std::map<std::string, native_event_data_t> multiple_pass_events = {
+    { "GA100", {"cuda_range:::sm__memory_throughput:stat=max:submetric=pct_of_peak_sustained_active", 4} },
+    { "GH100", {"cuda_range:::sm__memory_throughput:stat=max:submetric=pct_of_peak_sustained_active", 5} },
+    { "GB202", {"cuda_range:::sm__memory_throughput:stat=max:submetric=pct_of_peak_sustained_active", 3} },
+}; 
+
+/** 
+  * @brief A function wrapper to print out the help message for test_cuda_range_multiple_pass_events.cu.
+*/
+static void print_help_message(void)
+{
+    std::cout << "./test_cuda_range_multiple_pass_events --device [NVIDIA device index]" << std::endl
+              << "Notes:" << std::endl
+              << "1. Only a single NVIDIA device index will be used." << std::endl
+              << "2. The NVIDIA device index will be used to append the device qualifier (i.e. :device=#)." << std::endl;
+
+    return;
+}
+
+/** 
+  * @brief Parse the command line arguments provided by the user.
+  *
+  * @param argc
+  *   Number of user passed arguments on the command line.
+  * @param *argv
+  *   Argument vector.
+  * @param &device_index
+  *   Stores the device index passed by the user to --device.
+*/
+static void parse_and_assign_args(int argc, char *argv[], int &device_index)
+{
+    for (int i = 1; i < argc; i++) {
+        char *arg = argv[i];
+        if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {
+            print_help_message();
+            exit(EXIT_SUCCESS);
+        }
+        else if(strcmp(arg, "--device") == 0) {
+            if (!argv[i + 1]) {
+                std::cout << "ERROR!! Add a NVIDIA device index." << std::endl;
+                exit(EXIT_FAILURE);
+            }
+            device_index = std::stoi(argv[i + 1]);
+            i++;
+        }
+        else {
+            print_help_message();
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    return;
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << "Running the cuda_range component test -- test_cuda_range_multiple_pass_events." << std::endl;
+    CHECK_CUDA_DRIVER_API_CALL( cuInit(0) );
+
+    CUpti_Profiler_Initialize_Params profiler_initialize_params {}; 
+    profiler_initialize_params.structSize = CUpti_Profiler_Initialize_Params_STRUCT_SIZE;
+    profiler_initialize_params.pPriv = nullptr;
+    CHECK_CUPTI_API_CALL( cuptiProfilerInitialize(&profiler_initialize_params) );
+   
+    int device_index = 0; 
+    // If a user provided command line arguments then print the help message.
+    if (argc > 1) {
+        parse_and_assign_args(argc, argv, device_index);
+    }
+
+    // Determine the number of compute-capable devices.
+    int number_of_devices_on_system = 0;
+    CHECK_CUDA_RUNTIME_API_CALL( cudaGetDeviceCount(&number_of_devices_on_system) );
+    // No compute-capable devices on the machine. Exiting.
+    if (number_of_devices_on_system < 1) {
+        std::cout << "No compute-capable devices found on the machine. This is required for the test to run." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // Initialize the PAPI library.
+    int papi_errno = PAPI_library_init( PAPI_VER_CURRENT );
+    if( papi_errno != PAPI_VER_CURRENT ) {
+        test_fail(__FILE__,__LINE__, "PAPI_library_init", papi_errno);
+    }
+    std::cout << "The PAPI version being used for this test is: "
+              << PAPI_VERSION_MAJOR(PAPI_VERSION) << "."
+              << PAPI_VERSION_MINOR(PAPI_VERSION) << "."
+              << PAPI_VERSION_REVISION(PAPI_VERSION) << "."
+              << std::endl;
+
+    // Confirm the cuda_range component exists e.g. compiled in.
+    int cuda_range_cmp_index = PAPI_get_component_index("cuda_range");
+    if (cuda_range_cmp_index < 0) {
+        std::cout << "The cuda_range component does not exist. This is often due to cuda_range not being passed to --with-components at configure." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // Get the chip name for the current device index.
+    CUpti_Device_GetChipName_Params get_chip_name_params {};
+    get_chip_name_params.structSize = CUpti_Device_GetChipName_Params_STRUCT_SIZE;
+    get_chip_name_params.pPriv = nullptr;
+    get_chip_name_params.deviceIndex = device_index;
+    CHECK_CUPTI_API_CALL( cuptiDeviceGetChipName(&get_chip_name_params) );
+    std::cout << "Proceeding to test multiple pass event support for device " << device_index
+              << " (" << get_chip_name_params.pChipName << ")" << "." << std::endl;
+
+    // Create a PAPI event set.
+    int event_set = PAPI_NULL;
+    CHECK_PAPI_API_CALL( PAPI_create_eventset(&event_set) );
+
+    // Add the cuda_range native event names to the event set.
+    CHECK_PAPI_API_CALL( PAPI_add_named_event(event_set, multiple_pass_events[get_chip_name_params.pChipName].cuda_range_native_event_name) );
+
+    // Start profiling.
+    CHECK_PAPI_API_CALL( PAPI_start(event_set) );
+
+    // Launch kernel.
+    int number_of_iterations = 50000;
+    VectorAddSubtract(number_of_iterations, KERNEL_QUIET);
+
+    size_t actual_number_of_passes_for_collection = 0;
+    long long cuda_range_counter_value = 0;
+    do {
+        papi_errno = PAPI_read(event_set, &cuda_range_counter_value);
+        VectorAddSubtract(number_of_iterations, KERNEL_QUIET);
+        actual_number_of_passes_for_collection++;
+    } while(papi_errno == PAPI_EALLPASSES_NOT_SUBMITTED);
+
+    std::cout << "Profiling results:" << std::endl;
+    std::cout << "---------------------" << std::endl;
+    if (actual_number_of_passes_for_collection == multiple_pass_events[get_chip_name_params.pChipName].expected_number_of_passes_for_collection) {
+        std::cout << "-> The actual number of passes for collection (" << actual_number_of_passes_for_collection << ")"
+                  << " equals the expected number of passes (" << multiple_pass_events[get_chip_name_params.pChipName].expected_number_of_passes_for_collection
+                  << ")." << std::endl;
+
+        std::cout << "-> " << multiple_pass_events[get_chip_name_params.pChipName].cuda_range_native_event_name << " -- " << cuda_range_counter_value << std::endl;
+    }
+    else {
+        std::cout << "-> The actual number of passes for collection (" << actual_number_of_passes_for_collection << ")"
+                  << " does not equal the expected number of passes (" << multiple_pass_events[get_chip_name_params.pChipName].expected_number_of_passes_for_collection
+                  << ")." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // Stop profiling.
+    CHECK_PAPI_API_CALL( PAPI_stop(event_set, NULL) );
+
+    // Cleanup the PAPI event set. 
+    CHECK_PAPI_API_CALL( PAPI_cleanup_eventset(event_set) );
+
+    // Destroy the PAPI event set.
+    CHECK_PAPI_API_CALL( PAPI_destroy_eventset(&event_set) );
+
+    // Shutdown the PAPI library. 
+    PAPI_shutdown();
+
+    test_pass(__FILE__);
+
+    return 0;
+}

--- a/src/components/cuda_range/tests/test_cuda_range_multiple_pass_events_fail.cu
+++ b/src/components/cuda_range/tests/test_cuda_range_multiple_pass_events_fail.cu
@@ -1,0 +1,100 @@
+/**
+* @file  test_cuda_range_multiple_pass_events_fail.cu.
+* @brief This test verifies multiple pass events fail unless
+*        a user has exported PAPI_CUDA_RANGE_ENABLE_MULTIPASSES.
+*/
+
+// C++ STL headers.
+#include <iostream>
+
+// Internal headers.
+#include <cuda_range_tests_helper.hpp>
+#include "papi.h"
+#include "papi_test.h"
+
+/** 
+  * @brief A function wrapper to print out the help message for test_cuda_range_multiple_pass_events_fail.cu.
+*/
+static void print_help_message(void)
+{
+    std::cout << "./test_cuda_range_multiple_pass_events_fail" << std::endl
+              << "Notes:" << std::endl
+              << "1. No command line arguments are available for this test as stands." << std::endl;
+
+    return;
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << "Running the cuda_range component test -- test_cuda_range_multiple_pass_events_fail." << std::endl;
+    CHECK_CUDA_DRIVER_API_CALL( cuInit(0) );
+
+    // If a user provided command line arguments then print the help message.
+    if (argc > 1) {
+        print_help_message();
+        exit(EXIT_FAILURE);
+    }
+
+    // Determine the number of compute-capable devices.
+    int number_of_devices_on_system = 0;
+    CHECK_CUDA_RUNTIME_API_CALL( cudaGetDeviceCount(&number_of_devices_on_system) );
+    // No compute-capable devices on the machine. Exiting.
+    if (number_of_devices_on_system < 1) {
+        std::cout << "No compute-capable devices found on the machine. This is required for the test to run." << std::endl;
+        exit(EXIT_FAILURE);
+    }   
+
+    // Initialize the PAPI library.
+    int papi_errno = PAPI_library_init( PAPI_VER_CURRENT );
+    if( papi_errno != PAPI_VER_CURRENT ) { 
+        test_fail(__FILE__,__LINE__, "PAPI_library_init", papi_errno);
+    }   
+    std::cout << "The PAPI version being used for this test is: "
+              << PAPI_VERSION_MAJOR(PAPI_VERSION) << "." 
+              << PAPI_VERSION_MINOR(PAPI_VERSION) << "." 
+              << PAPI_VERSION_REVISION(PAPI_VERSION) << "." 
+              << std::endl;
+
+    // Confirm the cuda_range component exists e.g. compiled in.
+    int cuda_range_cmp_index = PAPI_get_component_index("cuda_range");
+    if (cuda_range_cmp_index < 0) {
+        std::cout << "The cuda_range component does not exist. This is often due to cuda_range not being passed to --with-components at configure." << std::endl;
+        exit(EXIT_FAILURE);
+    }   
+
+    // Initialize the cuda_range component/Get the first cuda_range event.
+    int modifier = PAPI_ENUM_FIRST;
+    int cuda_range_eventcode = 0 | PAPI_NATIVE_MASK;
+    CHECK_PAPI_API_CALL( PAPI_enum_cmp_event(&cuda_range_eventcode, modifier, cuda_range_cmp_index) );
+
+    // Search for a cuda_range native event that requires multiple passes for collection.
+    PAPI_event_info_t event_info;
+    modifier = PAPI_ENUM_EVENTS;
+    do {
+        CHECK_PAPI_API_CALL( PAPI_get_event_info(cuda_range_eventcode, &event_info) );
+    } while( event_info.num_passes_for_collection == 1 &&
+             PAPI_enum_cmp_event(&cuda_range_eventcode, modifier, cuda_range_cmp_index) == PAPI_OK);
+
+    // Create a PAPI event set. 
+    int event_set = PAPI_NULL;
+    CHECK_PAPI_API_CALL( PAPI_create_eventset(&event_set) );
+
+    // Attempt to add the multiple pass event. 
+    papi_errno = PAPI_add_named_event(event_set, event_info.symbol);
+    // PAPI_EMULPASS correctly returned.
+    if (papi_errno == PAPI_EMULPASS) {
+        std::cout << "-> " << event_info.symbol << " requires " << event_info.num_passes_for_collection
+                  << " passes for collection -- PAPI_EMULPASS correctly returned" << std::endl;
+    }
+    // PAPI_EMULPASS not correctly returned.
+    else {
+        std::cout << "PAPI_EMULPASS not returned and should have been" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    CHECK_PAPI_API_CALL( PAPI_destroy_eventset(&event_set) );
+
+    test_pass(__FILE__);
+
+    return 0;
+}

--- a/src/components/cuda_range/tests/test_cuda_range_multiple_pass_events_succeed.cu
+++ b/src/components/cuda_range/tests/test_cuda_range_multiple_pass_events_succeed.cu
@@ -1,5 +1,5 @@
 /**
-* @file  test_cuda_range_multiple_pass_events.cu.
+* @file  test_cuda_range_multiple_pass_events_succeed.cu.
 * @brief This test verifies that multiple pass event support is functional.
 */
 
@@ -84,7 +84,7 @@ static void parse_and_assign_args(int argc, char *argv[], int &device_index)
 
 int main(int argc, char **argv)
 {
-    std::cout << "Running the cuda_range component test -- test_cuda_range_multiple_pass_events." << std::endl;
+    std::cout << "Running the cuda_range component test -- test_cuda_range_multiple_pass_events_succeed." << std::endl;
     CHECK_CUDA_DRIVER_API_CALL( cuInit(0) );
 
     CUpti_Profiler_Initialize_Params profiler_initialize_params {}; 
@@ -133,6 +133,13 @@ int main(int argc, char **argv)
     CHECK_CUPTI_API_CALL( cuptiDeviceGetChipName(&get_chip_name_params) );
     std::cout << "Proceeding to test multiple pass event support for device " << device_index
               << " (" << get_chip_name_params.pChipName << ")" << "." << std::endl;
+
+    // Enable multiple pass support.
+    int status = setenv("PAPI_CUDA_RANGE_ENABLE_MULTIPASSES", "1", 1);
+    if (status != 0) {
+        std::cout << "Failed to set PAPI_CUDA_RANGE_ENABLE_MULTIPASSES equal to 1." << std::endl;
+        exit(EXIT_FAILURE);
+    }
 
     // Create a PAPI event set.
     int event_set = PAPI_NULL;

--- a/src/components/cuda_range/tests/test_cuda_range_no_user_context.cu
+++ b/src/components/cuda_range/tests/test_cuda_range_no_user_context.cu
@@ -1,0 +1,194 @@
+/**
+* @file  test_cuda_range_no_user_context.cu
+* @brief This test verifies that CUDA contexts are being created internally
+*        if one is not created by the user on the calling CPU thread.
+*/
+
+// C++ STL headers.
+#include <cstring>
+#include <iostream>
+#include <string>
+
+// CTK headers.
+#include <cuda.h>
+
+// Internal headers.
+#include "cuda_range_tests_helper.hpp"
+#include <gpu_work.h>
+#include "papi.h"
+#include "papi_test.h"
+
+#define KERNEL_QUIET 1
+
+/** 
+  * @brief A function wrapper to print out the help message for test_cuda_range_no_user_context.cu.
+*/
+static void print_help_message(void)
+{
+    std::cout << "./test_cuda_range_no_user_context --device [NVIDIA device index]" << std::endl
+              << "Notes:" << std::endl
+              << "1. Only a single NVIDIA device index will be used." << std::endl
+              << "2. The NVIDIA device index will be used to append the device qualifier (i.e. :device=#)." << std::endl;
+
+    return;
+}
+
+/** 
+  * @brief Parse the command line arguments provided by the user.
+  *
+  * @param argc
+  *   Number of user passed arguments on the command line.
+  * @param *argv
+  *   Argument vector.
+  * @param &device_index
+  *   Stores the device index passed by the user to --device.
+*/
+static void parse_and_assign_args(int argc, char *argv[], int &device_index)
+{
+    for (int i = 1; i < argc; i++) {
+        char *arg = argv[i];
+        if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {
+            print_help_message();
+            exit(EXIT_SUCCESS);
+        }
+        else if(strcmp(arg, "--device") == 0) {
+            if (!argv[i + 1]) {
+                std::cout << "ERROR!! Add a NVIDIA device index." << std::endl;
+                exit(EXIT_FAILURE);
+            }
+            device_index = std::stoi(argv[i + 1]);
+            i++;
+        }
+        else {
+            print_help_message();
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    return;
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << "Running the cuda_range component test -- test_cuda_range_no_user_context.cu." << std::endl;
+    CHECK_CUDA_DRIVER_API_CALL( cuInit(0) );
+
+    int device_index = 0;
+    // If a user provided command line arguments then parse them.
+    if (argc > 1) {
+        parse_and_assign_args(argc, argv, device_index);
+    }
+
+    // Determine the number of compute-capable devices.
+    int number_of_devices_on_system = 0;
+    CHECK_CUDA_RUNTIME_API_CALL( cudaGetDeviceCount(&number_of_devices_on_system) );
+    // No compute-capable devices on the machine. Exiting.
+    if (number_of_devices_on_system < 1) {
+        std::cout << "No compute-capable devices found on the machine. This is required for the test to run." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // Verify the device_index is valid.
+    if (device_index < 0 || device_index > number_of_devices_on_system) {
+        std::cout << "The device index is invalid. The number of NVIDIA devices on the system is "
+                  << number_of_devices_on_system << "." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // Initialize the PAPI library.
+    int papi_errno = PAPI_library_init( PAPI_VER_CURRENT );
+    if( papi_errno != PAPI_VER_CURRENT ) {
+        test_fail(__FILE__,__LINE__, "PAPI_library_init", papi_errno);
+    }
+    std::cout << "The PAPI version being used for this test is: "
+              << PAPI_VERSION_MAJOR(PAPI_VERSION) << "."
+              << PAPI_VERSION_MINOR(PAPI_VERSION) << "."
+              << PAPI_VERSION_REVISION(PAPI_VERSION) << "."
+              << std::endl;
+
+    // Confirm the cuda_range component exists e.g. compiled in.
+    int cuda_range_cmp_index = PAPI_get_component_index("cuda_range");
+    if (cuda_range_cmp_index < 0) {
+        std::cout << "The cuda_range component does not exist. This is often due to cuda_range not being passed to --with-components at configure." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // Set the internal environment variable to verify CUDA context creation.
+    int status = setenv("PAPI_CUDA_RANGE_INTERNAL_VERIFY_CONTEXTS", "TRUE", 1);
+    if (status != 0) {
+        std::cout << "Failed to set PAPI_CUDA_RANGE_INTERNAL_VERIFY_CONTEXTS environment variable." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // Get a cuda_range native event name.
+    std::string cuda_range_native_event_name {};
+    get_cuda_range_native_event_name(cuda_range_cmp_index, cuda_range_native_event_name);
+    cuda_range_native_event_name += ":device=" + std::to_string(device_index);
+
+    // Create a PAPI event set.
+    int event_set = PAPI_NULL;
+    CHECK_PAPI_API_CALL( PAPI_create_eventset(&event_set) );
+
+    // Add the cuda_range native event names to the event set.
+    CHECK_PAPI_API_CALL( PAPI_add_named_event(event_set, cuda_range_native_event_name.c_str()) );
+
+    // Formatting.
+    std::cout << "Verifying internally created CUDA context:" << std::endl;
+    std::cout << "------------------------------------------" << std::endl;
+
+    // Verify a CUDA context was created.
+    CUcontext context;
+    CHECK_CUDA_DRIVER_API_CALL( cuCtxGetCurrent(&context) );
+    // CUDA context creation success.
+    if (context != nullptr) {
+        std::cout << "- CUDA context was successfully created internally." << std::endl;
+    }
+    // CUDA context creation failed.
+    else {
+        std::cout << "- CUDA context was not successfully created internally. Exiting" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // Verify a CUDA context was created for the correct device qualifier.
+    CUdevice device;
+    CHECK_CUDA_DRIVER_API_CALL( cuCtxGetDevice_v2(&device, context) );
+    // Correct device qualifier.
+    if (device == device_index) {
+        std::cout << "- CUDA context was correctly created for the qualifier :device=" << device_index << "." << std::endl;
+    }
+    // Incorrect device qualifier.
+    else {
+        std::cout << "- CUDA context was not correctly created for the qualifier :device=" << device_index << ". Exiting." << std::endl;
+        exit(EXIT_FAILURE); 
+    }
+
+    // Start profiling.
+    CHECK_PAPI_API_CALL( PAPI_start(event_set) );
+
+    // Launch kernel.
+    int number_of_iterations = 50000; 
+    VectorAddSubtract(number_of_iterations, KERNEL_QUIET);
+
+    // Stop profiling.
+    long long cuda_range_counter_value = 0;
+    CHECK_PAPI_API_CALL( PAPI_stop(event_set, &cuda_range_counter_value) );
+
+    // Print profiling data.
+    std::cout << std::endl
+              << "Profiling results:" << std::endl
+              << "------------------------------------------" << std::endl
+              << "- " << cuda_range_native_event_name << " -- " << cuda_range_counter_value << std::endl;
+
+    // Cleanup the PAPI event set. 
+    CHECK_PAPI_API_CALL( PAPI_cleanup_eventset(event_set) );
+
+    // Destroy the PAPI event set.
+    CHECK_PAPI_API_CALL( PAPI_destroy_eventset(&event_set) );
+
+    // Shutdown the PAPI library. 
+    PAPI_shutdown();
+
+    test_pass(__FILE__);
+
+    return 0;
+}

--- a/src/components/cuda_range/tests/test_cuda_range_pthreads.cu
+++ b/src/components/cuda_range/tests/test_cuda_range_pthreads.cu
@@ -1,0 +1,237 @@
+/**
+* @file  test_cuda_range_pthreads.cu
+* @brief For each enabled NVIDIA device detected on the machine a matching thread will be created
+*        using pthread_create. For each thread, cuCtxCreate will be called which will
+*        create a Cuda context.
+*
+*        For each enabled device, their matching thread will have a workflow of:
+*        1. Creating a PAPI event set.
+*        2. Adding events to the PAPI event set.
+*        3. Starting the PAPI event set.
+*        4. Stopping the PAPI event set.
+*/
+
+// C++ STL headers.
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+// POSIX standard headers.
+#include <pthread.h>
+
+// CTK headers.
+#include <cuda.h>
+
+// Internal headers.
+#include "cuda_range_tests_helper.hpp"
+#include "gpu_work.h"
+#include "papi.h"
+#include "papi_test.h"
+
+#define KERNEL_QUIET 1
+
+/** 
+  * @brief An enum containing member variables for pthreads.
+*/
+typedef struct pthread_params_t
+{
+    int thread_num;
+    std::vector<std::string> cuda_range_native_event_names;
+    char *cuda_range_native_event_name;
+    pthread_t thread_id;
+} pthread_params_t;
+
+/** 
+  * @brief The pthread_create start routine.
+  *   
+  * @param *arg
+  *   An instance of the structure pthread_params_t.
+*/
+void *thread_start(void *arg)
+{
+    pthread_params_t *tinfo = (pthread_params_t *) arg;
+
+    // Create a CUDA context for the current thread.
+    CUcontext context;
+    unsigned int flags = 0;
+    CUdevice device = tinfo->thread_num;
+    CHECK_CUDA_DRIVER_API_CALL( cuCtxCreate(&context, (CUctxCreateParams*)0, flags, device) );
+
+    // Create a PAPI event set.
+    int event_set = PAPI_NULL;
+    CHECK_PAPI_API_CALL( PAPI_create_eventset(&event_set) );
+
+    // Add cuda_range native event names to the event set.
+    for (std::string name : tinfo->cuda_range_native_event_names) {
+        std::string cuda_range_native_event_name_device = name + ":device=" + std::to_string(tinfo->thread_num);
+        CHECK_PAPI_API_CALL( PAPI_add_named_event(event_set, cuda_range_native_event_name_device.c_str()) );
+    }
+
+    // Start profiling.
+    CHECK_PAPI_API_CALL( PAPI_start(event_set) );
+
+    // Launch kernel.
+    int number_of_iterations = 50000;
+    VectorAddSubtract(number_of_iterations * (tinfo->thread_num + 1), KERNEL_QUIET);
+
+    // Stop profiling.
+    std::vector<long long> cuda_range_counter_values(tinfo->cuda_range_native_event_names.size());
+    CHECK_PAPI_API_CALL( PAPI_stop(event_set, cuda_range_counter_values.data()) );
+
+    // Print profiling data.
+    for (size_t i = 0; i < tinfo->cuda_range_native_event_names.size(); i++) {
+        std::cout << "Thread " << tinfo->thread_num << ": " << tinfo->cuda_range_native_event_names[i]
+                  << " produced the counter value -- " << cuda_range_counter_values[i] << "." << std::endl;
+    }
+
+    // Cleanup the PAPI event set.
+    CHECK_PAPI_API_CALL( PAPI_cleanup_eventset(event_set) );
+
+    // Destroy the PAPI event set.
+    CHECK_PAPI_API_CALL( PAPI_destroy_eventset(&event_set) );
+
+    // Destroy the CUDA context created on the thread.
+    CHECK_CUDA_DRIVER_API_CALL( cuCtxDestroy(context) );
+
+    return NULL;
+}
+
+/** 
+  * @brief A function wrapper to print out the help message for test_cuda_range_pthreads.cu.
+*/
+static void print_help_message(void)
+{
+    std::cout << "./test_cuda_range_pthreads --cuda-range-native-event-names [list of cuda_range native event names separated by a comma]." << std::endl
+              << "Notes:" << std::endl
+              << "1. The cuda_range native event names must not have the device qualifier appended (i.e. no :device=#)." << std::endl;
+
+    return;
+}
+
+/** 
+  * @brief Parse the command line arguments provided by the user.
+  *
+  * @param argc
+  *   Number of user passed arguments on the command line.
+  * @param *argv
+  *   Argument vector.
+  * @param &cuda_range_native_event_names
+  *   Stores the cuda_range native event names passed by the user to --cuda-range-native-event-names.
+*/
+static void parse_and_assign_args(int argc, char *argv[], std::vector<std::string> &cuda_range_native_event_names)
+{
+    for (int i = 1; i < argc; ++i) {   
+        char *arg = argv[i];
+        if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {   
+            print_help_message();
+            exit(EXIT_SUCCESS);
+        }   
+        else if (strcmp(arg, "--cuda-range-native-event-names") == 0) {   
+            if (!argv[i + 1]) {   
+                printf("ERROR!! --cuda-range-native-event-names given, but no events listed.\n");
+                exit(EXIT_FAILURE);
+            }   
+
+            const char *cuda_range_native_event_name = strtok(argv[i + 1], ",");
+            while (cuda_range_native_event_name != NULL) {   
+                if (strstr(cuda_range_native_event_name, ":device")) {
+                    std::cout << "The cuda_range native event name " << cuda_range_native_event_name << " has a device qualifier appended. This is not allowed." << std::endl;
+                    exit(EXIT_FAILURE);
+                }
+
+                cuda_range_native_event_names.push_back(cuda_range_native_event_name); 
+
+                cuda_range_native_event_name = strtok(NULL, ",");
+            }
+            i++;
+        }
+        else {   
+            print_help_message();
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    return;
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << "Running the cuda_range component test -- test_cuda_range_pthreads.cu." << std::endl;
+    CHECK_CUDA_DRIVER_API_CALL( cuInit(0) );
+
+    // If a user provided command line arguments then print the help message.
+    std::vector<std::string> cuda_range_native_event_names {};
+    if (argc > 1) {
+        parse_and_assign_args(argc, argv, cuda_range_native_event_names);
+    }   
+
+    // Determine the number of compute-capable devices.
+    int number_of_devices_on_system = 0;
+    CHECK_CUDA_RUNTIME_API_CALL( cudaGetDeviceCount(&number_of_devices_on_system) );
+    // No compute-capable devices on the machine. Exiting.
+    if (number_of_devices_on_system < 1) {
+        std::cout << "No compute-capable devices found on the machine. This is required for the test to run." << std::endl;
+        exit(EXIT_FAILURE);
+    }   
+
+    // Initialize the PAPI library.
+    int papi_errno = PAPI_library_init( PAPI_VER_CURRENT );
+    if( papi_errno != PAPI_VER_CURRENT ) { 
+        test_fail(__FILE__,__LINE__, "PAPI_library_init", papi_errno);
+    }   
+    std::cout << "The PAPI version being used for this test is: "
+              << PAPI_VERSION_MAJOR(PAPI_VERSION) << "." 
+              << PAPI_VERSION_MINOR(PAPI_VERSION) << "." 
+              << PAPI_VERSION_REVISION(PAPI_VERSION) << "." 
+              << std::endl;
+
+    // Initialize thread support in the PAPI library.
+    CHECK_PAPI_API_CALL( PAPI_thread_init((unsigned long (*)(void)) pthread_self) );
+
+    // Confirm the cuda_range component exists e.g. compiled in.
+    int cuda_range_cmp_index = PAPI_get_component_index("cuda_range");
+    if (cuda_range_cmp_index < 0) {
+        std::cout << "The cuda_range component does not exist. This is often due to cuda_range not being passed to --with-components at configure." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // The user did not provide the command line argument --cuda-range-native-event-names.
+    if (cuda_range_native_event_names.size() == 0) {
+        cuda_range_native_event_names.resize(1);
+        get_cuda_range_native_event_name(cuda_range_cmp_index, cuda_range_native_event_names[0]);
+    } 
+
+    pthread_params_t *tinfo = (pthread_params_t *) calloc(number_of_devices_on_system, sizeof(pthread_params_t));
+    CHECK_MEMORY_ALLOCATION_CALL(tinfo);
+
+    std::cout << "Total number of threads to be launched: " << number_of_devices_on_system << "." << std::endl;
+    // Create threads.
+    for(size_t tnum = 0; tnum < number_of_devices_on_system; tnum++) {
+        tinfo[tnum].thread_num = tnum;
+        tinfo[tnum].cuda_range_native_event_names = cuda_range_native_event_names;
+
+        int status = pthread_create(&tinfo[tnum].thread_id, NULL, thread_start, &tinfo[tnum]);
+        if(status != 0) {
+            std::cout << "Call to pthread_create failed for thread " << tnum << " with error code " << status << "." << std::endl;
+            exit(EXIT_FAILURE);
+        }   
+    }
+
+    // Join with each thread.
+    for (size_t tnum = 0; tnum < number_of_devices_on_system; tnum++) {
+        int status = pthread_join(tinfo[tnum].thread_id, NULL);
+        if (status != 0) {
+            std::cout << "Call to pthread_join failed for thread " << tnum << " with error code " << status << "." << std::endl;
+            exit(EXIT_FAILURE);
+        }
+    }
+    free(tinfo);
+
+    // Shutdown the PAPI library.
+    PAPI_shutdown();
+
+    test_pass(__FILE__);
+
+    return 0;
+}

--- a/src/configure
+++ b/src/configure
@@ -6924,7 +6924,7 @@ for comp in $components; do
   fi
 
   # check for intel_gpu or rocp_sdk component to determine if we need -lstdc++ in LDFLAGS
-  if (test "x$comp" = "xintel_gpu" || test "x$comp" = "xrocp_sdk"); then
+  if (test "x$comp" = "xintel_gpu" || test "x$comp" = "xrocp_sdk" || test "x$comp" = "xcuda_range"); then
     LDFLAGS="$LDFLAGS -lstdc++ -pthread"
   fi
 

--- a/src/configure.in
+++ b/src/configure.in
@@ -2075,7 +2075,7 @@ for comp in $components; do
   fi
 
   # check for intel_gpu or rocp_sdk component to determine if we need -lstdc++ in LDFLAGS
-  if (test "x$comp" = "xintel_gpu" || test "x$comp" = "xrocp_sdk"); then
+  if (test "x$comp" = "xintel_gpu" || test "x$comp" = "xrocp_sdk" || test "x$comp" = "xcuda_range"); then
     LDFLAGS="$LDFLAGS -lstdc++ -pthread"
   fi
 

--- a/src/papi.c
+++ b/src/papi.c
@@ -1537,13 +1537,13 @@ PAPI_event_code_to_name( int EventCode, char *out )
 			return PAPI_ENOCMP;
 		}
 
-		int stringLength = PAPI_MAX_STR_LEN;
-		if (strcmp(_papi_hwd[compIdx]->cmp_info.name, "cuda") == 0) {
-			stringLength = PAPI_2MAX_STR_LEN;
+		int string_length = PAPI_MAX_STR_LEN;
+		if (strcmp(_papi_hwd[compIdx]->cmp_info.name, "cuda") == 0 ||
+                    strcmp(_papi_hwd[compIdx]->cmp_info.name, "cuda_range") == 0) {
+			string_length = PAPI_2MAX_STR_LEN;
 		}
-
 		return ( _papi_hwi_native_code_to_name
-				 ( ( unsigned int ) EventCode, out, stringLength ) );
+				 ( ( unsigned int ) EventCode, out, string_length ) );
 	}
 
 	if ( IS_USER_DEFINED(EventCode) ) {
@@ -3096,8 +3096,16 @@ PAPI_stop( int EventSet, long long *values )
 	context = _papi_hwi_get_context( ESI, NULL );
 	/* Read the current counter values into the EventSet */
 	retval = _papi_hwi_read( context, ESI, ESI->sw_stop );
-	if ( retval != PAPI_OK )
-		papi_return( retval );
+	if (retval != PAPI_OK) {
+		/* Multiple pass events. */
+		if (retval == PAPI_EALLPASSES_NOT_SUBMITTED) {
+			APIDBG("Acknowledging all passes were not submitted; however, continuing.");
+		}
+		/* Catch all. */
+		else {
+			papi_return( retval );
+		}
+	}
 
 	/* Remove the control bits from the active counter config. */
 	retval = _papi_hwd[cidx]->stop( context, ESI->ctl_state );

--- a/src/papi.h
+++ b/src/papi.h
@@ -1021,6 +1021,8 @@ enum {
      int  num_quals;                                       /**< number of qualifiers */
      char quals[PAPI_MAX_COMP_QUALS][PAPI_HUGE_STR_LEN];   /**< qualifiers */
      char quals_descrs[PAPI_MAX_COMP_QUALS][PAPI_HUGE_STR_LEN];  /**< qualifier descriptions */
+     size_t num_passes_for_collection;                           /**< number of passes required to be
+                                                                 submitted to the GPU for collection */
    } PAPI_event_info_t;
 
 

--- a/src/papi.h
+++ b/src/papi.h
@@ -281,7 +281,8 @@ failure.
 #define PAPI_EDELAY_INIT -26   /**< Delayed initialization component */
 #define PAPI_EMULPASS   -27    /**< Event exists, but cannot be counted due to multiple passes required by hardware */
 #define PAPI_PARTIAL    -28    /**< Component is partially disabled */
-#define PAPI_NUM_ERRORS	 29    /**< Number of error messages specified in this API */
+#define PAPI_EALLPASSES_NOT_SUBMITTED -29 /**< Native event requires more than a single pass for profiling. */
+#define PAPI_NUM_ERRORS	 30    /**< Number of error messages specified in this API */
 
 #define PAPI_NOT_INITED		0
 #define PAPI_LOW_LEVEL_INITED 	1       /* Low level has called library init */

--- a/src/papi_internal.c
+++ b/src/papi_internal.c
@@ -426,6 +426,7 @@ _papi_hwi_init_errors(void) {
     /* 26 PAPI_EDELAY_INIT */ _papi_hwi_add_error("Delayed initialization component");
     /* 27 PAPI_EMULPASS */ _papi_hwi_add_error("Event exists, but cannot be counted due to multiple passes required by hardware");
     /* 28 PAPI_PARTIAL */ _papi_hwi_add_error("Component in use is partially disabled, see utils/papi_component_avail for more information.");
+    /* 29 PAPI_EALLPASSES_NOT_SUBMITTED */ _papi_hwi_add_error("Native event requires more than a single pass for profiling.");
 }
 
 int


### PR DESCRIPTION
## Pull Request Description
This PR adds the component `cuda_range` to the PAPI library. This component serves as the successor to the `cuda` component and internally uses the new CUPTI APIs (CUPTI Profiler Host and CUPTI Range Profiling).

## Testing
The most recent testing took place on Methane at ICL (1 * A100) with Cuda Toolkit 13.0.0.

- `cuda_range` component tests: ✅ 
- PAPI utilities*: ✅ 

__*__ `papi_component_avail`, `papi_native_avail`, and `papi_command_line`.

Throughout development I have tested the `cuda_range` component with:
- H100's and GB202's
- Cuda Toolkits 13.1.1 and 13.2.1

Furthermore, I have specifically tested `papi_native_avail` on Methane at ICL (1 * A100) and Guyot at ICL (8 * A100) with Cuda Toolkit 13.0.0 to measure the wall clock time to enumerate all events, the results are:
- On Methane at ICL (1 * A100), it takes ~9 seconds to enumerate 3,062 `cuda_range` native events during which the description and number of passes is collected.
- On Guyot at ICL (8 * A100), it takes ~12 seconds to enumerate 3,062 `cuda_range` native events during which the description and number of passes is collected.

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
