### PR TITLE
cat: resolve race condition in Makefile

### DIFF
--- a/src/counter_analysis_toolkit/Makefile
+++ b/src/counter_analysis_toolkit/Makefile
@@ -66,7 +66,7 @@ all: branch.o d_cache eventstock.o flops i_cache instr vector
 
 d_cache: timing_kernels.o prepareArray.o compar.o dcache.o
 
-i_cache: icache.o icache_seq_kernel_0.o
+i_cache: icache_seq_kernel_0.o
 
 vector: weak_symbols.o vec.o vec_scalar_verify.o $(VECSRC)
 
@@ -95,7 +95,7 @@ icache.o: icache.c icache.h
 	bash gen_seq_dlopen.sh
 	$(CC) $(CFLAGS) $(OPT0) $(INCFLAGS) -c icache.c -o icache.o
 
-icache_seq_kernel_0.o: icache_seq.c icache_seq.h
+icache_seq_kernel_0.o: icache.o
 	$(CC) $(CFLAGS) $(OPT0) $(INCFLAGS) -c icache_seq.c -o icache_seq.o
 	$(CC) $(CFLAGS) $(OPT0) $(INCFLAGS) -fPIC -c icache_seq_kernel.c -o icache_seq_kernel_0.o
 	$(CC) $(CFLAGS) $(OPT0) -shared -o icache_seq_kernel_0.so icache_seq_kernel_0.o


### PR DESCRIPTION
## Pull Request Description

The Makefile previously had a race condition that was observable only when parallel make was used. In this case, the automatically generated icache_seq_kernel.c had not been fully generated, so warnings and errors were emitted due to the compiler parsing an incomplete source file.

This PR resolves Issue #463.

These changes on a system containing the Intel Skylake architecture using GCC 11.5.0.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
