### PR TITLE
rocp_sdk: Honor PAPI_ROCP_SDK_ROOT for AMDCXX

### DIFF
--- a/src/components/rocp_sdk/tests/Makefile
+++ b/src/components/rocp_sdk/tests/Makefile
@@ -16,7 +16,7 @@ ROCP_SDK_INCL+=-I$(PAPI_ROCM_ROOT)/include     \
               -I$(PAPI_ROCM_ROOT)/include/rocprofiler-sdk
 endif
 
-AMDCXX   ?= amdclang++
+AMDCXX   ?= $(PAPI_ROCP_SDK_ROOT)/bin/amdclang++
 CFLAGS    = $(OPTFLAGS)
 INCFLAGS += $(INCLUDE) $(ROCP_SDK_INCL)
 CPPFLAGS += $(INCFLAGS)


### PR DESCRIPTION
## Pull Request Description
On Odyssey at Oregon (MI300A) using ROCm 6.3.4 and 6.4.4, I encounter the below compilation error:
```
/opt/rocm-6.4.4/include/hip/amd_detail/amd_warp_functions.h:96:37: error: use of undeclared identifier '__AMDGCN_WAVEFRONT_SIZE'
   96 |     static constexpr int warpSize = __AMDGCN_WAVEFRONT_SIZE;

```

The cause of this compilation error is how `AMDCXX` is set equal to `?= amdclang++` and does not honor a user setting `PAPI_ROCP_SDK_ROOT`, but the include files do:
```
  4 ROCP_SDK_INCL=-I$(PAPI_ROCP_SDK_ROOT)/include     \
  5               -I$(PAPI_ROCP_SDK_ROOT)/include/hsa \
  6               -I$(PAPI_ROCP_SDK_ROOT)/hsa/include \
  7                           -I$(PAPI_ROCP_SDK_ROOT)/include/rocprofiler-sdk
```

Therefore, a mismatch in the compiler version and header files can occur and lead to the above compilation error if a user does not `module load` the ROCm version set in `PAPI_ROCP_SDK_ROOT`.

# Testing
Testing took place on Odyssey at Oregon (MI300A) with ROCm 6.3.4 and 6.4.4.

- Building: ✅ 
- PAPI utilities*: ✅ 
- `rocp_sdk` component tests: ✅ 

__*__ - `papi_component_avail`, `papi_command_line`, `papi_native_avail`

## Author Checklist
- [x] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [x] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [x] **Tests**
The PR needs to pass all the tests
