### PR TITLE
rocp_sdk: remove resolved limitation from README

### DIFF
--- a/src/components/rocp_sdk/README.md
+++ b/src/components/rocp_sdk/README.md
@@ -65,5 +65,4 @@ To see the ROCP\_SDK component's latest supported hardware and software please v
 ## Known Limitations
 
 * If the `rocm` and `rocp_sdk` components are both configured, then `rocp_sdk` will be built for ROCm versions >= 6.3.2.
-* In dispatch mode, PAPI may read zeros if reading takes place immediately after the return of a GPU kernel. This is not a PAPI bug. It may occur because calls such as hipDeviceSynchronize() do not guarantee that ROCprofiler has been called and all counter buffers have been flushed.  Therefore, it is recommended that the user code adds a delay between the return of a kernel and calls to PAPI_read(), PAPI_stop(), etc.
 * If an application is linked against the static PAPI library libpapi.a, then the application must call PAPI_library_init() through PAPI_add_named_event()/PAPI_add_event()/PAPI_enum_cmp_event() before calling any hip routines (e.g. hipInit(), hipGetDeviceCount(), hipLaunchKernelGGL(), etc). If the application is linked against the dynamic library libpapi.so, then the order of operations does not matter.


### PR DESCRIPTION
## Pull Request Description

Commit d7ac473360b47a2a023197a0c0b245f72f1578ef in PR #608 resolved the issue of PAPI_read() accessing counter values before record_callback() had completed, so the README is being updated accordingly.

## Author Checklist
- [ ] **Description**
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] **Commits**
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] **Tests**
The PR needs to pass all the tests
