### PR TITLE
validation_tests: fix bug in asm syntax

### DIFF
--- a/src/validation_tests/instructions_testcode.c
+++ b/src/validation_tests/instructions_testcode.c
@@ -77,7 +77,7 @@ int instructions_million(void) {
 		"	bne	55b		// repeat till zero\n"
 		: /* no output registers */
 		: /* no inputs */
-		: "cc", "r2" /* clobbered */
+		: "cc", "x2" /* clobbered */
 	);
 	return 0;
 #endif


### PR DESCRIPTION
## Pull Request Description

The register that is actually used in this case is x2, but the clobber list contains r2.

These changes have been tested using NVHPC 25.9 on a system containing the Arm Neoverse V2 architecture.

This PR resolves Issue #655.

Here are the steps I used to build:
```
module load nvhpc/25.9
export CC="/packages/nvhpc/25.9_cuda13.0/Linux_aarch64/25.9/compilers/bin/nvc"
export CFLAGS="--diag_suppress set_but_not_used,nonobject_pointer_arithmetic,branch_past_initialization,integer_sign_change,code_is_unreachable,incompatible_assignment_operands,incompatible_param,mixed_enum_type,declared_but_not_referenced,bad_initializer_type"
./configure --prefix=${INSTDIR} --with-libsde=no --disable-fortran
```

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
