### PR TITLE
sysdetect: Update tests/Makefile to support nvfortran

### DIFF
--- a/src/components/sysdetect/tests/Makefile
+++ b/src/components/sysdetect/tests/Makefile
@@ -24,7 +24,7 @@ nvidia_compilers := nvfortran
 
 gfortran_variants := $(shell echo "$(F77)" | grep --ignore-case --fixed-strings --silent gfortran; echo $$?)
 ifeq ($(gfortran_variants), 0)
-    F90FLAGS += $(FFLAGS) -free-form -ffree-line-length-none
+    F90FLAGS += $(FFLAGS) -ffree-form -ffree-line-length-none
 else ifeq ($(patsubst %flang,,$(notdir $(F77))),)  # compiler name ends with flang
     F90FLAGS += $(FFLAGS) -ffree-form
 else ifneq ($(findstring $(notdir $(F77)), $(intel_compilers)),)

--- a/src/components/sysdetect/tests/Makefile
+++ b/src/components/sysdetect/tests/Makefile
@@ -20,17 +20,21 @@ endif
 
 intel_compilers := ifort ifx
 cray_compilers := ftn crayftn
+nvidia_compilers := nvfortran
 
 gfortran_variants := $(shell echo "$(F77)" | grep --ignore-case --fixed-strings --silent gfortran; echo $$?)
 ifeq ($(gfortran_variants), 0)
-    FFLAGS +=-ffree-form -ffree-line-length-none
+    F90FLAGS += $(FFLAGS) -free-form -ffree-line-length-none
 else ifeq ($(patsubst %flang,,$(notdir $(F77))),)  # compiler name ends with flang
-    FFLAGS +=-ffree-form
+    F90FLAGS += $(FFLAGS) -ffree-form
 else ifneq ($(findstring $(notdir $(F77)), $(intel_compilers)),)
-    FFLAGS +=-free
+    F90FLAGS += $(FFLAGS) -free
 else ifneq ($(findstring $(notdir $(F77)), $(cray_compilers)),)
-    FFLAGS +=-ffree
+    F90FLAGS += $(FFLAGS) -ffree
+else ifneq ($(findstring $(notdir $(F77)), $(nvidia_compilers)),)
+    F90FLAGS += $(FFLAGS) -Mfree
 endif
+F90 ?= $(F77)
 
 TESTS = query_device_simple \
         $(FTESTS)           \
@@ -48,7 +52,7 @@ query_device_mpi.o: query_device_mpi.c
 	$(MPICC) $(CFLAGS) $(OPTFLAGS) $(INCLUDE) -c -o $@ $<
 
 query_device_simple_f: query_device_simple_f.F
-	$(F77) $(FFLAGS) -I../../.. -o $@ $< $(PAPILIB) $(LDFLAGS)
+	$(F90) $(F90FLAGS) -I../../.. -o $@ $< $(PAPILIB) $(LDFLAGS)
 
 clean:
 	rm -f $(TESTS) *.o


### PR DESCRIPTION
## Pull Request Description
In the master branch, if a user chooses to use `nvfortran`, that is:
```
export F77=/packages/nvhpc/24.11/Linux_aarch64/24.11/compilers/bin/nvfortran
```
Then the `sysdetect` component test `query_device_simple_f.F` will fail to compile resulting in the PAPI build failing:
```
/packages/nvhpc/24.11/Linux_aarch64/24.11/compilers/bin/nvfortran --diag_suppress=nonobject_pointer_arithmetic,set_but_not_used -noswitcherror -DUSE_PTHREAD_MUTEXES   -noswitcherror -Dlinux -ffixed-line-length-132 -I../../.. -o query_device_simple_f query_device_simple_f.F ../../../libpapi.a 
nvfortran-Warning-Unknown switch: --diag_suppress=nonobject_pointer_arithmetic,set_but_not_used
nvfortran-Warning-Unknown switch: -ffixed-line-length-132
query_device_simple_f.F:
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 14)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 15)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 16)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 17)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 18)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 19)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 20)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 21)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 22)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 23)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 24)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 25)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 26)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 27)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 28)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 29)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 30)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 31)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 32)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 33)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 34)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 35)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 36)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 37)
NVFORTRAN-S-0021-Label field of continuation line is not blank (../../../f90papi.h: 38)
NVFORTRAN-F-0008-Error limit exceeded (../../../f90papi.h: 3)
NVFORTRAN/arm64 Linux 24.11-0: compilation aborted
make[2]: *** [Makefile:51: query_device_simple_f] Error 2
```

To resolve this build failure, a new conditional is added to `sysdetect/tests/Makefile` for `nvfortran`:
```
else ifneq ($(findstring $(notdir $(F77)), $(nvidia_compilers)),)
    F90FLAGS += $(FFLAGS) -Mfree
endif
```
Furthermore, `query_device_simple_f.F` is F90 and so we appropriately allow users to export `F90` and `F90FLAGS` for this fortran source file. 

Lastly, this PR closes #656.

## Testing
This PR was tested on Grace1 at Oregon (NVIDIA Grace-Grace Superchip) using the following configure:
```
./configure --prefix=$PWD/test-install --with-debug=yes
```

### Using `nvfortran` version 24.11
- PAPI build: ✅ 
- PAPI utilties*: ✅ 
- `sysdetect/tests/query_device_simple_f.c`: ✅  (Note: Output is not formatted well compared to gfortran. A possible second PR to address this is needed.)


### Using `gfortran` version 13.3.0
- PAPI build: ✅ 
- PAPI utilities*: ✅ 
- `sysdetect/tests/query_device_simple_f.c`: ✅ 

__*__ - `papi_component_avail`, `papi_native_avail`, and `papi_command_line`

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
