### PR TITLE
amd_smi: tests/Makefile include amd_smi rather than rocm_smi

### DIFF
--- a/src/components/amd_smi/tests/Makefile
+++ b/src/components/amd_smi/tests/Makefile
@@ -24,7 +24,7 @@ BASE_INCLUDES_FROM_LOG ?= -I. -I../../.. -I../../../testlib -I../../../validatio
 PAPI_DIR_INCLUDE ?= ../../../include
 
 INCLUDE_PAPI := $(BASE_INCLUDES_FROM_LOG) -I$(PAPI_DIR_INCLUDE)
-INCLUDE_AMDSMI := -I$(PAPI_AMDSMI_ROOT)/include -I$(PAPI_AMDSMI_ROOT)/include/rocm_smi
+INCLUDE_AMDSMI := -I$(PAPI_AMDSMI_ROOT)/include -I$(PAPI_AMDSMI_ROOT)/include/amd_smi
 INCLUDE_HIP := -I$(PAPI_AMDSMI_ROOT)/include/hip \
                -I$(PAPI_AMDSMI_ROOT)/include/hsa \
                -I$(PAPI_AMDSMI_ROOT)/include/rocprofiler \


### PR DESCRIPTION
## Pull Request Description
Line 27 in `amd_smi/tests/Makefile` has:
```
-I$(PAPI_AMDSMI_ROOT)/include/rocm_smi
```

As this is the `amd_smi` component this should be:
```
-I$(PAPI_AMDSMI_ROOT)/include/amd_smi
```

Otherwise, if you attempt to include `amdsmi.h` in an `amd_smi` test source file the following compilation error occurs:
```
amdsmi_energy_monotonic.c:23:10: fatal error: amdsmi.h: No such file or directory
   23 | #include <amdsmi.h>
      |          ^~~~~~~~~~
```

This PR rectifies this issue.

## Testing
Testing was done on Odyssey (4 * MI300A) at Oregon with the following setup:
```
export PAPI_AMDSMI_ROOT=/opt/rocm-7.2.4
./configure --prefix=$PWD/test-install --with-components="amd_smi" --with-debug=yes
```

The results are:
- PAPI build: ✅ 
- PAPI utilities*: ✅ 
- `amd_smi` component tests: ✅ (lacked permissions for `amdsmi_set_test.c`)

__*__ - `papi_component_avail`, `papi_native_avail`, and `papi_command_line`

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
